### PR TITLE
feat: dashboard overhaul — issue #27

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,6 +12,7 @@
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.49.4",
         "ai": "^4.3.15",
+        "googleapis": "^171.4.0",
         "lucide-react": "^0.511.0",
         "next": "^15.3.1",
         "react": "^19.1.0",
@@ -1423,6 +1424,15 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ai": {
       "version": "4.3.19",
       "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
@@ -1457,6 +1467,70 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1706,6 +1780,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1790,6 +1873,29 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
@@ -1802,6 +1908,36 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1847,12 +1983,212 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "171.4.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-171.4.0.tgz",
+      "integrity": "sha512-xybFL2SmmUgIifgsbsRQYRdNrSAYwxWZDmkZTGjUIaRnX5jPqR8el/cEvo6rCqh7iaZx6MfEPS/lrDgZ0bymkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.2.0",
+        "googleapis-common": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.1.tgz",
+      "integrity": "sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^7.0.0-rc.4",
+        "google-auth-library": "^10.1.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
@@ -1902,6 +2238,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iceberg-js": {
@@ -2000,6 +2349,15 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -2021,6 +2379,27 @@
       },
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/lightningcss": {
@@ -2351,6 +2730,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -3290,6 +3678,44 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3297,6 +3723,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/parse-entities": {
@@ -3384,6 +3822,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/react": {
@@ -3569,6 +4022,26 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3637,6 +4110,78 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/source-map-js": {
@@ -3898,6 +4443,12 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -3955,6 +4506,15 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/ws": {

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.49.4",
     "ai": "^4.3.15",
+    "googleapis": "^171.4.0",
     "lucide-react": "^0.511.0",
     "next": "^15.3.1",
     "react": "^19.1.0",

--- a/web/src/app/(protected)/layout.tsx
+++ b/web/src/app/(protected)/layout.tsx
@@ -17,9 +17,11 @@ export default async function ProtectedLayout({
   }
 
   return (
-    <div className="min-h-screen bg-neutral-950 text-neutral-100">
-      <main className="pb-24 max-w-2xl mx-auto px-4">{children}</main>
+    <div className="flex min-h-screen bg-neutral-950 text-neutral-100">
       <Nav />
+      <main className="flex-1 ml-12 lg:ml-48 px-5 lg:px-8 pt-8 pb-8 min-w-0">
+        <div className="max-w-4xl">{children}</div>
+      </main>
     </div>
   );
 }

--- a/web/src/app/(protected)/page.tsx
+++ b/web/src/app/(protected)/page.tsx
@@ -2,46 +2,63 @@ import { createClient } from "@/lib/supabase/server";
 import HabitsSummary from "@/components/dashboard/habits-summary";
 import TasksSummary from "@/components/dashboard/tasks-summary";
 import FitnessSummary from "@/components/dashboard/fitness-summary";
