### PR TITLE
chore: timezone fixes, docs, and diagram for v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,47 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ---
 
+## [0.10.0] — 2026-04-10
+
+### Added
+- `web/src/components/ui/logo.tsx` — MB monogram SVG logo; used in sidebar header and login page
+- `web/src/components/nav.tsx` — replaced fixed bottom nav with a left sidebar: full labels + blue active state on desktop (≥lg), 48px icon-only rail with hover tooltips on mobile; closes issue #27
+- `web/src/app/api/fun-fact/route.ts` — calls Claude Haiku (`claude-haiku-4-5-20251001`, max 150 tokens) for a daily surprising fact; caches result in `profile` table as `key='fun_fact_cache'` (JSON `{fact, date}`); regenerates only when date changes
+- `web/src/app/api/google/calendar/route.ts` — fetches today's Google Calendar events via `googleapis`; OAuth2 with refresh token; returns `[{time, title, location?}]` sorted by start time
+- `web/src/app/api/google/gmail/route.ts` — fetches up to 5 important unread emails (subject filter: meeting / urgent / invoice / action required / deadline); metadata-only fetch for performance; returns `[{from, subject, receivedAt}]`
+- `web/src/components/dashboard/fun-fact.tsx` — full-width Fun Fact card with blue left border, spark icon, loading skeleton, italic text
+- `web/src/components/dashboard/schedule-today.tsx` — Schedule Today card; client component; fetches `/api/google/calendar`; Geist Mono for times; distinct error state
+- `web/src/components/dashboard/important-emails.tsx` — Important Emails card; client component; fetches `/api/google/gmail`; distinct error vs empty states
+- `web/src/components/dashboard/recovery-summary.tsx` — Recovery & Sleep card; color-coded readiness/sleep scores (≥80 green, 60–79 amber, <60 red); Geist Mono for HRV, RHR, sleep totals
+- `web/src/lib/timezone.ts` — timezone-aware date utilities: `todayString`, `getLast7Days`, `daysAgoString`, `startOfTodayRFC3339`, `endOfTodayRFC3339`; reads `USER_TIMEZONE` env var (default `America/Los_Angeles`)
+
+### Changed
+- `web/src/app/(protected)/layout.tsx` — restructured to flex row with sidebar; `ml-12 lg:ml-48` offset; removed `pb-24` bottom nav clearance
+- `web/src/app/(protected)/page.tsx` — full daily briefing layout: Fun Fact (full width) + 2-column grid (Schedule/Emails left; Recovery/Fitness/Habits/Tasks right); server fetches recovery and recent workout; date display uses `USER_TIMEZONE`
+- `web/src/app/layout.tsx` — replaced Inter with Geist Sans + Geist Mono (`next/font/google`); exposes `--font-sans` and `--font-mono` CSS variables
+- `web/src/components/dashboard/fitness-summary.tsx` — added `recentWorkout` prop; shows most recent workout session below body comp; numeric values use Geist Mono
+- `web/src/components/dashboard/habits-summary.tsx` — progress bar fill changed to `bg-blue-500`; counts use Geist Mono
+- `web/src/components/dashboard/tasks-summary.tsx` — task count uses Geist Mono
+- `web/src/components/habits/habit-toggle.tsx` — completed state uses `bg-blue-500` fill with white checkmark (was neutral-100/neutral-950)
+- `web/src/components/tasks/add-task-form.tsx` — submit button changed to `bg-blue-500 hover:bg-blue-400 text-white`
+- `web/src/components/chat/chat-interface.tsx` — send button changed to `bg-blue-500 hover:bg-blue-400 text-white`
+- `web/src/app/login/page.tsx` — added MB logo; sign-in button changed to blue
+- `web/src/components/fitness/body-comp-chart.tsx` — weight line changed to `#3b82f6` (blue-500); added `CartesianGrid` with `#262626` (neutral-800) horizontal lines
+- `web/src/app/(protected)/habits/page.tsx` — `today` and `getLast7Days` now use `timezone.ts` helpers
+- `web/src/app/(protected)/chat/page.tsx` — `today` uses `todayString()` from `timezone.ts`
+- `web/src/app/api/chat/route.ts` — `targetDate` defaults and `sinceStr` now use `todayString()` / `daysAgoString()` from `timezone.ts`
+- `web/src/app/api/google/calendar/route.ts` — `timeMin`/`timeMax` now use `startOfTodayRFC3339()` / `endOfTodayRFC3339()` with proper SF timezone offset (fixes wrong-day event fetch when server runs in UTC)
+- `web/src/app/api/fun-fact/route.ts` — cache date check uses `todayString()` from `timezone.ts`
+- `web/src/lib/types.ts` — `RecoveryMetrics` extended with `total_sleep_hrs`, `deep_hrs`, `rem_hrs`, `active_cal` (columns already existed in Supabase schema)
+- `scripts/sync-oura.py` — removed `new_dates` guard; script now upserts all dates in range instead of skipping existing rows; fixes partial rows (readiness/sleep score present but HRV/deep sleep NULL) never getting backfilled when Oura's API publishes delayed sleep detail
+
+### Fixed
+- Google Calendar API was constructing `timeMin`/`timeMax` from `new Date()` in UTC, causing it to fetch the wrong day's events when server runs in UTC (e.g. Vercel)
+- All `new Date().toISOString().split("T")[0]` calls in server components and API routes returned UTC dates, causing off-by-one date errors for SF users after ~5pm local time
+- Oura sync silently skipped existing rows on re-run, permanently leaving `avg_hrv`, `resting_hr`, `total_sleep_hrs`, `deep_hrs` as NULL when the first write captured only summary scores (Oura API publishes detailed sleep data hours after readiness/sleep scores)
+
+---
+
 ## [0.9.0] — 2026-04-10
 
 ### Added
