### PR TITLE
fix: web API error handling and schema corrections

### DIFF
--- a/web/src/app/(protected)/tasks/page.tsx
+++ b/web/src/app/(protected)/tasks/page.tsx
@@ -4,36 +4,54 @@ import TaskItem from "@/components/tasks/task-item";
 import AddTaskForm from "@/components/tasks/add-task-form";
 import type { Task } from "@/lib/types";
 
-async function addTask(title: string, priority: string, dueDate: string) {
+async function addTask(title: string, priority: string, dueDate: string): Promise<{ error?: string }> {
   "use server";
-  const supabase = await createClient();
-  await supabase.from("tasks").insert({
-    title,
-    priority: priority || "medium",
-    status: "active",
-    due_date: dueDate || null,
-  });
-  revalidatePath("/tasks");
-  revalidatePath("/");
+  try {
+    const supabase = await createClient();
+    const { error } = await supabase.from("tasks").insert({
+      title,
+      priority: priority || "medium",
+      status: "active",
+      due_date: dueDate || null,
+    });
+    if (error) return { error: error.message };
+    revalidatePath("/tasks");
+    revalidatePath("/");
+    return {};
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Failed to add task" };
+  }
 }
 
-async function completeTask(taskId: string) {
+async function completeTask(taskId: string): Promise<{ error?: string }> {
   "use server";
-  const supabase = await createClient();
-  await supabase
-    .from("tasks")
-    .update({ status: "completed", completed_at: new Date().toISOString() })
-    .eq("id", taskId);
-  revalidatePath("/tasks");
-  revalidatePath("/");
+  try {
+    const supabase = await createClient();
+    const { error } = await supabase
+      .from("tasks")
+      .update({ status: "completed", completed_at: new Date().toISOString() })
+      .eq("id", taskId);
+    if (error) return { error: error.message };
+    revalidatePath("/tasks");
+    revalidatePath("/");
+    return {};
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Failed to complete task" };
+  }
 }
 
-async function archiveTask(taskId: string) {
+async function archiveTask(taskId: string): Promise<{ error?: string }> {
   "use server";
-  const supabase = await createClient();
-  await supabase.from("tasks").update({ status: "archived" }).eq("id", taskId);
-  revalidatePath("/tasks");
-  revalidatePath("/");
+  try {
+    const supabase = await createClient();
+    const { error } = await supabase.from("tasks").update({ status: "archived" }).eq("id", taskId);
+    if (error) return { error: error.message };
+    revalidatePath("/tasks");
+    revalidatePath("/");
+    return {};
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Failed to archive task" };
+  }
 }
 
 const priorityOrder = { high: 0, medium: 1, low: 2 };

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -122,6 +122,9 @@ Tools available:
         },
       }),
       execute: async ({ title, priority, category, due_date }) => {
+        if (due_date && !/^\d{4}-\d{2}-\d{2}$/.test(due_date)) {
+          return { error: `due_date must be YYYY-MM-DD format, got: "${due_date}"` };
+        }
         const { data, error } = await supabase
           .from("tasks")
           .insert({ title, priority: priority ?? null, category: category ?? null, due_date: due_date ?? null, status: "active" })
@@ -247,7 +250,7 @@ Tools available:
             .order("date", { ascending: false }),
           supabase
             .from("recovery_metrics")
-            .select("date, hrv_ms, resting_hr, sleep_score, readiness_score, source")
+            .select("date, avg_hrv, resting_hr, sleep_score, readiness, source")
             .order("date", { ascending: false })
             .limit(1),
         ]);
@@ -292,23 +295,29 @@ Tools available:
 
       const lastUserMessage = messages[messages.length - 1];
 
-      await supabase.from("chat_messages").insert([
-        {
-          session_id: sessionId,
-          role: "user",
-          content: lastUserMessage.content,
-        },
-        {
-          session_id: sessionId,
-          role: "assistant",
-          content: text,
-        },
-      ]);
+      try {
+        const { error: insertError } = await supabase.from("chat_messages").insert([
+          {
+            session_id: sessionId,
+            role: "user",
+            content: lastUserMessage.content,
+          },
+          {
+            session_id: sessionId,
+            role: "assistant",
+            content: text,
+          },
+        ]);
+        if (insertError) throw insertError;
 
-      await supabase
-        .from("chat_sessions")
-        .update({ last_active_at: new Date().toISOString() })
-        .eq("id", sessionId);
+        const { error: updateError } = await supabase
+          .from("chat_sessions")
+          .update({ last_active_at: new Date().toISOString() })
+          .eq("id", sessionId);
+        if (updateError) throw updateError;
+      } catch (err) {
+        console.error("[chat] onFinish persist error:", err);
+      }
     },
   });
 

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -82,7 +82,7 @@ function LoginForm() {
 
           <button
             type="submit"
-            disabled={state === "loading" || !email.trim() || !password.trim()}
+            disabled={state === "loading" || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) || !password.trim()}
             className="w-full bg-neutral-100 text-neutral-950 rounded-lg px-4 py-2.5 text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:bg-white transition-colors"
           >
             {state === "loading" ? "Signing in..." : "Sign in"}

