### PR TITLE
fix: add unique constraint to study_log(date, subject)

### DIFF
--- a/supabase/migrations/20260410170000_study_log_unique_constraint.sql
+++ b/supabase/migrations/20260410170000_study_log_unique_constraint.sql
@@ -1,0 +1,4 @@
+-- Prevent duplicate study log entries for the same date + subject.
+-- Without this constraint, weekly review duration totals can be inflated
+-- if the same session is logged more than once.
+alter table study_log add constraint study_log_date_subject_unique unique (date, subject);


### PR DESCRIPTION
## Summary
- Add migration with `unique(date, subject)` constraint on `study_log` table
- Without this, duplicate entries could inflate weekly review duration totals if the same study session was logged more than once

## Test plan
- [ ] Apply migration: `supabase db push` or run directly against the DB
- [ ] Verify that attempting to insert a duplicate `(date, subject)` pair returns a unique constraint error

🤖 Generated with [Claude Code](https://claude.com/claude-code)