@@ -191,7 +232,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ---
 
-[Unreleased]: https://github.com/Theioz/mr-bridge-assistant/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/Theioz/mr-bridge-assistant/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/Theioz/mr-bridge-assistant/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Theioz/mr-bridge-assistant/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Theioz/mr-bridge-assistant/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Theioz/mr-bridge-assistant/compare/v0.6.0...v0.7.0

--- a/README.md
+++ b/README.md
@@ -5,68 +5,50 @@ A personal AI assistant context layer for Claude Code. Syncs fitness, habit, and
 ## Architecture
 
 ```mermaid
-graph TD
-    subgraph Sources["Data Sources"]
-        OF[Oura Ring]
-        FB[Fitbit]
-        GF[Google Fit]
-        RP[Renpho Scale]
+flowchart LR
+    subgraph devices["Devices"]
+        oura["Oura Ring"]
+        fitbit["Fitbit"]
+        gfit["Google Fit"]
+        renpho["Renpho"]
     end
 
-    subgraph Scripts["Sync Scripts"]
-        SO[sync-oura.py]
-        SF[sync-fitbit.py]
-        SG[sync-googlefit.py]
-        SR[sync-renpho.py]
+    subgraph scripts["Sync Scripts"]
+        so["sync-oura"]
+        sf["sync-fitbit"]
+        sg["sync-googlefit"]
+        sr["sync-renpho"]
     end
 
-    subgraph DB["Supabase"]
-        RM[(recovery_metrics)]
-        WS[(workout_sessions)]
-        FL[(fitness_log)]
-        HB[(habits)]
-        TK[(tasks)]
-        PR[(profile)]
-        CS[(chat_messages)]
+    db[("Supabase\n14 tables")]
+
+    subgraph web["Next.js Web App"]
+        rc["api/chat"]
+        rf["api/fun-fact"]
+        rcal["api/calendar"]
+        rmail["api/gmail"]
+        pg["Dashboard · Habits · Tasks · Fitness · Chat"]
     end
 
-    subgraph Web["Next.js Web App"]
-        subgraph Routes["API Routes"]
-            CA["api/chat"]
-            FN["api/fun-fact"]
-            GC["api/google/calendar"]
-            GM["api/google/gmail"]
-        end
-        subgraph Pages["Pages"]
-            PD[Dashboard]
-            PH[Habits]
-            PT[Tasks]
-            PF[Fitness]
-            PC[Chat]
-        end
+    subgraph ext["External APIs"]
+        cl["Anthropic Claude"]
+        gc["Google Calendar"]
+        gm["Gmail"]
     end
 
-    subgraph Ext["External APIs"]
-        AN[Anthropic]
-        GCA[Google Calendar]
-        GMA[Gmail]
-    end
+    oura --> so --> db
+    fitbit --> sf --> db
+    gfit --> sg --> db
+    renpho --> sr --> db
 
-    OF --> SO --> RM
-    FB --> SF --> WS
-    GF --> SG --> FL
-    RP --> SR --> FL
+    db --> pg
+    db --> rc
+    rc --> db
 
-    RM & WS & FL --> PD & PF
-    HB --> PD & PH
-    TK --> PD & PT
-    CS --> PC
-    PR --> FN
-
-    AN --> CA & FN
-    GCA --> GC --> PD
-    GMA --> GM --> PD
-    CA --> CS
+    cl --> rc & rf
+    gc --> rcal --> pg
+    gm --> rmail --> pg
+    rf --> pg
 ```
 
 ## Purpose