-import RecentChat from "@/components/dashboard/recent-chat";
-import type { HabitLog, Task, FitnessLog, ChatMessage } from "@/lib/types";
+import RecoverySummary from "@/components/dashboard/recovery-summary";
+import FunFact from "@/components/dashboard/fun-fact";
+import ScheduleToday from "@/components/dashboard/schedule-today";
+import ImportantEmails from "@/components/dashboard/important-emails";
+import type { HabitLog, Task, FitnessLog, RecoveryMetrics, WorkoutSession } from "@/lib/types";
 
 export default async function DashboardPage() {
   const supabase = await createClient();
   const today = new Date().toISOString().split("T")[0];
 
-  const [habitsResult, registryResult, tasksResult, fitnessResult, prevFitnessResult, chatResult] =
-    await Promise.all([
-      supabase.from("habits").select("*").eq("date", today),
-      supabase.from("habit_registry").select("id").eq("active", true),
-      supabase.from("tasks").select("*").eq("status", "active"),
-      supabase
-        .from("fitness_log")
-        .select("*")
-        .not("body_fat_pct", "is", null)
-        .order("date", { ascending: false })
-        .limit(1)
-        .maybeSingle(),
-      supabase
-        .from("fitness_log")
-        .select("*")
-        .not("body_fat_pct", "is", null)
-        .order("date", { ascending: false })
-        .range(1, 1)
-        .maybeSingle(),
-      supabase
-        .from("chat_messages")
-        .select("*")
-        .order("created_at", { ascending: false })
-        .limit(1)
-        .maybeSingle(),
-    ]);
+  const [
+    habitsResult,
+    registryResult,
+    tasksResult,
+    fitnessResult,
+    prevFitnessResult,
+    recoveryResult,
+    workoutResult,
+  ] = await Promise.all([
+    supabase.from("habits").select("*").eq("date", today),
+    supabase.from("habit_registry").select("id").eq("active", true),
+    supabase.from("tasks").select("*").eq("status", "active"),
+    supabase
+      .from("fitness_log")
+      .select("*")
+      .not("body_fat_pct", "is", null)
+      .order("date", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .from("fitness_log")
+      .select("*")
+      .not("body_fat_pct", "is", null)
+      .order("date", { ascending: false })
+      .range(1, 1)
+      .maybeSingle(),
+    supabase
+      .from("recovery_metrics")
+      .select("*")
+      .order("date", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .from("workout_sessions")
+      .select("*")
+      .order("date", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+  ]);
 
   const todayHabits = (habitsResult.data ?? []) as HabitLog[];
   const totalHabits = registryResult.data?.length ?? 0;
   const tasks = (tasksResult.data ?? []) as Task[];
   const latestFitness = fitnessResult.data as FitnessLog | null;
   const prevFitness = prevFitnessResult.data as FitnessLog | null;
-  const recentMessage = chatResult.data as ChatMessage | null;
+  const recovery = recoveryResult.data as RecoveryMetrics | null;
+  const recentWorkout = workoutResult.data as WorkoutSession | null;
 
   const dateStr = new Date().toLocaleDateString("en-US", {
     weekday: "long",
@@ -50,17 +67,28 @@ export default async function DashboardPage() {
   });
 
   return (
-    <div className="pt-8 pb-4 space-y-6">
+    <div className="space-y-6">
       <div>
-        <h1 className="text-xl font-semibold text-neutral-100">Dashboard</h1>
+        <h1 className="text-xl font-semibold text-neutral-100">Good morning</h1>
         <p className="text-sm text-neutral-500 mt-0.5">{dateStr}</p>
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
-        <HabitsSummary habits={todayHabits} total={totalHabits} />
-        <TasksSummary tasks={tasks} />
-        <FitnessSummary latest={latestFitness} previous={prevFitness} />
-        <RecentChat message={recentMessage} />
+      <FunFact />
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* Left column */}
+        <div className="space-y-4">
+          <ScheduleToday />
+          <ImportantEmails />
+        </div>
+
+        {/* Right column */}
+        <div className="space-y-4">
+          <RecoverySummary recovery={recovery} />
+          <FitnessSummary latest={latestFitness} previous={prevFitness} recentWorkout={recentWorkout} />
+          <HabitsSummary habits={todayHabits} total={totalHabits} />
+          <TasksSummary tasks={tasks} />
+        </div>
       </div>
     </div>
   );

--- a/web/src/app/api/fun-fact/route.ts
+++ b/web/src/app/api/fun-fact/route.ts
@@ -1,0 +1,55 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import { generateText } from "ai";
+import { createServiceClient } from "@/lib/supabase/service";
+import { NextResponse } from "next/server";
+
+const CACHE_KEY = "fun_fact_cache";
+
+interface FunFactCache {
+  fact: string;
+  date: string;
+}
+
+export async function GET() {
+  try {
+    const supabase = createServiceClient();
+    const today = new Date().toISOString().split("T")[0];
+
+    // Check cache
+    const { data: cached } = await supabase
+      .from("profile")
+      .select("value")
+      .eq("key", CACHE_KEY)
+      .maybeSingle();
+
+    if (cached?.value) {
+      const parsed = JSON.parse(cached.value) as FunFactCache;
+      if (parsed.date === today) {
+        return NextResponse.json({ fact: parsed.fact });
+      }
+    }
+
+    // Generate new fact
+    const { text } = await generateText({
+      model: anthropic("claude-haiku-4-5-20251001"),
+      maxTokens: 150,
+      prompt:
+        "Give me one genuinely interesting and surprising fact. Pick randomly from: science, history, space, nature, psychology, technology. Return just the fact as a single sentence or two. No intro like 'Did you know'. Just the fact.",
+    });
+
+    const fact = text.trim();
+
+    // Upsert into profile cache
+    await supabase
+      .from("profile")
+      .upsert(
+        { key: CACHE_KEY, value: JSON.stringify({ fact, date: today } satisfies FunFactCache) },
+        { onConflict: "key" }
+      );
+
+    return NextResponse.json({ fact });
+  } catch (err) {
+    console.error("[fun-fact] error:", err);
+    return NextResponse.json({ fact: null, error: "Failed to generate fun fact" });
+  }
+}

--- a/web/src/app/api/google/calendar/route.ts
+++ b/web/src/app/api/google/calendar/route.ts
@@ -1,0 +1,64 @@
+import { google } from "googleapis";
+import { NextResponse } from "next/server";
+
+export interface CalendarEvent {
+  time: string;
+  title: string;
+  location?: string;
+}
+
+function formatTime(dateTimeStr: string | null | undefined, dateStr: string | null | undefined): string {
+  if (!dateTimeStr && dateStr) return "All day";
+  if (!dateTimeStr) return "";
+  const d = new Date(dateTimeStr);
+  return d.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+}
+
+export async function GET() {
+  try {
+    const clientId = process.env.GOOGLE_CLIENT_ID;
+    const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+    const refreshToken = process.env.GOOGLE_REFRESH_TOKEN;
+
+    if (!clientId || !clientSecret || !refreshToken) {
+      return NextResponse.json({ events: [] });
+    }
+
+    const auth = new google.auth.OAuth2(clientId, clientSecret);
+    auth.setCredentials({ refresh_token: refreshToken });
+
+    const calendar = google.calendar({ version: "v3", auth });
+
+    const now = new Date();
+    const timeMin = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0).toISOString();
+    const timeMax = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59).toISOString();
+
+    const res = await calendar.events.list({
+      calendarId: "primary",
+      timeMin,
+      timeMax,
+      singleEvents: true,
+      orderBy: "startTime",
+      maxResults: 10,
+    });
+
+    const items = res.data.items ?? [];
+
+    const events: CalendarEvent[] = items
+      .filter((e) => e.status !== "cancelled")
+      .map((e) => ({
+        time: formatTime(e.start?.dateTime, e.start?.date),
+        title: e.summary ?? "(No title)",
+        ...(e.location ? { location: e.location } : {}),
+      }));
+
+    return NextResponse.json({ events });
+  } catch (err) {
+    console.error("[calendar] error:", err);
+    return NextResponse.json({ events: [], error: "Failed to fetch calendar" });
+  }
+}

--- a/web/src/app/api/google/gmail/route.ts
+++ b/web/src/app/api/google/gmail/route.ts
@@ -1,0 +1,70 @@
+import { google } from "googleapis";
+import { NextResponse } from "next/server";
+
+export interface EmailSummary {
+  from: string;
+  subject: string;
+  receivedAt: string;
+}
+
+function parseFrom(raw: string): string {
+  // "Display Name <email@example.com>" → "Display Name"
+  const match = raw.match(/^"?([^"<]+)"?\s*</);
+  if (match) return match[1].trim();
+  // bare email → return as-is
+  return raw.replace(/<[^>]+>/, "").trim() || raw;
+}
+
+function getHeader(headers: { name?: string | null; value?: string | null }[], name: string): string {
+  return headers.find((h) => h.name?.toLowerCase() === name.toLowerCase())?.value ?? "";
+}
+
+export async function GET() {
+  try {
+    const clientId = process.env.GOOGLE_CLIENT_ID;
+    const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+    const refreshToken = process.env.GOOGLE_REFRESH_TOKEN;
+
+    if (!clientId || !clientSecret || !refreshToken) {
+      return NextResponse.json({ emails: [] });
+    }
+
+    const auth = new google.auth.OAuth2(clientId, clientSecret);
+    auth.setCredentials({ refresh_token: refreshToken });
+
+    const gmail = google.gmail({ version: "v1", auth });
+
+    const listRes = await gmail.users.messages.list({
+      userId: "me",
+      q: 'is:unread subject:(meeting OR urgent OR invoice OR "action required" OR deadline)',
+      maxResults: 5,
+    });
+
+    const messages = listRes.data.messages ?? [];
+    if (messages.length === 0) {
+      return NextResponse.json({ emails: [] });
+    }
+
+    const emails: EmailSummary[] = await Promise.all(
+      messages.map(async (m) => {
+        const msg = await gmail.users.messages.get({
+          userId: "me",
+          id: m.id!,
+          format: "metadata",
+          metadataHeaders: ["From", "Subject", "Date"],
+        });
+        const headers = msg.data.payload?.headers ?? [];
+        return {
+          from: parseFrom(getHeader(headers, "From")),
+          subject: getHeader(headers, "Subject") || "(No subject)",
+          receivedAt: getHeader(headers, "Date"),
+        };
+      })
+    );
+
+    return NextResponse.json({ emails });
+  } catch (err) {
+    console.error("[gmail] error:", err);
+    return NextResponse.json({ emails: [], error: "Failed to fetch emails" });
+  }
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,8 +1,16 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
-const inter = Inter({ subsets: ["latin"] });
+const geistSans = Geist({
+  subsets: ["latin"],
+  variable: "--font-sans",
+});
+
+const geistMono = Geist_Mono({
+  subsets: ["latin"],
+  variable: "--font-mono",
+});
 
 export const metadata: Metadata = {
   title: "Mr. Bridge",
@@ -16,7 +24,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className="dark">
-      <body className={`${inter.className} bg-neutral-950 text-neutral-100 antialiased`}>
+      <body className={`${geistSans.variable} ${geistMono.variable} font-[family-name:var(--font-sans)] bg-neutral-950 text-neutral-100 antialiased`}>
         {children}
       </body>
     </html>

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { createClient } from "@/lib/supabase/client";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useState } from "react";
+import Logo from "@/components/ui/logo";
 
 type State = "idle" | "loading" | "error";
 
@@ -34,9 +35,12 @@ function LoginForm() {
   return (
     <div className="min-h-screen bg-neutral-950 flex items-center justify-center px-4">
       <div className="w-full max-w-sm space-y-8">
-        <div>
-          <h1 className="text-2xl font-semibold text-neutral-100">Mr. Bridge</h1>
-          <p className="mt-1 text-sm text-neutral-500">Personal assistant</p>
+        <div className="flex items-center gap-3">
+          <Logo size={36} />
+          <div>
+            <h1 className="text-2xl font-semibold text-neutral-100">Mr. Bridge</h1>
+            <p className="mt-0.5 text-sm text-neutral-500">Personal assistant</p>
+          </div>
         </div>
 
         {hasAuthError && (
@@ -83,7 +87,7 @@ function LoginForm() {
           <button
             type="submit"
             disabled={state === "loading" || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) || !password.trim()}
-            className="w-full bg-neutral-100 text-neutral-950 rounded-lg px-4 py-2.5 text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:bg-white transition-colors"
+            className="w-full bg-blue-500 text-white rounded-lg px-4 py-2.5 text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:bg-blue-400 transition-colors"
           >
             {state === "loading" ? "Signing in..." : "Sign in"}
           </button>

--- a/web/src/components/chat/chat-interface.tsx
+++ b/web/src/components/chat/chat-interface.tsx
@@ -75,7 +75,7 @@ export default function ChatInterface({ sessionId, initialMessages }: Props) {
         <button
           type="submit"
           disabled={isLoading || !input.trim()}
-          className="bg-neutral-100 text-neutral-950 rounded-xl px-3.5 py-2.5 disabled:opacity-30 hover:bg-white transition-colors"
+          className="bg-blue-500 text-white rounded-xl px-3.5 py-2.5 disabled:opacity-30 hover:bg-blue-400 transition-colors"
         >
           <Send size={16} />
         </button>

--- a/web/src/components/dashboard/fitness-summary.tsx
+++ b/web/src/components/dashboard/fitness-summary.tsx
@@ -1,9 +1,10 @@
 import Link from "next/link";
-import type { FitnessLog } from "@/lib/types";
+import type { FitnessLog, WorkoutSession } from "@/lib/types";
 
 interface Props {
   latest: FitnessLog | null;
   previous: FitnessLog | null;
+  recentWorkout?: WorkoutSession | null;
 }
 
 function delta(current: number | null, prev: number | null) {
@@ -12,21 +13,21 @@ function delta(current: number | null, prev: number | null) {
   return d > 0 ? `+${d.toFixed(1)}` : d.toFixed(1);
 }
 
-export default function FitnessSummary({ latest, previous }: Props) {
+export default function FitnessSummary({ latest, previous, recentWorkout }: Props) {
   const weightDelta = delta(latest?.weight_lb ?? null, previous?.weight_lb ?? null);
   const bfDelta = delta(latest?.body_fat_pct ?? null, previous?.body_fat_pct ?? null);
 
   return (
     <Link href="/fitness" className="block bg-neutral-900 rounded-xl p-4 border border-neutral-800 hover:border-neutral-700 transition-colors">
-      <p className="text-xs text-neutral-500 uppercase tracking-wide mb-3">Body comp</p>
+      <p className="text-xs text-neutral-500 uppercase tracking-wide mb-3">Fitness</p>
       {latest ? (
         <div className="space-y-1.5">
           {latest.weight_lb != null && (
             <div className="flex items-baseline gap-2">
-              <span className="text-2xl font-semibold text-neutral-100">{latest.weight_lb}</span>
+              <span className="text-2xl font-semibold font-[family-name:var(--font-mono)] text-neutral-100">{latest.weight_lb}</span>
               <span className="text-xs text-neutral-500">lb</span>
               {weightDelta && (
-                <span className={`text-xs ml-auto ${parseFloat(weightDelta) < 0 ? "text-green-400" : "text-red-400"}`}>
+                <span className={`text-xs ml-auto font-[family-name:var(--font-mono)] ${parseFloat(weightDelta) < 0 ? "text-green-400" : "text-red-400"}`}>
                   {weightDelta}
                 </span>
               )}
@@ -34,19 +35,35 @@ export default function FitnessSummary({ latest, previous }: Props) {
           )}
           {latest.body_fat_pct != null && (
             <div className="flex items-baseline gap-2">
-              <span className="text-lg font-medium text-neutral-300">{latest.body_fat_pct}%</span>
+              <span className="text-lg font-medium font-[family-name:var(--font-mono)] text-neutral-300">{latest.body_fat_pct}%</span>
               <span className="text-xs text-neutral-500">body fat</span>
               {bfDelta && (
-                <span className={`text-xs ml-auto ${parseFloat(bfDelta) < 0 ? "text-green-400" : "text-red-400"}`}>
+                <span className={`text-xs ml-auto font-[family-name:var(--font-mono)] ${parseFloat(bfDelta) < 0 ? "text-green-400" : "text-red-400"}`}>
                   {bfDelta}
                 </span>
               )}
             </div>
           )}
-          <p className="text-xs text-neutral-600 mt-2">{latest.date}</p>
+          <p className="text-xs text-neutral-600">{latest.date}</p>
         </div>
       ) : (
-        <p className="text-sm text-neutral-600">No data yet</p>
+        <p className="text-sm text-neutral-600">No body comp data</p>
+      )}
+
+      {recentWorkout && (
+        <div className="mt-3 pt-3 border-t border-neutral-800">
+          <p className="text-xs text-neutral-500 mb-1">Last workout</p>
+          <p className="text-sm text-neutral-300">
+            {recentWorkout.activity}
+            {recentWorkout.duration_mins != null && (
+              <span className="text-neutral-500"> · <span className="font-[family-name:var(--font-mono)]">{recentWorkout.duration_mins}</span>m</span>
+            )}
+            {recentWorkout.calories != null && (
+              <span className="text-neutral-500"> · <span className="font-[family-name:var(--font-mono)]">{recentWorkout.calories}</span> cal</span>
+            )}
+          </p>
+          <p className="text-xs text-neutral-600 mt-0.5">{recentWorkout.date}</p>
+        </div>
       )}
     </Link>
   );

--- a/web/src/components/dashboard/fun-fact.tsx
+++ b/web/src/components/dashboard/fun-fact.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Sparkles } from "lucide-react";
+
+export default function FunFact() {
+  const [fact, setFact] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/fun-fact")
+      .then((r) => r.json())
+      .then((d) => setFact(d.fact ?? null))
+      .catch(() => setFact(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="bg-neutral-900 rounded-xl p-4 border border-neutral-800 border-l-2 border-l-blue-500">
+      <div className="flex items-center gap-2 mb-2">
+        <Sparkles size={13} className="text-blue-400 shrink-0" />
+        <p className="text-xs text-blue-400 uppercase tracking-wide font-medium">Fun Fact</p>
+      </div>
+
+      {loading ? (
+        <div className="space-y-2">
+          <div className="h-3 bg-neutral-800 rounded animate-pulse w-full" />
+          <div className="h-3 bg-neutral-800 rounded animate-pulse w-4/5" />
+        </div>
+      ) : fact ? (
+        <p className="text-sm text-neutral-300 italic leading-relaxed">{fact}</p>
+      ) : (
+        <p className="text-sm text-neutral-600">No fact available.</p>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/dashboard/habits-summary.tsx
+++ b/web/src/components/dashboard/habits-summary.tsx
@@ -13,13 +13,13 @@ export default function HabitsSummary({ habits, total }: Props) {
   return (
     <Link href="/habits" className="block bg-neutral-900 rounded-xl p-4 border border-neutral-800 hover:border-neutral-700 transition-colors">
       <p className="text-xs text-neutral-500 uppercase tracking-wide mb-3">Habits today</p>
-      <p className="text-2xl font-semibold text-neutral-100">
+      <p className="text-2xl font-semibold font-[family-name:var(--font-mono)] text-neutral-100">
         {completed}
         <span className="text-neutral-500 text-lg font-normal"> / {total}</span>
       </p>
       <div className="mt-3 h-1.5 bg-neutral-800 rounded-full overflow-hidden">
         <div
-          className="h-full bg-neutral-100 rounded-full transition-all"
+          className="h-full bg-blue-500 rounded-full transition-all"
           style={{ width: `${pct}%` }}
         />
       </div>

--- a/web/src/components/dashboard/important-emails.tsx
+++ b/web/src/components/dashboard/important-emails.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Mail } from "lucide-react";
+import type { EmailSummary } from "@/app/api/google/gmail/route";
+
+export default function ImportantEmails() {
+  const [emails, setEmails] = useState<EmailSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/google/gmail")
+      .then((r) => r.json())
+      .then((d) => setEmails(d.emails ?? []))
+      .catch(() => setEmails([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="bg-neutral-900 rounded-xl p-4 border border-neutral-800">
+      <div className="flex items-center gap-2 mb-3">
+        <Mail size={13} className="text-neutral-500 shrink-0" />
+        <p className="text-xs text-neutral-500 uppercase tracking-wide">Important Emails</p>
+      </div>
+
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2].map((i) => (
+            <div key={i} className="space-y-1.5">
+              <div className="h-3 bg-neutral-800 rounded animate-pulse w-1/3" />
+              <div className="h-3 bg-neutral-800 rounded animate-pulse w-4/5" />
+            </div>
+          ))}
+        </div>
+      ) : emails.length > 0 ? (
+        <div className="divide-y divide-neutral-800/50">
+          {emails.map((email, i) => (
+            <div key={i} className="py-2 first:pt-0 last:pb-0">
+              <p className="text-xs text-neutral-400 truncate">{email.from}</p>
+              <p className="text-sm text-neutral-200 truncate mt-0.5">{email.subject}</p>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-neutral-600">Inbox clear</p>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/dashboard/recovery-summary.tsx
+++ b/web/src/components/dashboard/recovery-summary.tsx
@@ -1,0 +1,81 @@
+import type { RecoveryMetrics } from "@/lib/types";
+
+interface Props {
+  recovery: RecoveryMetrics | null;
+}
+
+function scoreColor(score: number | null): string {
+  if (score == null) return "text-neutral-500";
+  if (score >= 80) return "text-green-400";
+  if (score >= 60) return "text-amber-400";
+  return "text-red-400";
+}
+
+function fmtHrs(hrs: number | null): string {
+  if (hrs == null) return "—";
+  const h = Math.floor(hrs);
+  const m = Math.round((hrs - h) * 60);
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+export default function RecoverySummary({ recovery }: Props) {
+  return (
+    <div className="bg-neutral-900 rounded-xl p-4 border border-neutral-800">
+      <p className="text-xs text-neutral-500 uppercase tracking-wide mb-3">Recovery &amp; Sleep</p>
+
+      {recovery ? (
+        <div className="space-y-3">
+          {/* Top scores row */}
+          <div className="flex gap-4">
+            <div>
+              <p className="text-xs text-neutral-500 mb-0.5">Readiness</p>
+              <span className={`text-2xl font-semibold font-[family-name:var(--font-mono)] ${scoreColor(recovery.readiness)}`}>
+                {recovery.readiness ?? "—"}
+              </span>
+            </div>
+            <div>
+              <p className="text-xs text-neutral-500 mb-0.5">Sleep</p>
+              <span className={`text-2xl font-semibold font-[family-name:var(--font-mono)] ${scoreColor(recovery.sleep_score)}`}>
+                {recovery.sleep_score ?? "—"}
+              </span>
+            </div>
+          </div>
+
+          {/* Metrics grid */}
+          <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 text-sm">
+            <div className="flex items-baseline gap-1.5">
+              <span className="text-neutral-500 text-xs w-16">HRV</span>
+              <span className="font-[family-name:var(--font-mono)] text-neutral-200">
+                {recovery.avg_hrv ?? "—"}
+                {recovery.avg_hrv != null && <span className="text-xs text-neutral-500 ml-0.5">ms</span>}
+              </span>
+            </div>
+            <div className="flex items-baseline gap-1.5">
+              <span className="text-neutral-500 text-xs w-16">RHR</span>
+              <span className="font-[family-name:var(--font-mono)] text-neutral-200">
+                {recovery.resting_hr ?? "—"}
+                {recovery.resting_hr != null && <span className="text-xs text-neutral-500 ml-0.5">bpm</span>}
+              </span>
+            </div>
+            <div className="flex items-baseline gap-1.5">
+              <span className="text-neutral-500 text-xs w-16">Total</span>
+              <span className="font-[family-name:var(--font-mono)] text-neutral-200">
+                {fmtHrs(recovery.total_sleep_hrs)}
+              </span>
+            </div>
+            <div className="flex items-baseline gap-1.5">
+              <span className="text-neutral-500 text-xs w-16">Deep</span>
+              <span className="font-[family-name:var(--font-mono)] text-neutral-200">
+                {fmtHrs(recovery.deep_hrs)}
+              </span>
+            </div>
+          </div>
+
+          <p className="text-xs text-neutral-600">Oura data reflects yesterday · {recovery.date}</p>
+        </div>
+      ) : (
+        <p className="text-sm text-neutral-600">No recovery data</p>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/dashboard/schedule-today.tsx
+++ b/web/src/components/dashboard/schedule-today.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Calendar } from "lucide-react";
+import type { CalendarEvent } from "@/app/api/google/calendar/route";
+
+export default function ScheduleToday() {
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/google/calendar")
+      .then((r) => r.json())
+      .then((d) => setEvents(d.events ?? []))
+      .catch(() => setEvents([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="bg-neutral-900 rounded-xl p-4 border border-neutral-800">
+      <div className="flex items-center gap-2 mb-3">
+        <Calendar size={13} className="text-neutral-500 shrink-0" />
+        <p className="text-xs text-neutral-500 uppercase tracking-wide">Schedule Today</p>
+      </div>
+
+      {loading ? (
+        <div className="space-y-2.5">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="flex gap-3">
+              <div className="h-3 bg-neutral-800 rounded animate-pulse w-14 shrink-0" />
+              <div className="h-3 bg-neutral-800 rounded animate-pulse flex-1" />
+            </div>
+          ))}
+        </div>
+      ) : events.length > 0 ? (
+        <div className="space-y-2.5">
+          {events.map((event, i) => (
+            <div key={i} className="flex gap-3 items-start">
+              <span className="text-xs font-[family-name:var(--font-mono)] text-neutral-500 shrink-0 w-16 pt-px">
+                {event.time}
+              </span>
+              <div className="min-w-0">
+                <p className="text-sm text-neutral-200 leading-snug truncate">{event.title}</p>
+                {event.location && (
+                  <p className="text-xs text-neutral-600 truncate mt-0.5">{event.location}</p>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-neutral-600">No events today</p>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/dashboard/tasks-summary.tsx
+++ b/web/src/components/dashboard/tasks-summary.tsx
@@ -13,7 +13,7 @@ export default function TasksSummary({ tasks }: Props) {
   return (
     <Link href="/tasks" className="block bg-neutral-900 rounded-xl p-4 border border-neutral-800 hover:border-neutral-700 transition-colors">
       <p className="text-xs text-neutral-500 uppercase tracking-wide mb-3">Active tasks</p>
-      <p className="text-2xl font-semibold text-neutral-100">{tasks.length}</p>
+      <p className="text-2xl font-semibold font-[family-name:var(--font-mono)] text-neutral-100">{tasks.length}</p>
       {tasks.length > 0 && (
         <div className="mt-3 flex gap-3 text-xs text-neutral-500">
           {high > 0 && <span><span className="text-red-400">{high}</span> high</span>}

--- a/web/src/components/fitness/body-comp-chart.tsx
+++ b/web/src/components/fitness/body-comp-chart.tsx
@@ -5,6 +5,7 @@ import {
   Line,
   XAxis,
   YAxis,
+  CartesianGrid,
   Tooltip,
   Legend,
   ResponsiveContainer,
@@ -76,6 +77,7 @@ export default function BodyCompChart({ data }: Props) {
           axisLine={false}
           domain={["auto", "auto"]}
         />
+        <CartesianGrid strokeDasharray="3 3" stroke="#262626" vertical={false} />
         <Tooltip content={<CustomTooltip />} />
         <Legend
           iconType="circle"
@@ -87,7 +89,7 @@ export default function BodyCompChart({ data }: Props) {
           type="monotone"
           dataKey="weight"
           name="Weight (lb)"
-          stroke="#a3a3a3"
+          stroke="#3b82f6"
           strokeWidth={1.5}
           dot={false}
           connectNulls

--- a/web/src/components/habits/habit-toggle.tsx
+++ b/web/src/components/habits/habit-toggle.tsx
@@ -37,12 +37,12 @@ export default function HabitToggle({ habit, log, toggleAction, date }: Props) {
       <span
         className={`w-5 h-5 rounded-md border flex items-center justify-center flex-shrink-0 transition-colors ${
           completed
-            ? "bg-neutral-100 border-neutral-100"
+            ? "bg-blue-500 border-blue-500"
             : "border-neutral-600"
         }`}
       >
         {completed && (
-          <svg className="w-3 h-3 text-neutral-950" viewBox="0 0 12 12" fill="none">
+          <svg className="w-3 h-3 text-white" viewBox="0 0 12 12" fill="none">
             <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
           </svg>
         )}

--- a/web/src/components/nav.tsx
+++ b/web/src/components/nav.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { LayoutDashboard, MessageSquare, CheckSquare, Activity, ListTodo } from "lucide-react";
+import Logo from "@/components/ui/logo";
 
 const tabs = [
   { href: "/", label: "Dashboard", icon: LayoutDashboard },
@@ -16,20 +17,37 @@ export default function Nav() {
   const pathname = usePathname();
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 bg-neutral-900 border-t border-neutral-800 z-50">
-      <div className="max-w-2xl mx-auto flex">
+    <nav className="fixed left-0 top-0 h-screen w-12 lg:w-48 bg-neutral-900 border-r border-neutral-800 z-50 flex flex-col">
+      {/* Logo */}
+      <div className="flex items-center justify-center lg:justify-start px-0 lg:px-4 pt-6 pb-6">
+        <Logo size={28} />
+        <span className="hidden lg:block ml-2.5 text-sm font-semibold text-neutral-100 tracking-tight">
+          Mr. Bridge
+        </span>
+      </div>
+
+      {/* Nav items */}
+      <div className="flex flex-col gap-1 px-1.5 lg:px-2">
         {tabs.map(({ href, label, icon: Icon }) => {
           const active = pathname === href;
           return (
             <Link
               key={href}
               href={href}
-              className={`flex-1 flex flex-col items-center gap-1 py-3 text-xs transition-colors ${
-                active ? "text-neutral-100" : "text-neutral-500 hover:text-neutral-300"
+              title={label}
+              className={`group relative flex items-center justify-center lg:justify-start gap-3 px-1.5 lg:px-3 py-2.5 rounded-lg text-sm transition-colors ${
+                active
+                  ? "text-blue-400 bg-blue-500/10 border-l-2 border-blue-500 rounded-l-none"
+                  : "text-neutral-500 hover:text-neutral-300 hover:bg-neutral-800/60 border-l-2 border-transparent rounded-l-none"
               }`}
             >
-              <Icon size={20} strokeWidth={active ? 2 : 1.5} />
-              <span>{label}</span>
+              <Icon size={18} strokeWidth={active ? 2 : 1.5} className="shrink-0" />
+              <span className="hidden lg:block font-medium">{label}</span>
+
+              {/* Tooltip for icon-only rail */}
+              <span className="lg:hidden absolute left-full ml-2 px-2 py-1 text-xs text-neutral-100 bg-neutral-800 border border-neutral-700 rounded-md whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10">
+                {label}
+              </span>
             </Link>
           );
         })}

--- a/web/src/components/tasks/add-task-form.tsx
+++ b/web/src/components/tasks/add-task-form.tsx
@@ -91,7 +91,7 @@ export default function AddTaskForm({ addAction }: Props) {
         <button
           type="submit"
           disabled={isPending || !title.trim()}
-          className="px-3 py-1.5 text-xs bg-neutral-100 text-neutral-950 rounded-lg font-medium disabled:opacity-40 hover:bg-white transition-colors"
+          className="px-3 py-1.5 text-xs bg-blue-500 text-white rounded-lg font-medium disabled:opacity-40 hover:bg-blue-400 transition-colors"
         >
           {isPending ? "Adding..." : "Add"}
         </button>

--- a/web/src/components/ui/logo.tsx
+++ b/web/src/components/ui/logo.tsx
@@ -1,0 +1,50 @@
+interface LogoProps {
+  size?: number;
+  className?: string;
+}
+
+export default function Logo({ size = 32, className = "" }: LogoProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-label="Mr. Bridge"
+    >
+      {/* Geometric background square */}
+      <rect width="32" height="32" rx="7" fill="#1d4ed8" fillOpacity="0.15" />
+      {/* M stroke */}
+      <path
+        d="M6 22V10l5 6 5-6v12"
+        stroke="#3b82f6"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* B strokes */}
+      <path
+        d="M18 10h5a2.5 2.5 0 0 1 0 5h-5V10z"
+        stroke="#3b82f6"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M18 15h5.5a2.5 2.5 0 0 1 0 5H18V15z"
+        stroke="#3b82f6"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M18 10v12"
+        stroke="#3b82f6"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -56,6 +56,10 @@ export interface RecoveryMetrics {
   resting_hr: number | null;
   sleep_score: number | null;
   readiness: number | null;
+  total_sleep_hrs: number | null;
+  deep_hrs: number | null;
+  rem_hrs: number | null;
+  active_cal: number | null;
   source: string | null;
 }
 


### PR DESCRIPTION
## Summary

- **Design system**: Geist Sans + Geist Mono fonts; blue-500 accent replaces neutral-100 on all interactive elements
- **Sidebar**: Replaces fixed bottom nav with a left sidebar — full labels on desktop (≥lg), icon-only 48px rail on mobile with hover tooltips; includes MB monogram logo
- **Daily briefing dashboard**: Full-width Fun Fact card, then 2-column grid with Schedule Today, Important Emails (left) and Recovery & Sleep, Fitness Snapshot, Habits, Tasks (right)
- **New API routes**: `/api/fun-fact` (Claude Haiku, Supabase-cached per day), `/api/google/calendar` (today's events), `/api/google/gmail` (important unread)
- **Recovery & Sleep card**: Shows Readiness + Sleep scores (color-coded ≥80/60–79/<60), HRV, RHR, total sleep, deep sleep in Geist Mono
- **Fitness Snapshot**: Body comp + most recent workout session
- **Chart**: blue-500 weight line, neutral-800 grid via CartesianGrid
- **Types**: `RecoveryMetrics` extended with `total_sleep_hrs`, `deep_hrs`, `rem_hrs`, `active_cal`

## Test plan

- [ ] `npm run dev` in `/web` — no build errors
- [ ] Dashboard loads all 8 sections; Google cards show loading skeleton → data (or graceful empty state)
- [ ] Fun fact: first load calls Claude and caches in `profile` table; second load is instant from cache
- [ ] Sidebar: desktop (≥lg) shows labels + blue active highlight; mobile (<lg) shows icon-only rail with tooltip on hover
- [ ] Login page: MB logo visible, blue sign-in button
- [ ] Habits page: completed habits show blue toggle fill
- [ ] Tasks: add-task submit button is blue
- [ ] Chat: send button is blue
- [ ] Fitness page: chart weight line is blue-500 with grid lines
- [ ] No regressions: habit toggle, task CRUD, chat streaming all work

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)