### PR TITLE
fix: voice interface temp file cleanup and wake word config

### DIFF
--- a/voice/bridge_voice.py
+++ b/voice/bridge_voice.py
@@ -11,6 +11,7 @@ Requires:
   - pip install -r voice/requirements.txt
 """
 
+import atexit
 import os
 import sys
 import struct
@@ -60,10 +61,23 @@ def load_system_prompt() -> str:
     return "\n\n---\n\n".join(parts)
 
 
+_temp_files: list[str] = []
+
+
+@atexit.register
+def _cleanup_temp_files():
+    for path in _temp_files:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
 def transcribe_audio(audio_data: bytes, sample_rate: int) -> str:
     """Transcribe audio bytes using faster-whisper."""
     model = WhisperModel(WHISPER_MODEL, device=WHISPER_DEVICE)
     with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+        _temp_files.append(f.name)
         import wave
         with wave.open(f.name, "wb") as wf:
             wf.setnchannels(1)
@@ -146,7 +160,7 @@ def main():
     system_prompt = load_system_prompt()
     conversation_history = []
 
-    porcupine = pvporcupine.create(access_key=access_key, keywords=["hey siri"])  # closest built-in; custom wake word via pvporcupine model file
+    porcupine = pvporcupine.create(access_key=access_key, keywords=[WAKE_WORD])
     pa = pyaudio.PyAudio()
     sample_rate = porcupine.sample_rate
     frame_length = porcupine.frame_length


### PR DESCRIPTION
## Summary
- Register `atexit` handler to delete temp `.wav` files created during Whisper transcription — previously they accumulated indefinitely in the system temp directory
- Replace hardcoded `"hey siri"` keyword with `WAKE_WORD` from `config.py`, which was already imported but unused

## Test plan
- [ ] Run the voice interface and trigger a few transcriptions — confirm `/tmp` doesn't accumulate `.wav` files after exit
- [ ] Confirm the wake word in `config.py` is what Porcupine listens for

🤖 Generated with [Claude Code](https://claude.com/claude-code)