--- a/README.md
+++ b/README.md
@@ -13,48 +13,43 @@ graph TD
         RP[Renpho Scale]
     end
 
-    subgraph Scripts["Sync Scripts (Python)"]
+    subgraph Scripts["Sync Scripts"]
         SO[sync-oura.py]
         SF[sync-fitbit.py]
         SG[sync-googlefit.py]
         SR[sync-renpho.py]
     end
 
-    subgraph DB["Supabase (PostgreSQL)"]
+    subgraph DB["Supabase"]
         RM[(recovery_metrics)]
         WS[(workout_sessions)]
         FL[(fitness_log)]
-        HB[(habits / habit_registry)]
+        HB[(habits)]
         TK[(tasks)]
         PR[(profile)]
-        CS[(chat_sessions / messages)]
+        CS[(chat_messages)]
     end
 
     subgraph Web["Next.js Web App"]
-        subgraph API["API Routes"]
-            CA[/api/chat]
-            FN[/api/fun-fact]
-            GC[/api/google/calendar]
-            GM[/api/google/gmail]
+        subgraph Routes["API Routes"]
+            CA["api/chat"]
+            FN["api/fun-fact"]
+            GC["api/google/calendar"]
+            GM["api/google/gmail"]
         end
         subgraph Pages["Pages"]
-            DB[Dashboard]
-            HP[Habits]
-            TP[Tasks]
-            FP[Fitness]
-            CP[Chat]
+            PD[Dashboard]
+            PH[Habits]
+            PT[Tasks]
+            PF[Fitness]
+            PC[Chat]
         end
     end
 
-    subgraph External["External APIs"]
-        AN[Anthropic Claude API]
-        GCA[Google Calendar API]
-        GMA[Gmail API]
-    end
-
-    subgraph CLI["Claude Code CLI"]
-        CC[Session Start\nBriefing]
-        MCP[MCP Servers\nCalendar · Gmail]
+    subgraph Ext["External APIs"]
+        AN[Anthropic]
+        GCA[Google Calendar]
+        GMA[Gmail]
     end
 
     OF --> SO --> RM
@@ -62,21 +57,16 @@ graph TD
     GF --> SG --> FL
     RP --> SR --> FL
 
-    RM & WS & FL --> DB & FP
-    HB --> DB & HP
-    TK --> DB & TP
-    CS --> CP
+    RM & WS & FL --> PD & PF
+    HB --> PD & PH
+    TK --> PD & PT
+    CS --> PC
     PR --> FN
 
-    AN --> CA
-    AN --> FN
-    GCA --> GC --> DB
-    GMA --> GM --> DB
+    AN --> CA & FN
+    GCA --> GC --> PD
+    GMA --> GM --> PD
     CA --> CS
