### PR TITLE
feat: multi-account Gmail + Calendar support (closes #11)

### DIFF
--- a/.claude/rules/mr-bridge-rules.md
+++ b/.claude/rules/mr-bridge-rules.md
@@ -21,7 +21,9 @@ Execute in this exact order:
    Read the output — it contains profile, tasks, habits, body composition, workouts, recovery, and study log.
 3. Read `memory/meal_log.md` (recipes not yet in Supabase query — still local)
 4. Fetch today's Google Calendar events using `List Calendar Events` (claude.ai Google Calendar MCP)
+   — includes both personal (jaydud6) and professional (leung.ss.jason, shared) calendars — note the calendar/account source for each event
 5. Search for important unread emails using `Search Gmail Emails` (claude.ai Gmail MCP) — filter: unread, subjects containing meeting / urgent / invoice / action required / deadline
+   — jaydud6 = personal (primary); leung.ss.jason = professional (aggregated via POP3, Gmail label: "professional") — note account source when surfacing emails
 6. Deliver session briefing (format below)
 
 ## Session Briefing Format

--- a/docs/gmail-multi-account.md
+++ b/docs/gmail-multi-account.md
@@ -1,0 +1,81 @@
+# Gmail & Calendar — Multi-Account Setup
+
+Covers how `jaydud6@gmail.com` (personal, primary) and `leung.ss.jason@gmail.com` (professional) are unified into a single Mr. Bridge session.
+
+---
+
+## Gmail — "Check mail from other accounts" (POP3 aggregation)
+
+Professional emails are pulled into the personal inbox. The OAuth token stays on `jaydud6@gmail.com` — no second credential set required.
+
+### Setup steps
+
+**1. Enable POP3 on leung.ss.jason**
+- Gmail → Settings → See all settings → Forwarding and POP/IMAP
+- Under "POP Download": select "Enable POP for all mail" (or "for mail that arrives from now on")
+- Save
+
+**2. Add leung.ss.jason as a mail source in jaydud6**
+- Gmail (jaydud6) → Settings → See all settings → Accounts → "Check mail from other accounts"
+- Click "Add a mail account" → enter `leung.ss.jason@gmail.com`
+- Choose: "Import emails from my other account (Gmailify)" if offered, otherwise use POP3
+- In the label step: check "Label incoming messages" → create or select label `professional`
+- Do NOT check "Archive incoming messages" — professional emails should stay in inbox
+
+**3. Verify**
+- Trigger an immediate pull: Settings → Accounts → "Check mail now" next to leung.ss.jason
+- Send a test email to `leung.ss.jason@gmail.com`; within 30–60 min it should appear in jaydud6's inbox tagged `professional`
+
+### Sync delay
+POP3 polls approximately every 30–60 minutes. Not real-time. Acceptable for session briefings. Use "Check mail now" in Settings to force an immediate poll.
+
+### How emails surface in Mr. Bridge
+
+| Email type | Where it comes from | Label in jaydud6 | Appears in dashboard? |
+|---|---|---|---|
+| Personal, high-signal | jaydud6 directly | none | Yes, if subject matches filter |
+| Professional | leung.ss.jason via POP3 | `professional` | Yes, if subject matches filter; shown with "work" badge |
+| Personal, noise | jaydud6 directly | none | No (subject filter blocks it) |
+
+The dashboard query: `is:unread subject:(meeting OR urgent OR invoice OR "action required" OR deadline)`
+Professional emails that don't match this filter are still pulled into the inbox but won't surface in the Important Emails card. They're accessible via Gmail directly.
+
+---
+
+## Google Calendar — Calendar sharing
+
+The professional calendar is shared with the personal account. The existing OAuth token (jaydud6) then sees all calendars via the Google Calendar API — no second auth required. Calendar sharing is real-time (no sync delay).
+
+### Setup steps
+
+**1. Share leung.ss.jason's calendars with jaydud6**
+- Google Calendar (leung.ss.jason) → Settings → click each calendar under "Settings for my calendars"
+- Under "Share with specific people or groups" → Add `jaydud6@gmail.com`
+- Permission: "See all event details"
+- Repeat for each calendar to share (typically: primary + any work project calendars)
+
+**2. Accept the shared calendar in jaydud6**
+- Google Calendar (jaydud6) should prompt to accept; or check "Other calendars" in the sidebar
+- The professional calendars appear under "Other calendars" with the leung.ss.jason label
+
+**3. Verify**
+- Create a test event in leung.ss.jason's Google Calendar
+- Confirm it appears in jaydud6's Google Calendar within seconds
+- Open Mr. Bridge web dashboard → Schedule Today card should show the event with the calendar name as source
+
+### How events surface in Mr. Bridge
+
+The calendar API (`/api/google/calendar`) now lists all calendars accessible to jaydud6 (primary + shared) and unions their events for today. Each event includes:
+- `calendarName` — the name of the calendar it came from
+- `isPrimary` — true only for jaydud6's own primary calendar
+
+Non-primary events show the `calendarName` as a subtitle in the Schedule Today dashboard card, so it's clear which account an event belongs to.
+
+---
+
+## Session Briefing Notes
+
+Steps 4 and 5 of the Session Start Protocol now reflect multi-account coverage:
+
+- **Calendar**: List Calendar Events returns events from all connected calendars. Note the source for any non-primary events.
+- **Gmail**: Search covers both accounts via POP3 aggregation. Professional emails arrive with Gmail label `professional`. Note "personal" or "work" when surfacing emails in the briefing.

--- a/web/src/app/api/google/calendar/route.ts
+++ b/web/src/app/api/google/calendar/route.ts
@@ -7,6 +7,8 @@ export interface CalendarEvent {
   time: string;
   title: string;
   location?: string;
+  calendarName: string;
+  isPrimary: boolean;
 }
 
 function formatTime(dateTimeStr: string | null | undefined, dateStr: string | null | undefined): string {
@@ -28,24 +30,39 @@ export async function GET() {
     const timeMin = startOfTodayRFC3339();
     const timeMax = endOfTodayRFC3339();
 
-    const res = await calendar.events.list({
-      calendarId: "primary",
-      timeMin,
-      timeMax,
-      singleEvents: true,
-      orderBy: "startTime",
-      maxResults: 10,
-    });
+    // List all calendars so events from shared accounts (e.g. leung.ss.jason) are included
+    const calListRes = await calendar.calendarList.list({ minAccessRole: "reader" });
+    const calendars = calListRes.data.items ?? [];
 
-    const items = res.data.items ?? [];
+    const allEventArrays = await Promise.all(
+      calendars.map(async (cal) => {
+        const res = await calendar.events.list({
+          calendarId: cal.id!,
+          timeMin,
+          timeMax,
+          singleEvents: true,
+          orderBy: "startTime",
+          maxResults: 10,
+        });
+        const calName = cal.summaryOverride ?? cal.summary ?? cal.id ?? "Unknown";
+        const isPrimary = cal.primary === true;
+        return (res.data.items ?? [])
+          .filter((e) => e.status !== "cancelled")
+          .map((e) => ({
+            time: formatTime(e.start?.dateTime, e.start?.date),
+            title: e.summary ?? "(No title)",
+            calendarName: calName,
+            isPrimary,
+            startDateTime: e.start?.dateTime ?? e.start?.date ?? "",
+            ...(e.location ? { location: e.location } : {}),
+          }));
+      })
+    );
 
-    const events: CalendarEvent[] = items
-      .filter((e) => e.status !== "cancelled")
-      .map((e) => ({
-        time: formatTime(e.start?.dateTime, e.start?.date),
-        title: e.summary ?? "(No title)",
-        ...(e.location ? { location: e.location } : {}),
-      }));
+    const events: CalendarEvent[] = allEventArrays
+      .flat()
+      .sort((a, b) => a.startDateTime.localeCompare(b.startDateTime))
+      .map(({ startDateTime: _dt, ...rest }) => rest);
 
     return NextResponse.json({ events });
   } catch (err) {

--- a/web/src/app/api/google/gmail/route.ts
+++ b/web/src/app/api/google/gmail/route.ts
@@ -6,6 +6,7 @@ export interface EmailSummary {
   from: string;
   subject: string;
   receivedAt: string;
+  account: "personal" | "professional";
 }
 
 function parseFrom(raw: string): string {
@@ -45,10 +46,17 @@ export async function GET() {
           metadataHeaders: ["From", "Subject", "Date"],
         });
         const headers = msg.data.payload?.headers ?? [];
+        const labelIds = msg.data.labelIds ?? [];
+        const account: EmailSummary["account"] = labelIds.some(
+          (l) => l.toLowerCase() === "professional"
+        )
+          ? "professional"
+          : "personal";
         return {
           from: parseFrom(getHeader(headers, "From")),
           subject: getHeader(headers, "Subject") || "(No subject)",
           receivedAt: getHeader(headers, "Date"),
+          account,
         };
       })
     );