--- a/web/src/components/tasks/add-task-form.tsx
+++ b/web/src/components/tasks/add-task-form.tsx
@@ -4,7 +4,7 @@ import { useState, useTransition, useRef } from "react";
 import { Plus } from "lucide-react";
 
 interface Props {
-  addAction: (title: string, priority: string, dueDate: string) => Promise<void>;
+  addAction: (title: string, priority: string, dueDate: string) => Promise<{ error?: string }>;
 }
 
 export default function AddTaskForm({ addAction }: Props) {
@@ -12,6 +12,7 @@ export default function AddTaskForm({ addAction }: Props) {
   const [title, setTitle] = useState("");
   const [priority, setPriority] = useState("medium");
   const [dueDate, setDueDate] = useState("");
+  const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -23,8 +24,13 @@ export default function AddTaskForm({ addAction }: Props) {
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!title.trim()) return;
+    setError(null);
     startTransition(async () => {
-      await addAction(title.trim(), priority, dueDate);
+      const result = await addAction(title.trim(), priority, dueDate);
+      if (result.error) {
+        setError(result.error);
+        return;
+      }
       setTitle("");
       setPriority("medium");
       setDueDate("");
@@ -71,6 +77,9 @@ export default function AddTaskForm({ addAction }: Props) {
           className="bg-neutral-800 border border-neutral-700 rounded-lg px-3 py-1.5 text-xs text-neutral-300 focus:outline-none flex-1"
         />
       </div>
+      {error && (
+        <p className="text-xs text-red-400">{error}</p>
+      )}
       <div className="flex gap-2 justify-end">
         <button
           type="button"

--- a/web/src/components/tasks/task-item.tsx
+++ b/web/src/components/tasks/task-item.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { Check, Archive } from "lucide-react";
 import type { Task } from "@/lib/types";
 
@@ -12,12 +12,13 @@ const priorityConfig = {
 
 interface Props {
   task: Task;
-  completeAction: (id: string) => Promise<void>;
-  archiveAction: (id: string) => Promise<void>;
+  completeAction: (id: string) => Promise<{ error?: string }>;
+  archiveAction: (id: string) => Promise<{ error?: string }>;
 }
 
 export default function TaskItem({ task, completeAction, archiveAction }: Props) {
   const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
 
   const priority = task.priority ? priorityConfig[task.priority] : null;
 
@@ -37,10 +38,15 @@ export default function TaskItem({ task, completeAction, archiveAction }: Props)
             {task.due_date && <span>Due {task.due_date}</span>}
           </p>
         )}
+        {error && <p className="text-xs text-red-400 mt-0.5 ml-3.5">{error}</p>}
       </div>
       <div className="flex gap-1 flex-shrink-0">
         <button
-          onClick={() => startTransition(() => completeAction(task.id))}
+          onClick={() => startTransition(async () => {
+            setError(null);
+            const result = await completeAction(task.id);
+            if (result.error) setError(result.error);
+          })}
           disabled={isPending}
           title="Complete"
           className="p-1.5 rounded-lg text-neutral-500 hover:text-green-400 hover:bg-neutral-800 transition-colors"
@@ -48,7 +54,11 @@ export default function TaskItem({ task, completeAction, archiveAction }: Props)
           <Check size={15} />
         </button>
         <button
-          onClick={() => startTransition(() => archiveAction(task.id))}
+          onClick={() => startTransition(async () => {
+            setError(null);
+            const result = await archiveAction(task.id);
+            if (result.error) setError(result.error);
+          })}
           disabled={isPending}
           title="Archive"
           className="p-1.5 rounded-lg text-neutral-500 hover:text-neutral-300 hover:bg-neutral-800 transition-colors"

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -52,10 +52,10 @@ export interface WorkoutSession {
 export interface RecoveryMetrics {
   id: string;
   date: string;
-  hrv_ms: number | null;
+  avg_hrv: number | null;
   resting_hr: number | null;
   sleep_score: number | null;
-  readiness_score: number | null;
+  readiness: number | null;
   source: string | null;
 }
 


### PR DESCRIPTION
## Summary
- **Recovery metrics bug fix**: `get_fitness_summary` tool was selecting wrong column names (`hrv_ms`, `readiness_score`) that don't exist in Supabase — silently returning nulls. Corrected to `avg_hrv`, `readiness` to match actual schema
- **Task server actions**: `addTask`, `completeTask`, `archiveTask` now wrapped in try/catch and return `{ error? }` — errors surface inline to the user instead of failing silently
- **Chat `onFinish`**: DB persist (message insert + session update) wrapped in try/catch to prevent silent message loss on failure
- **`due_date` validation**: `add_task` chat tool validates `YYYY-MM-DD` format before inserting
- **Login form**: Submit button now disabled on invalid email format (not just empty)

## Test plan
- [ ] Verify chat fitness summary returns HRV and readiness values (not null)
- [ ] Trigger a task add failure and confirm inline error appears
- [ ] Confirm login button stays disabled for malformed emails like `user@`

🤖 Generated with [Claude Code](https://claude.com/claude-code)