-
-    DB --> DB
-    DB & RM & WS & FL & HB & TK & PR --> CC
-    GCA & GMA --> MCP --> CC
 ```
 
 ## Purpose

--- a/README.md
+++ b/README.md
@@ -1,11 +1,90 @@
 # Mr. Bridge — Personal Assistant
 
-A personal AI assistant context layer for Claude Code. Syncs fitness, habit, and task data from external APIs into Supabase, delivers a structured session briefing, and tracks accountability across devices.
+A personal AI assistant context layer for Claude Code. Syncs fitness, habit, and task data from external APIs into Supabase, delivers a structured session briefing, and tracks accountability across devices. Includes a full Next.js web interface for real-time access from any browser.
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph Sources["Data Sources"]
+        OF[Oura Ring]
+        FB[Fitbit]
+        GF[Google Fit]
+        RP[Renpho Scale]
+    end
+
+    subgraph Scripts["Sync Scripts (Python)"]
+        SO[sync-oura.py]
+        SF[sync-fitbit.py]
+        SG[sync-googlefit.py]
+        SR[sync-renpho.py]
+    end
+
+    subgraph DB["Supabase (PostgreSQL)"]
+        RM[(recovery_metrics)]
+        WS[(workout_sessions)]
+        FL[(fitness_log)]
+        HB[(habits / habit_registry)]
+        TK[(tasks)]
+        PR[(profile)]
+        CS[(chat_sessions / messages)]
+    end
+
+    subgraph Web["Next.js Web App"]
+        subgraph API["API Routes"]
+            CA[/api/chat]
+            FN[/api/fun-fact]
+            GC[/api/google/calendar]
+            GM[/api/google/gmail]
+        end
+        subgraph Pages["Pages"]
+            DB[Dashboard]
+            HP[Habits]
+            TP[Tasks]
+            FP[Fitness]
+            CP[Chat]
+        end
+    end
+
+    subgraph External["External APIs"]
+        AN[Anthropic Claude API]
+        GCA[Google Calendar API]
+        GMA[Gmail API]
+    end
+
+    subgraph CLI["Claude Code CLI"]
+        CC[Session Start\nBriefing]
+        MCP[MCP Servers\nCalendar · Gmail]
+    end
+
+    OF --> SO --> RM
+    FB --> SF --> WS
+    GF --> SG --> FL
+    RP --> SR --> FL
+
+    RM & WS & FL --> DB & FP
+    HB --> DB & HP
+    TK --> DB & TP
+    CS --> CP
+    PR --> FN
+
+    AN --> CA
+    AN --> FN
+    GCA --> GC --> DB
+    GMA --> GM --> DB
+    CA --> CS
+
+    DB --> DB
+    DB & RM & WS & FL & HB & TK & PR --> CC
+    GCA & GMA --> MCP --> CC
+```
 
 ## Purpose
-Mr. Bridge is built to run like infrastructure — frameworks over feelings, quantified over qualitative, no filler. It pulls live data from Supabase at session start and gives you a concise brief before you do anything else. All data is stored in the cloud — accessible from any device, ready for a web interface.
+
+Mr. Bridge runs like infrastructure — structured over casual, quantified over qualitative, no filler. It pulls live data from Supabase at session start and delivers a concise brief before anything else. All live data is stored in the cloud and accessible from Claude Code, the web interface, or any device.
 
 ## File Structure