--- a/web/src/components/dashboard/important-emails.tsx
+++ b/web/src/components/dashboard/important-emails.tsx
@@ -42,7 +42,12 @@ export default function ImportantEmails() {
         <div className="divide-y divide-neutral-800/50">
           {emails.map((email, i) => (
             <div key={i} className="py-2 first:pt-0 last:pb-0">
-              <p className="text-xs text-neutral-400 truncate">{email.from}</p>
+              <p className="text-xs text-neutral-400 truncate">
+                {email.from}
+                {email.account === "professional" && (
+                  <span className="ml-1.5 text-neutral-600 text-[10px]">work</span>
+                )}
+              </p>
               <p className="text-sm text-neutral-200 truncate mt-0.5">{email.subject}</p>
             </div>
           ))}

--- a/web/src/components/dashboard/schedule-today.tsx
+++ b/web/src/components/dashboard/schedule-today.tsx
@@ -47,8 +47,13 @@ export default function ScheduleToday() {
               </span>
               <div className="min-w-0">
                 <p className="text-sm text-neutral-200 leading-snug truncate">{event.title}</p>
-                {event.location && (
-                  <p className="text-xs text-neutral-600 truncate mt-0.5">{event.location}</p>
+                {(event.location || !event.isPrimary) && (
+                  <p className="text-xs text-neutral-600 truncate mt-0.5">
+                    {event.location}
+                    {!event.isPrimary && (
+                      <span className={event.location ? " · " : ""}>{event.calendarName}</span>
+                    )}
+                  </p>
                 )}
               </div>
             </div>


### PR DESCRIPTION
## Summary

- **Gmail aggregation**: `leung.ss.jason@gmail.com` is pulled into `jaydud6@gmail.com` via POP3. Professional emails arrive with a `Professional` Gmail label. The `/api/google/gmail` route now reads that label and returns an `account` field (`"personal"` | `"professional"`) on each email.
- **Calendar multi-account**: The `/api/google/calendar` route now lists all calendars accessible to the authenticated account (including shared ones from leung.ss.jason) and unions their events. Each event gets `calendarName` and `isPrimary` fields.
- **Dashboard attribution**: Important Emails card shows a `work` badge next to the sender for professional emails. Schedule Today card shows the calendar name as a subtitle for non-primary calendar events.
- **Session rules**: Steps 4+5 of the session protocol updated to note multi-account coverage and that account source should be called out in briefings.
- **Docs**: `docs/gmail-multi-account.md` covers the full one-time setup (POP3 aggregation + Calendar sharing) and how emails/events surface in Mr. Bridge.

## Test plan

- [ ] Send test email to `leung.ss.jason@gmail.com` with subject "urgent: test" → trigger "Check mail now" in jaydud6 Gmail settings → verify it appears in dashboard with `work` badge
- [ ] Create test event in leung.ss.jason Google Calendar → verify it appears in Schedule Today card with the calendar name shown
- [ ] Confirm personal (jaydud6) emails still surface normally with no badge
- [ ] Confirm noise emails (no matching subject keywords) from either account do not appear in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)