+
 ```
 mr-bridge-assistant/
 ├── CLAUDE.md                              # Session bootstrap (loads rules via @path)
@@ -26,19 +105,38 @@ mr-bridge-assistant/
 │   ├── src/
 │   │   ├── app/
 │   │   │   ├── (protected)/               # Auth-gated pages
-│   │   │   │   ├── page.tsx               # Dashboard
+│   │   │   │   ├── layout.tsx             # Protected layout with sidebar
+│   │   │   │   ├── page.tsx               # Daily briefing dashboard
 │   │   │   │   ├── tasks/page.tsx         # Task management
-│   │   │   │   ├── habits/page.tsx        # Habit tracking
+│   │   │   │   ├── habits/page.tsx        # Habit tracking + 7-day history
 │   │   │   │   ├── fitness/page.tsx       # Body composition + workouts
 │   │   │   │   └── chat/page.tsx          # Mr. Bridge chat
-│   │   │   ├── api/chat/route.ts          # Claude API + Supabase tool use
+│   │   │   ├── api/
+│   │   │   │   ├── chat/route.ts          # Claude API + Supabase tool use (7 tools)
+│   │   │   │   ├── fun-fact/route.ts      # Claude Haiku daily fact + Supabase cache
+│   │   │   │   └── google/
+│   │   │   │       ├── calendar/route.ts  # Today's Google Calendar events
+│   │   │   │       └── gmail/route.ts     # Important unread emails
 │   │   │   └── login/page.tsx
 │   │   ├── components/
+│   │   │   ├── nav.tsx                    # Left sidebar (desktop labels / mobile icon rail)
+│   │   │   ├── ui/
+│   │   │   │   └── logo.tsx               # MB monogram SVG
 │   │   │   ├── chat/                      # Chat UI with markdown rendering
 │   │   │   ├── tasks/                     # Task CRUD components
-│   │   │   ├── habits/                    # Habit toggle + history
-│   │   │   └── dashboard/                 # Summary cards
+│   │   │   ├── habits/                    # Habit toggle + 7-day history grid
+│   │   │   ├── fitness/                   # Body comp chart (Recharts)
+│   │   │   └── dashboard/
+│   │   │       ├── fun-fact.tsx           # Daily fun fact card
+│   │   │       ├── schedule-today.tsx     # Google Calendar card
+│   │   │       ├── important-emails.tsx   # Gmail card
+│   │   │       ├── recovery-summary.tsx   # Oura recovery & sleep card
+│   │   │       ├── fitness-summary.tsx    # Body comp + last workout card
+│   │   │       ├── habits-summary.tsx     # Today's habit progress card
+│   │   │       ├── tasks-summary.tsx      # Active tasks card
+│   │   │       └── recent-chat.tsx        # Last chat message card
 │   │   └── lib/
+│   │       ├── timezone.ts                # Timezone-aware date helpers (USER_TIMEZONE)
 │   │       ├── supabase/                  # Client, server, service clients
 │   │       └── types.ts                   # TypeScript interfaces for all DB tables
 │   └── package.json
@@ -207,13 +305,13 @@ Feature backlog is tracked via [GitHub Issues](https://github.com/Theioz/mr-brid
 
 ## Web Interface
 
-A Next.js web app deployed on Vercel providing a full UI for Mr. Bridge:
+A Next.js web app deployed on Vercel providing a full daily briefing UI:
 
-- **Chat** — stream responses from Claude claude-sonnet-4-6 with markdown rendering (tables, bold, code blocks)
-- **Tasks** — add, complete, and archive tasks with inline error feedback
-- **Habits** — daily check-in, 7-day history grid
-- **Fitness** — body composition history and workout log
-- **Dashboard** — summary cards across all data sources
+- **Dashboard** — Fun Fact (Claude Haiku), Schedule Today (Google Calendar), Important Emails (Gmail), Recovery & Sleep (Oura), Fitness Snapshot, Habits, Tasks
+- **Chat** — streams responses from Claude Sonnet with markdown rendering
+- **Tasks** — add, complete, and archive tasks
+- **Habits** — daily check-in with blue toggle states, 7-day history grid
+- **Fitness** — body composition chart (Recharts) + workout log
 
 **Local development:**
 ```bash
@@ -228,6 +326,10 @@ NEXT_PUBLIC_SUPABASE_URL=...
 NEXT_PUBLIC_SUPABASE_ANON_KEY=...
 SUPABASE_SERVICE_ROLE_KEY=...
 ANTHROPIC_API_KEY=...
+GOOGLE_CLIENT_ID=...
+GOOGLE_CLIENT_SECRET=...
+GOOGLE_REFRESH_TOKEN=...
+USER_TIMEZONE=America/Los_Angeles
 ```
 
 ## Voice Interface (Jarvis Mode)

--- a/scripts/sync-oura.py
+++ b/scripts/sync-oura.py
@@ -118,19 +118,21 @@ def main():
 
     all_dates = sorted(set(readiness) | set(sleep_detail))
 
+    if not all_dates:
+        print("[sync-oura] No data returned from Oura.")
+        return
+
     client = get_client()
     existing = existing_dates(client)
     new_dates = [d for d in all_dates if d not in existing]
+    update_dates = [d for d in all_dates if d in existing]
 
-    if not new_dates:
-        print("[sync-oura] No new data.")
-        return
-
-    print(f"\nNew recovery entries ({len(new_dates)}):")
-    for d in new_dates:
+    print(f"\nRecovery entries to write ({len(new_dates)} new, {len(update_dates)} update):")
+    for d in all_dates:
         sd = sleep_detail.get(d, {})
+        tag = "NEW" if d in new_dates else "UPD"
         print(
-            f"  {d} — Readiness: {readiness.get(d)} | Sleep: {sleep_scores.get(d)} | "
+            f"  [{tag}] {d} — Readiness: {readiness.get(d)} | Sleep: {sleep_scores.get(d)} | "
             f"Total: {sd.get('total_sleep_hrs')}h | HRV: {sd.get('avg_hrv')}ms | "
             f"RHR: {sd.get('resting_hr')} | Active Cal: {active_cal.get(d)}"
         )
@@ -142,7 +144,7 @@ def main():
             return
 
     sb_rows = []
-    for d in new_dates:
+    for d in all_dates:
         sd = sleep_detail.get(d, {})
         sb_rows.append({
             "date": d,
@@ -160,7 +162,7 @@ def main():
 
     written = upsert(client, "recovery_metrics", sb_rows, conflict="date")
     log_sync(client, "oura", "ok", written)
-    print(f"[sync-oura] Synced {written} row(s) to Supabase.")
+    print(f"[sync-oura] Upserted {written} row(s) to Supabase.")
 
 
 if __name__ == "__main__":

--- a/web/src/app/(protected)/chat/page.tsx
+++ b/web/src/app/(protected)/chat/page.tsx
@@ -1,11 +1,12 @@
 import { createClient } from "@/lib/supabase/server";
 import ChatInterface from "@/components/chat/chat-interface";
 import type { ChatMessage, ChatSession } from "@/lib/types";
+import { todayString } from "@/lib/timezone";
 import type { Message } from "ai";
 
 export default async function ChatPage() {
   const supabase = await createClient();
-  const today = new Date().toISOString().split("T")[0];
+  const today = todayString();
 
   // Find or create today's web session
   let session: ChatSession | null = null;

--- a/web/src/app/(protected)/habits/page.tsx
+++ b/web/src/app/(protected)/habits/page.tsx
@@ -3,6 +3,7 @@ import { revalidatePath } from "next/cache";
 import HabitToggle from "@/components/habits/habit-toggle";
 import HabitHistory from "@/components/habits/habit-history";
 import type { HabitRegistry, HabitLog } from "@/lib/types";
+import { todayString, getLast7Days } from "@/lib/timezone";
 
 async function toggleHabit(habitId: string, date: string, completed: boolean) {
   "use server";
@@ -14,17 +15,9 @@ async function toggleHabit(habitId: string, date: string, completed: boolean) {
   revalidatePath("/");
 }
 
-function getLast7Days(): string[] {
-  return Array.from({ length: 7 }, (_, i) => {
-    const d = new Date();
-    d.setDate(d.getDate() - (6 - i));
-    return d.toISOString().split("T")[0];
-  });
-}
-
 export default async function HabitsPage() {
   const supabase = await createClient();
-  const today = new Date().toISOString().split("T")[0];
+  const today = todayString();
   const last7 = getLast7Days();
 
   const [registryResult, todayLogsResult, historyLogsResult] = await Promise.all([

--- a/web/src/app/(protected)/page.tsx
+++ b/web/src/app/(protected)/page.tsx
@@ -7,10 +7,11 @@ import FunFact from "@/components/dashboard/fun-fact";
 import ScheduleToday from "@/components/dashboard/schedule-today";
 import ImportantEmails from "@/components/dashboard/important-emails";
 import type { HabitLog, Task, FitnessLog, RecoveryMetrics, WorkoutSession } from "@/lib/types";
+import { todayString, USER_TZ } from "@/lib/timezone";
 
 export default async function DashboardPage() {
   const supabase = await createClient();
-  const today = new Date().toISOString().split("T")[0];
+  const today = todayString();
 
   const [
     habitsResult,
@@ -64,6 +65,7 @@ export default async function DashboardPage() {
     weekday: "long",
     month: "long",
     day: "numeric",
+    timeZone: USER_TZ,
   });
 
   return (

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -1,4 +1,5 @@
 import { anthropic } from "@ai-sdk/anthropic";
+import { todayString, daysAgoString } from "@/lib/timezone";
 import { streamText, tool, jsonSchema, wrapLanguageModel } from "ai";
 import type { LanguageModelV1Middleware } from "ai";
 import { createServiceClient } from "@/lib/supabase/service";
@@ -165,7 +166,7 @@ Tools available:
         },
       }),
       execute: async ({ date }) => {
-        const targetDate = date ?? new Date().toISOString().slice(0, 10);
+        const targetDate = date ?? todayString();
         const [registryResult, logsResult] = await Promise.all([
           supabase.from("habit_registry").select("id, name, emoji, category").eq("active", true),
           supabase.from("habits").select("habit_id, completed, notes").eq("date", targetDate),
@@ -197,7 +198,7 @@ Tools available:
         },
       }),
       execute: async ({ name, date, notes }) => {
-        const targetDate = date ?? new Date().toISOString().slice(0, 10);
+        const targetDate = date ?? todayString();
         const { data: habits, error: lookupError } = await supabase
           .from("habit_registry")
           .select("id, name")
@@ -232,9 +233,7 @@ Tools available:
         },
       }),
       execute: async ({ days = 7 }) => {
-        const since = new Date();
-        since.setDate(since.getDate() - days);
-        const sinceStr = since.toISOString().slice(0, 10);
+        const sinceStr = daysAgoString(days);
 
         const [bodyCompResult, workoutsResult, recoveryResult] = await Promise.all([
           supabase

--- a/web/src/app/api/fun-fact/route.ts
+++ b/web/src/app/api/fun-fact/route.ts
@@ -2,6 +2,7 @@ import { anthropic } from "@ai-sdk/anthropic";
 import { generateText } from "ai";
 import { createServiceClient } from "@/lib/supabase/service";
 import { NextResponse } from "next/server";
+import { todayString } from "@/lib/timezone";
 
 const CACHE_KEY = "fun_fact_cache";
 
@@ -13,7 +14,7 @@ interface FunFactCache {
 export async function GET() {
   try {
     const supabase = createServiceClient();
-    const today = new Date().toISOString().split("T")[0];
+    const today = todayString();
 
     // Check cache
     const { data: cached } = await supabase

--- a/web/src/app/api/google/calendar/route.ts
+++ b/web/src/app/api/google/calendar/route.ts
@@ -1,5 +1,6 @@
 import { google } from "googleapis";
 import { NextResponse } from "next/server";
+import { startOfTodayRFC3339, endOfTodayRFC3339 } from "@/lib/timezone";
 
 export interface CalendarEvent {
   time: string;
@@ -33,9 +34,8 @@ export async function GET() {
 
     const calendar = google.calendar({ version: "v3", auth });
 
-    const now = new Date();
-    const timeMin = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0).toISOString();
-    const timeMax = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59).toISOString();
+    const timeMin = startOfTodayRFC3339();
+    const timeMax = endOfTodayRFC3339();
 
     const res = await calendar.events.list({
       calendarId: "primary",

--- a/web/src/components/dashboard/important-emails.tsx
+++ b/web/src/components/dashboard/important-emails.tsx
@@ -7,12 +7,16 @@ import type { EmailSummary } from "@/app/api/google/gmail/route";
 export default function ImportantEmails() {
   const [emails, setEmails] = useState<EmailSummary[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     fetch("/api/google/gmail")
       .then((r) => r.json())
-      .then((d) => setEmails(d.emails ?? []))
-      .catch(() => setEmails([]))
+      .then((d) => {
+        if (d.error) { setError(true); return; }
+        setEmails(d.emails ?? []);
+      })
+      .catch(() => setError(true))
       .finally(() => setLoading(false));
   }, []);
 
@@ -32,6 +36,8 @@ export default function ImportantEmails() {
             </div>
           ))}
         </div>
+      ) : error ? (
+        <p className="text-sm text-red-400/70">Failed to load — check Google credentials</p>
       ) : emails.length > 0 ? (
         <div className="divide-y divide-neutral-800/50">
           {emails.map((email, i) => (

--- a/web/src/components/dashboard/schedule-today.tsx
+++ b/web/src/components/dashboard/schedule-today.tsx
@@ -7,12 +7,16 @@ import type { CalendarEvent } from "@/app/api/google/calendar/route";
 export default function ScheduleToday() {
   const [events, setEvents] = useState<CalendarEvent[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     fetch("/api/google/calendar")
       .then((r) => r.json())
-      .then((d) => setEvents(d.events ?? []))
-      .catch(() => setEvents([]))
+      .then((d) => {
+        if (d.error) { setError(true); return; }
+        setEvents(d.events ?? []);
+      })
+      .catch(() => setError(true))
       .finally(() => setLoading(false));
   }, []);
 
@@ -32,6 +36,8 @@ export default function ScheduleToday() {
             </div>
           ))}
         </div>
+      ) : error ? (
+        <p className="text-sm text-red-400/70">Failed to load — check Google credentials</p>
       ) : events.length > 0 ? (
         <div className="space-y-2.5">
           {events.map((event, i) => (

--- a/web/src/lib/timezone.ts
+++ b/web/src/lib/timezone.ts
@@ -1,0 +1,57 @@
+export const USER_TZ: string = process.env.USER_TIMEZONE ?? "America/Los_Angeles";
+
+/** Returns today's date as YYYY-MM-DD in the user's timezone. */
+export function todayString(tz = USER_TZ): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: tz }).format(new Date());
+}
+
+/**
+ * Returns the last N days as YYYY-MM-DD strings in the user's timezone,
+ * oldest first. Default 7 days (index 0 = 6 days ago, index 6 = today).
+ */
+export function getLast7Days(tz = USER_TZ): string[] {
+  return Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(Date.now() - (6 - i) * 86_400_000);
+    return new Intl.DateTimeFormat("en-CA", { timeZone: tz }).format(d);
+  });
+}
+
+/** Returns a YYYY-MM-DD string for N days ago in the user's timezone. */
+export function daysAgoString(days: number, tz = USER_TZ): string {
+  const d = new Date(Date.now() - days * 86_400_000);
+  return new Intl.DateTimeFormat("en-CA", { timeZone: tz }).format(d);
+}
+
+/**
+ * Returns the UTC offset string for a timezone at the current moment,
+ * e.g. "-07:00" for PDT or "-08:00" for PST.
+ */
+function tzOffsetString(tz: string): string {
+  const now = new Date();
+  const utc = new Date(now.toLocaleString("en-US", { timeZone: "UTC" }));
+  const local = new Date(now.toLocaleString("en-US", { timeZone: tz }));
+  const diffMins = Math.round((local.getTime() - utc.getTime()) / 60_000);
+  const sign = diffMins >= 0 ? "+" : "-";
+  const abs = Math.abs(diffMins);
+  const h = String(Math.floor(abs / 60)).padStart(2, "0");
+  const m = String(abs % 60).padStart(2, "0");
+  return `${sign}${h}:${m}`;
+}
+
+/**
+ * Returns an RFC 3339 string for midnight of today in the user's timezone,
+ * suitable for Google Calendar's timeMin.
+ * e.g. "2026-04-10T00:00:00-07:00"
+ */
+export function startOfTodayRFC3339(tz = USER_TZ): string {
+  return `${todayString(tz)}T00:00:00${tzOffsetString(tz)}`;
+}
+
+/**
+ * Returns an RFC 3339 string for end-of-day today in the user's timezone,
+ * suitable for Google Calendar's timeMax.
+ * e.g. "2026-04-10T23:59:59-07:00"
+ */
+export function endOfTodayRFC3339(tz = USER_TZ): string {
+  return `${todayString(tz)}T23:59:59${tzOffsetString(tz)}`;
+}


### PR DESCRIPTION
Follow-up to #28 — commits that landed after the PR was merged.

## Changes

- **Timezone fixes** — all server-side `new Date().toISOString()` date strings replaced with `todayString()` / `getLast7Days()` from new `web/src/lib/timezone.ts`; Google Calendar `timeMin`/`timeMax` now use proper RFC3339 with SF offset; `USER_TIMEZONE=America/Los_Angeles` added to `.env.local`
- **Oura sync fix** — `sync-oura.py` now upserts all dates instead of skipping existing rows, so partial rows (readiness/score present but HRV/sleep detail NULL) get backfilled when Oura's API publishes delayed data
- **README** — architecture diagram (Mermaid flowchart LR), updated file structure, updated web interface section
- **CHANGELOG** — v0.10.0 entry with full Added/Changed/Fixed breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)