### PR TITLE
feat: dashboard visual polish & dynamic UX overhaul (#38)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,5 @@
 {
     "windowColor.mainColor": "#f8a735",
     "window.title": "claude-code-best-practice",
-    "workbench.colorCustomizations": {
-        "statusBar.background": "#16825d",
-        "statusBar.foreground": "#ffffff"
-    }
+    "workbench.colorCustomizations": {}
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # claude-code-best-practice
 from vibe coding to agentic engineering - practice makes claude perfect
 
-![updated with Claude Code](https://img.shields.io/badge/updated_with_Claude_Code-v2.1.97%20(Apr%2010%2C%202026%2012%3A30%20AM%20PKT)-white?style=flat&labelColor=555) <a href="https://github.com/shanraisshan/claude-code-best-practice/stargazers"><img src="https://img.shields.io/github/stars/shanraisshan/claude-code-best-practice?style=flat&label=%E2%98%85&labelColor=555&color=white" alt="GitHub Stars"></a><br>
+![updated with Claude Code](https://img.shields.io/badge/updated_with_Claude_Code-v2.1.101%20(Apr%2011%2C%202026%206%3A17%20PM%20PKT)-white?style=flat&labelColor=555) <a href="https://github.com/shanraisshan/claude-code-best-practice/stargazers"><img src="https://img.shields.io/github/stars/shanraisshan/claude-code-best-practice?style=flat&label=%E2%98%85&labelColor=555&color=white" alt="GitHub Stars"></a><br>
 
 [![Best Practice](!/tags/best-practice.svg)](best-practice/) [![Implemented](!/tags/implemented.svg)](implementation/) [![Orchestration Workflow](!/tags/orchestration-workflow.svg)](orchestration-workflow/orchestration-workflow.md) [![Claude](!/tags/claude.svg)](https://code.claude.com/docs) [![Boris](!/tags/boris-cherny.svg)](#-tips-and-tricks) [![Community](!/tags/community.svg)](#-subscribe) ![Click on these badges below to see the actual sources](!/tags/click-badges.svg)<br>
 <img src="!/tags/a.svg" height="14"> = Agents · <img src="!/tags/c.svg" height="14"> = Commands · <img src="!/tags/s.svg" height="14"> = Skills

--- a/best-practice/claude-skills.md
+++ b/best-practice/claude-skills.md
@@ -1,6 +1,6 @@
 # Skills Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Apr%2009%2C%202026%2011%3A30%20PM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.97-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Apr%2011%2C%202026%206%3A08%20PM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.101-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../implementation/claude-skills-implementation.md)
 
 Claude Code skills — frontmatter fields and official bundled skills.

--- a/best-practice/claude-subagents.md
+++ b/best-practice/claude-subagents.md
@@ -1,6 +1,6 @@
 # Sub-agents Best Practice
 
-![Last Updated](https://img.shields.io/badge/Last_Updated-Apr%2009%2C%202026%2011%3A34%20PM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.97-blue?style=flat&labelColor=555)<br>
+![Last Updated](https://img.shields.io/badge/Last_Updated-Apr%2011%2C%202026%206%3A10%20PM%20PKT-white?style=flat&labelColor=555) ![Version](https://img.shields.io/badge/Claude_Code-v2.1.101-blue?style=flat&labelColor=555)<br>
 [![Implemented](https://img.shields.io/badge/Implemented-2ea44f?style=flat)](../implementation/claude-subagents-implementation.md)
 
 Claude Code subagents — frontmatter fields and official built-in agent types.

--- a/changelog/best-practice/claude-skills/changelog.md
+++ b/changelog/best-practice/claude-skills/changelog.md
@@ -129,3 +129,9 @@ No drift detected — frontmatter fields (13) and bundled skills (5) are fully s
 ## [2026-04-09 11:30 PM PKT] Claude Code v2.1.97
 
 No drift detected — frontmatter fields (13) and bundled skills (5) are fully synchronized with official docs.
+
+---
+
+## [2026-04-11 06:08 PM PKT] Claude Code v2.1.101
+
+No drift detected — frontmatter fields (13) and bundled skills (5) are fully synchronized with official docs.

--- a/changelog/best-practice/claude-subagents/changelog.md
+++ b/changelog/best-practice/claude-subagents/changelog.md
@@ -167,3 +167,9 @@ No drift detected — report is fully in sync with official docs. All 16 frontma
 ## [2026-04-09 11:34 PM PKT] Claude Code v2.1.97
 
 No drift detected — report is fully in sync with official docs. All 16 frontmatter fields and 5 built-in agents match.
+
+---
+
+## [2026-04-11 06:10 PM PKT] Claude Code v2.1.101
+
+No drift detected — report is fully in sync with official docs. All 16 frontmatter fields and 5 built-in agents match.

--- a/docs/gmail-multi-account.md
+++ b/docs/gmail-multi-account.md
@@ -1,81 +1,111 @@
 # Gmail & Calendar — Multi-Account Setup
 
-Covers how `jaydud6@gmail.com` (personal, primary) and `leung.ss.jason@gmail.com` (professional) are unified into a single Mr. Bridge session.
+Covers how `jaydud6@gmail.com` (personal, primary) and `leung.ss.jason@gmail.com` (professional) are unified into a single Mr. Bridge session. The OAuth token stays on `jaydud6@gmail.com` — no second credential set is required.
 
 ---
 
-## Gmail — "Check mail from other accounts" (POP3 aggregation)
+## Gmail — POP3 aggregation
 
-Professional emails are pulled into the personal inbox. The OAuth token stays on `jaydud6@gmail.com` — no second credential set required.
+Gmail's "Check mail from other accounts" pulls `leung.ss.jason@gmail.com` into `jaydud6@gmail.com` via POP3. Professional emails land in the personal inbox with a `Professional` label, which the dashboard uses to badge them as `work`.
 
-### Setup steps
+> **Note:** Gmailify (Google's OAuth-based import) does not accept normal Google passwords and requires an OAuth flow that is not straightforward to complete. Use POP3 instead.
 
-**1. Enable POP3 on leung.ss.jason**
-- Gmail → Settings → See all settings → Forwarding and POP/IMAP
-- Under "POP Download": select "Enable POP for all mail" (or "for mail that arrives from now on")
-- Save
+### Step 1 — Enable POP3 on leung.ss.jason
 
-**2. Add leung.ss.jason as a mail source in jaydud6**
-- Gmail (jaydud6) → Settings → See all settings → Accounts → "Check mail from other accounts"
-- Click "Add a mail account" → enter `leung.ss.jason@gmail.com`
-- Choose: "Import emails from my other account (Gmailify)" if offered, otherwise use POP3
-- In the label step: check "Label incoming messages" → create or select label `professional`
-- Do NOT check "Archive incoming messages" — professional emails should stay in inbox
+1. Sign into `leung.ss.jason@gmail.com`
+2. Settings (gear) → **See all settings** → **Forwarding and POP/IMAP** tab
+3. Under **POP Download** → select **Enable POP for all mail**
+4. Save changes
 
-**3. Verify**
-- Trigger an immediate pull: Settings → Accounts → "Check mail now" next to leung.ss.jason
-- Send a test email to `leung.ss.jason@gmail.com`; within 30–60 min it should appear in jaydud6's inbox tagged `professional`
+### Step 2 — Generate an App Password for leung.ss.jason
+
+Gmail's POP3 requires an App Password, not your regular account password (this is true even if 2-Step Verification was already enabled).
+
+1. Go to **myaccount.google.com** while signed into `leung.ss.jason@gmail.com`
+2. Security → **2-Step Verification** — enable it if not already on
+3. Search for **"App passwords"** at the top of the page
+4. Create a new App Password (name it anything, e.g. "Mr Bridge POP3")
+5. Copy the 16-character code — you'll use it in the next step
+
+### Step 3 — Add leung.ss.jason as a mail source in jaydud6
+
+1. Sign into `jaydud6@gmail.com`
+2. Settings → **See all settings** → **Accounts and Import** tab
+3. Under **Check mail from other accounts** → click **Add a mail account**
+4. Enter `leung.ss.jason@gmail.com` → Next → select **Import emails from my other account (Gmailify)** if offered, or choose **POP3**
+5. Use these POP3 settings:
+   - **Username:** `leung.ss.jason@gmail.com`
+   - **Password:** the 16-character App Password from Step 2
+   - **POP Server:** `pop.gmail.com`
+   - **Port:** `995`
+   - **Always use a secure connection (SSL):** checked
+6. Check **Label incoming messages** → create label `Professional`
+7. Leave **Archive incoming messages** unchecked (professional = high signal, keep in inbox)
+8. Click **Add Account**
+
+### Step 4 — Verify
+
+- In jaydud6's Gmail settings, click **Check mail now** next to `leung.ss.jason@gmail.com (POP3)` to trigger an immediate pull
+- Send a test email to `leung.ss.jason@gmail.com` with subject `urgent: test`
+- It should appear in `jaydud6@gmail.com`'s inbox within seconds (after "Check mail now") or within 30–60 min on the normal polling schedule
+- Confirm it has the `Professional` label applied
 
 ### Sync delay
-POP3 polls approximately every 30–60 minutes. Not real-time. Acceptable for session briefings. Use "Check mail now" in Settings to force an immediate poll.
+
+POP3 polls approximately every 30–60 minutes. Not real-time. Acceptable for session briefings. Use **Check mail now** in Gmail settings to force an immediate pull.
 
 ### How emails surface in Mr. Bridge
 
-| Email type | Where it comes from | Label in jaydud6 | Appears in dashboard? |
+| Email type | Source | Label in jaydud6 | Dashboard? |
 |---|---|---|---|
 | Personal, high-signal | jaydud6 directly | none | Yes, if subject matches filter |
-| Professional | leung.ss.jason via POP3 | `professional` | Yes, if subject matches filter; shown with "work" badge |
-| Personal, noise | jaydud6 directly | none | No (subject filter blocks it) |
+| Professional | leung.ss.jason via POP3 | `Professional` | Yes, if subject matches filter — shown with `work` badge |
+| Personal, noise | jaydud6 directly | none | No — subject keyword filter blocks it |
 
-The dashboard query: `is:unread subject:(meeting OR urgent OR invoice OR "action required" OR deadline)`
-Professional emails that don't match this filter are still pulled into the inbox but won't surface in the Important Emails card. They're accessible via Gmail directly.
+**Dashboard query:** `is:unread subject:(meeting OR urgent OR invoice OR "action required" OR deadline)`
+
+**How the `work` badge works:** The Gmail API returns internal label IDs (opaque strings like `Label_XXXXXXXXXX`), not display names. On each request, `/api/google/gmail` fetches the full label list first to resolve the `Professional` display name to its internal ID, then checks each message's `labelIds` against that ID. This is why the label name in Gmail settings must match exactly — the code looks for a label named `Professional` (case-insensitive).
 
 ---
 
 ## Google Calendar — Calendar sharing
 
-The professional calendar is shared with the personal account. The existing OAuth token (jaydud6) then sees all calendars via the Google Calendar API — no second auth required. Calendar sharing is real-time (no sync delay).
+The professional calendar is shared with `jaydud6@gmail.com`. The existing OAuth token sees all calendars including shared ones. Calendar sharing is real-time — no sync delay.
 
-### Setup steps
+### Step 1 — Share leung.ss.jason's calendar with jaydud6
 
-**1. Share leung.ss.jason's calendars with jaydud6**
-- Google Calendar (leung.ss.jason) → Settings → click each calendar under "Settings for my calendars"
-- Under "Share with specific people or groups" → Add `jaydud6@gmail.com`
-- Permission: "See all event details"
-- Repeat for each calendar to share (typically: primary + any work project calendars)
+1. Sign into `leung.ss.jason@gmail.com` → **calendar.google.com**
+2. Settings (gear) → **Settings**
+3. In the left sidebar under **Settings for my calendars** → click **Jason Leung** (or the calendar name)
+4. Under **Share with specific people or groups** → click **Add people and groups**
+5. Enter `jaydud6@gmail.com`, set permission to **See all event details** → Send
+6. Repeat for any other calendars to share (work project calendars, etc.)
 
-**2. Accept the shared calendar in jaydud6**
-- Google Calendar (jaydud6) should prompt to accept; or check "Other calendars" in the sidebar
-- The professional calendars appear under "Other calendars" with the leung.ss.jason label
+### Step 2 — Accept the shared calendar in jaydud6
 
-**3. Verify**
-- Create a test event in leung.ss.jason's Google Calendar
-- Confirm it appears in jaydud6's Google Calendar within seconds
-- Open Mr. Bridge web dashboard → Schedule Today card should show the event with the calendar name as source
+- A sharing invite arrives as an email to `jaydud6@gmail.com` — click **Accept**
+- Or: open Google Calendar as jaydud6 and look for the calendar under **Other calendars** in the sidebar
+
+### Step 3 — Verify
+
+1. Create a test event in `leung.ss.jason@gmail.com`'s calendar
+2. Confirm it appears immediately in `jaydud6@gmail.com`'s Google Calendar view
+3. Open the Mr. Bridge web dashboard → Schedule Today card should show the event with the calendar name shown as a subtitle
 
 ### How events surface in Mr. Bridge
 
-The calendar API (`/api/google/calendar`) now lists all calendars accessible to jaydud6 (primary + shared) and unions their events for today. Each event includes:
-- `calendarName` — the name of the calendar it came from
-- `isPrimary` — true only for jaydud6's own primary calendar
+`/api/google/calendar` lists all calendars accessible to `jaydud6@gmail.com` (primary + shared) and unions their events for today. Events are re-sorted by start time after the merge. Each event includes:
 
-Non-primary events show the `calendarName` as a subtitle in the Schedule Today dashboard card, so it's clear which account an event belongs to.
+- `calendarName` — the name of the calendar it came from (e.g. "Jason Leung")
+- `isPrimary` — `true` only for jaydud6's own primary calendar
+
+Non-primary calendar events show the `calendarName` as a subtitle in the Schedule Today dashboard card for source attribution.
 
 ---
 
-## Session Briefing Notes
+## Session Briefing
 
-Steps 4 and 5 of the Session Start Protocol now reflect multi-account coverage:
+Steps 4 and 5 of the Session Start Protocol reflect multi-account coverage:
 
-- **Calendar**: List Calendar Events returns events from all connected calendars. Note the source for any non-primary events.
-- **Gmail**: Search covers both accounts via POP3 aggregation. Professional emails arrive with Gmail label `professional`. Note "personal" or "work" when surfacing emails in the briefing.
+- **Calendar**: `List Calendar Events` returns events from all connected calendars. Note the source for non-primary events.
+- **Gmail**: `Search Gmail Emails` covers both accounts (professional emails arrive via POP3 with label `Professional`). Note "personal" or "work" when surfacing emails in the briefing.

--- a/web/src/app/(protected)/page.tsx
+++ b/web/src/app/(protected)/page.tsx
@@ -8,8 +8,24 @@ import RecoverySummary from "@/components/dashboard/recovery-summary";
 import FunFact from "@/components/dashboard/fun-fact";
 import ScheduleToday from "@/components/dashboard/schedule-today";
 import ImportantEmails from "@/components/dashboard/important-emails";
-import type { HabitLog, Task, FitnessLog, RecoveryMetrics, WorkoutSession } from "@/lib/types";
+import type { HabitLog, HabitRegistry, Task, FitnessLog, RecoveryMetrics, WorkoutSession } from "@/lib/types";
 import { todayString, USER_TZ } from "@/lib/timezone";
+
+function getGreeting(tz: string): string {
+  const hour = parseInt(
+    new Date().toLocaleString("en-US", { hour: "numeric", hour12: false, timeZone: tz })
+  );
+  if (hour < 12) return "Good morning";
+  if (hour < 17) return "Good afternoon";
+  return "Good evening";
+}
+
+function readinessBadgeClass(score: number | null): string {
+  if (score == null) return "";
+  if (score >= 80) return "border-green-800 text-green-400 bg-green-950/40";
+  if (score >= 60) return "border-amber-800 text-amber-400 bg-amber-950/40";
+  return "border-red-800 text-red-400 bg-red-950/40";
+}
 
 export default async function DashboardPage() {
   const supabase = await createClient();
@@ -26,7 +42,7 @@ export default async function DashboardPage() {
     workoutResult,
   ] = await Promise.all([
     supabase.from("habits").select("*").eq("date", today),
-    supabase.from("habit_registry").select("id").eq("active", true),
+    supabase.from("habit_registry").select("id, name, emoji").eq("active", true),
     supabase.from("tasks").select("*").eq("status", "active"),
     supabase
       .from("fitness_log")
@@ -63,7 +79,8 @@ export default async function DashboardPage() {
   ]);
 
   const todayHabits = (habitsResult.data ?? []) as HabitLog[];
-  const totalHabits = registryResult.data?.length ?? 0;
+  const habitRegistry = (registryResult.data ?? []) as Pick<HabitRegistry, "id" | "name" | "emoji">[];
+  const totalHabits = habitRegistry.length;
   const tasks = (tasksResult.data ?? []) as Task[];
   const latestFitness = fitnessResult.data as FitnessLog | null;
   const prevFitness = prevFitnessResult.data as FitnessLog | null;
@@ -71,6 +88,7 @@ export default async function DashboardPage() {
   const recoveryTrends = ((recoveryTrendsResult.data ?? []) as RecoveryMetrics[]).reverse();
   const recentWorkout = workoutResult.data as WorkoutSession | null;
 
+  const greeting = getGreeting(USER_TZ);
   const dateStr = new Date().toLocaleDateString("en-US", {
     weekday: "long",
     month: "long",
@@ -79,30 +97,49 @@ export default async function DashboardPage() {
   });
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-xl font-semibold text-neutral-100">Good morning</h1>
-        <p className="text-sm text-neutral-500 mt-0.5">{dateStr}</p>
+    <div className="space-y-5">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-neutral-100">{greeting}</h1>
+          <p className="text-sm text-neutral-500 mt-0.5">{dateStr}</p>
+        </div>
+        {recovery?.readiness != null && (
+          <span className={`text-xs font-[family-name:var(--font-mono)] px-2.5 py-1 rounded-lg border ${readinessBadgeClass(recovery.readiness)}`}>
+            Readiness {recovery.readiness}
+          </span>
+        )}
       </div>
 
-      <FunFact />
-
-      <RecoverySummary recovery={recovery} trends={recoveryTrends} />
-
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        {/* Left column */}
-        <div className="space-y-4">
-          <ScheduleToday />
-          <ImportantEmails />
+      {/* Bento grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        {/* Recovery — 2/3 width */}
+        <div className="lg:col-span-2">
+          <RecoverySummary recovery={recovery} trends={recoveryTrends} />
         </div>
 
-        {/* Right column */}
-        <div className="space-y-4">
-          <FitnessSummary latest={latestFitness} previous={prevFitness} recentWorkout={recentWorkout} />
-          <HabitsSummary habits={todayHabits} total={totalHabits} />
+        {/* Right sidebar: Habits + Tasks stacked */}
+        <div className="flex flex-col gap-4">
+          <HabitsSummary habits={todayHabits} total={totalHabits} registry={habitRegistry} />
           <TasksSummary tasks={tasks} />
         </div>
+
+        {/* Row 2: Schedule (1 col) + Fitness (2 col) */}
+        <div className="lg:col-span-1">
+          <ScheduleToday />
+        </div>
+        <div className="lg:col-span-2">
+          <FitnessSummary latest={latestFitness} previous={prevFitness} recentWorkout={recentWorkout} />
+        </div>
+
+        {/* Row 3: Emails — full width */}
+        <div className="lg:col-span-3">
+          <ImportantEmails />
+        </div>
       </div>
+
+      {/* Fun fact — demoted to ambient strip */}
+      <FunFact />
     </div>
   );
 }

--- a/web/src/app/api/google/gmail/route.ts
+++ b/web/src/app/api/google/gmail/route.ts
@@ -26,6 +26,12 @@ export async function GET() {
     const auth = getGoogleAuthClient();
     const gmail = google.gmail({ version: "v1", auth });
 
+    // Resolve the "Professional" label name → internal ID (user labels use opaque IDs, not names)
+    const labelsRes = await gmail.users.labels.list({ userId: "me" });
+    const professionalLabelId = labelsRes.data.labels?.find(
+      (l) => l.name?.toLowerCase() === "professional"
+    )?.id ?? null;
+
     const listRes = await gmail.users.messages.list({
       userId: "me",
       q: 'is:unread subject:(meeting OR urgent OR invoice OR "action required" OR deadline)',
@@ -47,11 +53,10 @@ export async function GET() {
         });
         const headers = msg.data.payload?.headers ?? [];
         const labelIds = msg.data.labelIds ?? [];
-        const account: EmailSummary["account"] = labelIds.some(
-          (l) => l.toLowerCase() === "professional"
-        )
-          ? "professional"
-          : "personal";
+        const account: EmailSummary["account"] =
+          professionalLabelId && labelIds.includes(professionalLabelId)
+            ? "professional"
+            : "personal";
         return {
           from: parseFrom(getHeader(headers, "From")),
           subject: getHeader(headers, "Subject") || "(No subject)",

--- a/web/src/components/dashboard/fitness-summary.tsx
+++ b/web/src/components/dashboard/fitness-summary.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { TrendingDown, TrendingUp, Minus } from "lucide-react";
 import type { FitnessLog, WorkoutSession } from "@/lib/types";
 
 interface Props {
@@ -13,38 +14,69 @@ function delta(current: number | null, prev: number | null) {
   return d > 0 ? `+${d.toFixed(1)}` : d.toFixed(1);
 }
 
+function TrendIcon({ value, invert = false }: { value: string | null; invert?: boolean }) {
+  if (!value) return null;
+  const n = parseFloat(value);
+  const isGood = invert ? n < 0 : n > 0;
+  const isFlat = Math.abs(n) < 0.05;
+  if (isFlat) return <Minus size={12} className="text-neutral-500" />;
+  if (isGood) return <TrendingDown size={12} className="text-green-400" />;
+  return <TrendingUp size={12} className="text-red-400" />;
+}
+
 export default function FitnessSummary({ latest, previous, recentWorkout }: Props) {
   const weightDelta = delta(latest?.weight_lb ?? null, previous?.weight_lb ?? null);
   const bfDelta = delta(latest?.body_fat_pct ?? null, previous?.body_fat_pct ?? null);
 
   return (
-    <Link href="/fitness" className="block bg-neutral-900 rounded-xl p-4 border border-neutral-800 hover:border-neutral-700 transition-colors">
+    <Link href="/fitness" className="block bg-neutral-900 rounded-xl p-4 border border-neutral-800 hover:border-neutral-700 transition-colors h-full">
       <p className="text-xs text-neutral-500 uppercase tracking-wide mb-3">Fitness</p>
+
       {latest ? (
-        <div className="space-y-1.5">
+        <div className="space-y-2">
+          {/* Weight row */}
           {latest.weight_lb != null && (
-            <div className="flex items-baseline gap-2">
-              <span className="text-2xl font-semibold font-[family-name:var(--font-mono)] text-neutral-100">{latest.weight_lb}</span>
+            <div className="flex items-center gap-2">
+              <span className="text-2xl font-semibold font-[family-name:var(--font-mono)] text-neutral-100 leading-none">
+                {latest.weight_lb}
+              </span>
               <span className="text-xs text-neutral-500">lb</span>
               {weightDelta && (
-                <span className={`text-xs ml-auto font-[family-name:var(--font-mono)] ${parseFloat(weightDelta) < 0 ? "text-green-400" : "text-red-400"}`}>
+                <span className={`flex items-center gap-0.5 text-xs ml-auto font-[family-name:var(--font-mono)] ${parseFloat(weightDelta) < 0 ? "text-green-400" : "text-red-400"}`}>
+                  <TrendIcon value={weightDelta} invert />
                   {weightDelta}
                 </span>
               )}
             </div>
           )}
+
+          {/* Body fat row */}
           {latest.body_fat_pct != null && (
-            <div className="flex items-baseline gap-2">
-              <span className="text-lg font-medium font-[family-name:var(--font-mono)] text-neutral-300">{latest.body_fat_pct}%</span>
+            <div className="flex items-center gap-2">
+              <span className="text-lg font-medium font-[family-name:var(--font-mono)] text-neutral-300 leading-none">
+                {latest.body_fat_pct}%
+              </span>
               <span className="text-xs text-neutral-500">body fat</span>
               {bfDelta && (
-                <span className={`text-xs ml-auto font-[family-name:var(--font-mono)] ${parseFloat(bfDelta) < 0 ? "text-green-400" : "text-red-400"}`}>
+                <span className={`flex items-center gap-0.5 text-xs ml-auto font-[family-name:var(--font-mono)] ${parseFloat(bfDelta) < 0 ? "text-green-400" : "text-red-400"}`}>
+                  <TrendIcon value={bfDelta} invert />
                   {bfDelta}
                 </span>
               )}
             </div>
           )}
-          <p className="text-xs text-neutral-600">{latest.date}</p>
+
+          {/* Muscle mass row if available */}
+          {latest.muscle_mass_lb != null && (
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-[family-name:var(--font-mono)] text-neutral-400 leading-none">
+                {latest.muscle_mass_lb}
+              </span>
+              <span className="text-xs text-neutral-500">lb muscle</span>
+            </div>
+          )}
+
+          <p className="text-xs text-neutral-600 pt-0.5">{latest.date}</p>
         </div>
       ) : (
         <p className="text-sm text-neutral-600">No body comp data</p>
@@ -52,14 +84,15 @@ export default function FitnessSummary({ latest, previous, recentWorkout }: Prop
 
       {recentWorkout && (
         <div className="mt-3 pt-3 border-t border-neutral-800">
-          <p className="text-xs text-neutral-500 mb-1">Last workout</p>
-          <p className="text-sm text-neutral-300">
-            {recentWorkout.activity}
-            {recentWorkout.duration_mins != null && (
-              <span className="text-neutral-500"> · <span className="font-[family-name:var(--font-mono)]">{recentWorkout.duration_mins}</span>m</span>
-            )}
+          <p className="text-xs text-neutral-500 mb-1.5">Last workout</p>
+          <p className="text-sm text-neutral-300 font-medium">{recentWorkout.activity}</p>
+          <p className="text-xs text-neutral-500 mt-0.5 font-[family-name:var(--font-mono)]">
+            {recentWorkout.duration_mins != null && <span>{recentWorkout.duration_mins}m</span>}
             {recentWorkout.calories != null && (
-              <span className="text-neutral-500"> · <span className="font-[family-name:var(--font-mono)]">{recentWorkout.calories}</span> cal</span>
+              <span>{recentWorkout.duration_mins != null ? " · " : ""}{recentWorkout.calories} cal</span>
+            )}
+            {recentWorkout.avg_hr != null && (
+              <span> · {recentWorkout.avg_hr} bpm</span>
             )}
           </p>
           <p className="text-xs text-neutral-600 mt-0.5">{recentWorkout.date}</p>

--- a/web/src/components/dashboard/fun-fact.tsx
+++ b/web/src/components/dashboard/fun-fact.tsx
@@ -15,22 +15,18 @@ export default function FunFact() {
       .finally(() => setLoading(false));
   }, []);
 
-  return (
-    <div className="bg-neutral-900 rounded-xl p-4 border border-neutral-800 border-l-2 border-l-blue-500">
-      <div className="flex items-center gap-2 mb-2">
-        <Sparkles size={13} className="text-blue-400 shrink-0" />
-        <p className="text-xs text-blue-400 uppercase tracking-wide font-medium">Fun Fact</p>
-      </div>
+  if (!loading && !fact) return null;
 
+  return (
+    <div className="flex items-start gap-3 pl-3 border-l border-neutral-800">
+      <Sparkles size={11} className="text-neutral-600 shrink-0 mt-0.5" />
       {loading ? (
-        <div className="space-y-2">
-          <div className="h-3 bg-neutral-800 rounded animate-pulse w-full" />
-          <div className="h-3 bg-neutral-800 rounded animate-pulse w-4/5" />
+        <div className="flex-1 space-y-1.5 py-0.5">
+          <div className="h-2.5 bg-neutral-800 rounded animate-pulse w-3/4" />
+          <div className="h-2.5 bg-neutral-800 rounded animate-pulse w-1/2" />
         </div>
-      ) : fact ? (
-        <p className="text-sm text-neutral-300 italic leading-relaxed">{fact}</p>
       ) : (
-        <p className="text-sm text-neutral-600">No fact available.</p>
+        <p className="text-xs text-neutral-600 italic leading-relaxed">{fact}</p>
       )}
     </div>
   );

--- a/web/src/components/dashboard/habits-summary.tsx
+++ b/web/src/components/dashboard/habits-summary.tsx
@@ -1,29 +1,56 @@
 import Link from "next/link";
-import type { HabitLog } from "@/lib/types";
+import type { HabitLog, HabitRegistry } from "@/lib/types";
 
 interface Props {
   habits: HabitLog[];
   total: number;
+  registry: Pick<HabitRegistry, "id" | "name" | "emoji">[];
 }
 
-export default function HabitsSummary({ habits, total }: Props) {
+export default function HabitsSummary({ habits, total, registry }: Props) {
   const completed = habits.filter((h) => h.completed).length;
   const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+  const habitItems = registry.map((reg) => ({
+    id: reg.id,
+    name: reg.name,
+    emoji: reg.emoji,
+    completed: habits.some((h) => h.habit_id === reg.id && h.completed),
+  }));
 
   return (
     <Link href="/habits" className="block bg-neutral-900 rounded-xl p-4 border border-neutral-800 hover:border-neutral-700 transition-colors">
       <p className="text-xs text-neutral-500 uppercase tracking-wide mb-3">Habits today</p>
+
+      {/* Count + progress bar */}
       <p className="text-2xl font-semibold font-[family-name:var(--font-mono)] text-neutral-100">
         {completed}
         <span className="text-neutral-500 text-lg font-normal"> / {total}</span>
       </p>
-      <div className="mt-3 h-1.5 bg-neutral-800 rounded-full overflow-hidden">
+      <div className="mt-2 h-1 bg-neutral-800 rounded-full overflow-hidden">
         <div
-          className="h-full bg-blue-500 rounded-full transition-all"
+          className={`h-full rounded-full transition-all ${pct === 100 ? "bg-green-500" : "bg-blue-500"}`}
           style={{ width: `${pct}%` }}
         />
       </div>
-      <p className="mt-1.5 text-xs text-neutral-500">{pct}% complete</p>
+
+      {/* Individual habit pills */}
+      {habitItems.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mt-3">
+          {habitItems.map((h) => (
+            <span
+              key={h.id}
+              className={`text-xs px-2 py-0.5 rounded-full border transition-colors ${
+                h.completed
+                  ? "bg-green-950/50 border-green-800/60 text-green-400"
+                  : "bg-neutral-800/50 border-neutral-700/60 text-neutral-500"
+              }`}
+            >
+              {h.emoji ? `${h.emoji} ${h.name}` : h.name}
+            </span>
+          ))}
+        </div>
+      )}
     </Link>
   );
 }

--- a/web/src/components/dashboard/inline-sparkline.tsx
+++ b/web/src/components/dashboard/inline-sparkline.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { LineChart, Line, ResponsiveContainer } from "recharts";
+
+interface Props {
+  data: (number | null)[];
+  color?: string;
+  height?: number;
+}
+
+export default function InlineSparkline({ data, color = "#3b82f6", height = 24 }: Props) {
+  const chartData = data.map((v, i) => ({ i, v }));
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <LineChart data={chartData}>
+        <Line
+          type="monotone"
+          dataKey="v"
+          stroke={color}
+          strokeWidth={1.5}
+          dot={false}
+          connectNulls
+          isAnimationActive={false}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/web/src/components/dashboard/recovery-summary.tsx
+++ b/web/src/components/dashboard/recovery-summary.tsx
@@ -1,5 +1,6 @@
 import type { RecoveryMetrics } from "@/lib/types";
 import RecoveryTrends from "./recovery-trends";
+import InlineSparkline from "./inline-sparkline";
 
 interface Props {
   recovery: RecoveryMetrics | null;
@@ -13,6 +14,37 @@ function scoreColor(score: number | null): string {
   return "text-red-400";
 }
 
+function scoreBg(score: number | null): string {
+  if (score == null) return "bg-neutral-800/30";
+  if (score >= 80) return "bg-green-950/30";
+  if (score >= 60) return "bg-amber-950/30";
+  return "bg-red-950/30";
+}
+
+function accentBar(score: number | null): string {
+  if (score == null) return "bg-neutral-700/50";
+  if (score >= 80) return "bg-green-500/50";
+  if (score >= 60) return "bg-amber-500/50";
+  return "bg-red-500/50";
+}
+
+function statusLabel(recovery: RecoveryMetrics): string {
+  const r = recovery.readiness;
+  if (r == null) return "Readiness unknown";
+  if (r >= 85) return "Recovery optimal — push hard today";
+  if (r >= 70) return "Recovery good — normal training";
+  if (r >= 55) return "Recovery moderate — moderate effort";
+  if (r >= 40) return "Readiness low — consider deload";
+  return "Readiness critical — rest day recommended";
+}
+
+function statusColor(score: number | null): string {
+  if (score == null) return "text-neutral-500 border-neutral-800 bg-neutral-900";
+  if (score >= 70) return "text-green-400/80 border-green-900 bg-green-950/20";
+  if (score >= 55) return "text-amber-400/80 border-amber-900 bg-amber-950/20";
+  return "text-red-400/80 border-red-900 bg-red-950/20";
+}
+
 function fmtHrs(hrs: number | null): string {
   if (hrs == null) return "—";
   const h = Math.floor(hrs);
@@ -21,73 +53,91 @@ function fmtHrs(hrs: number | null): string {
 }
 
 export default function RecoverySummary({ recovery, trends }: Props) {
+  const trendHrv = trends?.map((d) => d.avg_hrv) ?? [];
+
   return (
-    <div className="bg-neutral-900 rounded-xl p-4 border border-neutral-800">
-      <p className="text-xs text-neutral-500 uppercase tracking-wide mb-3">Recovery &amp; Sleep</p>
+    <div className="bg-neutral-900 rounded-xl border border-neutral-800 overflow-hidden h-full">
+      {/* Color accent bar at top */}
+      <div className={`h-0.5 w-full ${accentBar(recovery?.readiness ?? null)}`} />
 
-      {recovery ? (
-        <div className="space-y-3">
-          {/* Top scores row */}
-          <div className="flex gap-4">
-            <div>
-              <p className="text-xs text-neutral-500 mb-0.5">Readiness</p>
-              <span className={`text-2xl font-semibold font-[family-name:var(--font-mono)] ${scoreColor(recovery.readiness)}`}>
-                {recovery.readiness ?? "—"}
-              </span>
+      <div className="p-5">
+        <p className="text-xs text-neutral-500 uppercase tracking-wide mb-4">Recovery &amp; Sleep</p>
+
+        {recovery ? (
+          <div className="space-y-4">
+            {/* Big scores */}
+            <div className={`flex items-end gap-8 rounded-xl p-4 ${scoreBg(recovery.readiness)}`}>
+              <div>
+                <p className="text-xs text-neutral-500 uppercase tracking-wide mb-1">Readiness</p>
+                <span className={`text-[3.25rem] font-bold font-[family-name:var(--font-mono)] leading-none ${scoreColor(recovery.readiness)}`}>
+                  {recovery.readiness ?? "—"}
+                </span>
+              </div>
+              <div className="pb-1">
+                <p className="text-xs text-neutral-500 uppercase tracking-wide mb-1">Sleep</p>
+                <span className={`text-[2.5rem] font-bold font-[family-name:var(--font-mono)] leading-none ${scoreColor(recovery.sleep_score)}`}>
+                  {recovery.sleep_score ?? "—"}
+                </span>
+              </div>
             </div>
-            <div>
-              <p className="text-xs text-neutral-500 mb-0.5">Sleep</p>
-              <span className={`text-2xl font-semibold font-[family-name:var(--font-mono)] ${scoreColor(recovery.sleep_score)}`}>
-                {recovery.sleep_score ?? "—"}
-              </span>
+
+            {/* Metrics grid */}
+            <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
+              {/* HRV with inline sparkline */}
+              <div className="flex items-center gap-2">
+                <span className="text-neutral-500 text-xs w-12 shrink-0">HRV</span>
+                <span className="font-[family-name:var(--font-mono)] text-neutral-200 shrink-0">
+                  {recovery.avg_hrv ?? "—"}
+                  {recovery.avg_hrv != null && <span className="text-xs text-neutral-500 ml-0.5">ms</span>}
+                </span>
+                {trendHrv.length > 2 && (
+                  <div className="flex-1 min-w-0">
+                    <InlineSparkline data={trendHrv} color="#3b82f6" height={20} />
+                  </div>
+                )}
+              </div>
+
+              <div className="flex items-center gap-2">
+                <span className="text-neutral-500 text-xs w-12 shrink-0">RHR</span>
+                <span className="font-[family-name:var(--font-mono)] text-neutral-200">
+                  {recovery.resting_hr ?? "—"}
+                  {recovery.resting_hr != null && <span className="text-xs text-neutral-500 ml-0.5">bpm</span>}
+                </span>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <span className="text-neutral-500 text-xs w-12 shrink-0">Total</span>
+                <span className="font-[family-name:var(--font-mono)] text-neutral-200">
+                  {fmtHrs(recovery.total_sleep_hrs)}
+                </span>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <span className="text-neutral-500 text-xs w-12 shrink-0">Deep</span>
+                <span className="font-[family-name:var(--font-mono)] text-neutral-200">
+                  {fmtHrs(recovery.deep_hrs)}
+                </span>
+              </div>
             </div>
+
+            {/* Status banner */}
+            <div className={`text-xs px-3 py-2 rounded-lg border ${statusColor(recovery.readiness)}`}>
+              {statusLabel(recovery)}
+            </div>
+
+            <p className="text-xs text-neutral-600">Oura · {recovery.date}</p>
+
+            {trends && trends.length > 0 && (
+              <>
+                <div className="border-t border-neutral-800" />
+                <RecoveryTrends data={trends} />
+              </>
+            )}
           </div>
-
-          {/* Metrics grid */}
-          <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 text-sm">
-            <div className="flex items-baseline gap-1.5">
-              <span className="text-neutral-500 text-xs w-16">HRV</span>
-              <span className="font-[family-name:var(--font-mono)] text-neutral-200">
-                {recovery.avg_hrv ?? "—"}
-                {recovery.avg_hrv != null && <span className="text-xs text-neutral-500 ml-0.5">ms</span>}
-              </span>
-            </div>
-            <div className="flex items-baseline gap-1.5">
-              <span className="text-neutral-500 text-xs w-16">RHR</span>
-              <span className="font-[family-name:var(--font-mono)] text-neutral-200">
-                {recovery.resting_hr ?? "—"}
-                {recovery.resting_hr != null && <span className="text-xs text-neutral-500 ml-0.5">bpm</span>}
-              </span>
-            </div>
-            <div className="flex items-baseline gap-1.5">
-              <span className="text-neutral-500 text-xs w-16">Total</span>
-              <span className="font-[family-name:var(--font-mono)] text-neutral-200">
-                {fmtHrs(recovery.total_sleep_hrs)}
-              </span>
-            </div>
-            <div className="flex items-baseline gap-1.5">
-              <span className="text-neutral-500 text-xs w-16">Deep</span>
-              <span className="font-[family-name:var(--font-mono)] text-neutral-200">
-                {fmtHrs(recovery.deep_hrs)}
-              </span>
-            </div>
-          </div>
-
-          {(recovery.avg_hrv == null || recovery.sleep_score == null || recovery.readiness == null) && (
-            <p className="text-xs text-amber-600">Some metrics not yet synced — check back later</p>
-          )}
-          <p className="text-xs text-neutral-600">Oura · {recovery.date}</p>
-
-          {trends && trends.length > 0 && (
-            <>
-              <div className="border-t border-neutral-800 my-1" />
-              <RecoveryTrends data={trends} />
-            </>
-          )}
-        </div>
-      ) : (
-        <p className="text-sm text-neutral-600">No recovery data</p>
-      )}
+        ) : (
+          <p className="text-sm text-neutral-600">No recovery data</p>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/src/components/dashboard/recovery-trends.tsx
+++ b/web/src/components/dashboard/recovery-trends.tsx
@@ -68,8 +68,8 @@ export default function RecoveryTrends({ data }: Props) {
       {/* HRV + Readiness */}
       <div>
         <p className="text-xs text-neutral-500 mb-2">HRV / Readiness — 14 days</p>
-        <ResponsiveContainer width="100%" height={100}>
-          <ComposedChart data={chartData} margin={{ top: 2, right: 8, left: -20, bottom: 0 }}>
+        <ResponsiveContainer width="100%" height={160}>
+          <ComposedChart data={chartData} margin={{ top: 4, right: 8, left: -20, bottom: 0 }}>
             <CartesianGrid {...gridProps} />
             <XAxis dataKey="date" {...axisProps} interval="preserveStartEnd" />
             <YAxis yAxisId="hrv" orientation="left" {...axisProps} domain={["auto", "auto"]} />
@@ -81,9 +81,13 @@ export default function RecoveryTrends({ data }: Props) {
               dataKey="hrv"
               name="HRV (ms)"
               stroke="#3b82f6"
-              strokeWidth={1.5}
+              strokeWidth={2}
               dot={false}
+              activeDot={{ r: 3, strokeWidth: 0 }}
               connectNulls
+              isAnimationActive
+              animationDuration={800}
+              animationEasing="ease-out"
             />
             <Line
               yAxisId="readiness"
@@ -91,9 +95,13 @@ export default function RecoveryTrends({ data }: Props) {
               dataKey="readiness"
               name="Readiness"
               stroke="#a3e635"
-              strokeWidth={1.5}
+              strokeWidth={2}
               dot={false}
+              activeDot={{ r: 3, strokeWidth: 0 }}
               connectNulls
+              isAnimationActive
+              animationDuration={800}
+              animationEasing="ease-out"
             />
           </ComposedChart>
         </ResponsiveContainer>
@@ -102,15 +110,15 @@ export default function RecoveryTrends({ data }: Props) {
       {/* Sleep breakdown */}
       <div>
         <p className="text-xs text-neutral-500 mb-2">Sleep breakdown — 14 days</p>
-        <ResponsiveContainer width="100%" height={100}>
-          <BarChart data={chartData} margin={{ top: 2, right: 8, left: -20, bottom: 0 }}>
+        <ResponsiveContainer width="100%" height={160}>
+          <BarChart data={chartData} margin={{ top: 4, right: 8, left: -20, bottom: 0 }}>
             <CartesianGrid {...gridProps} />
             <XAxis dataKey="date" {...axisProps} interval="preserveStartEnd" />
             <YAxis {...axisProps} domain={[0, "auto"]} />
             <Tooltip content={<CustomTooltip />} />
-            <Bar dataKey="light" name="Light (h)" stackId="sleep" fill="#6366f1" radius={[0, 0, 0, 0]} />
-            <Bar dataKey="deep" name="Deep (h)" stackId="sleep" fill="#3b82f6" radius={[0, 0, 0, 0]} />
-            <Bar dataKey="rem" name="REM (h)" stackId="sleep" fill="#06b6d4" radius={[2, 2, 0, 0]} />
+            <Bar dataKey="light" name="Light (h)" stackId="sleep" fill="#6366f1" radius={[0, 0, 0, 0]} isAnimationActive animationDuration={600} />
+            <Bar dataKey="deep" name="Deep (h)" stackId="sleep" fill="#3b82f6" radius={[0, 0, 0, 0]} isAnimationActive animationDuration={600} />
+            <Bar dataKey="rem" name="REM (h)" stackId="sleep" fill="#06b6d4" radius={[2, 2, 0, 0]} isAnimationActive animationDuration={600} />
           </BarChart>
         </ResponsiveContainer>
       </div>

--- a/web/src/components/dashboard/schedule-today.tsx
+++ b/web/src/components/dashboard/schedule-today.tsx
@@ -4,10 +4,23 @@ import { useEffect, useState } from "react";
 import { Calendar } from "lucide-react";
 import type { CalendarEvent } from "@/app/api/google/calendar/route";
 
+function parseTimeToMinutes(timeStr: string): number | null {
+  // Handles "9:00 AM", "2:30 PM" — returns minutes since midnight
+  const match = timeStr.match(/(\d+):(\d+)\s*(AM|PM)/i);
+  if (!match) return null;
+  let h = parseInt(match[1]);
+  const m = parseInt(match[2]);
+  const ampm = match[3].toUpperCase();
+  if (ampm === "PM" && h !== 12) h += 12;
+  if (ampm === "AM" && h === 12) h = 0;
+  return h * 60 + m;
+}
+
 export default function ScheduleToday() {
   const [events, setEvents] = useState<CalendarEvent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  const [nowMinutes, setNowMinutes] = useState<number | null>(null);
 
   useEffect(() => {
     fetch("/api/google/calendar")
@@ -18,10 +31,42 @@ export default function ScheduleToday() {
       })
       .catch(() => setError(true))
       .finally(() => setLoading(false));
+
+    const now = new Date();
+    setNowMinutes(now.getHours() * 60 + now.getMinutes());
   }, []);
 
+  // Split events into past / upcoming based on start time
+  type RenderedItem =
+    | { type: "event"; event: CalendarEvent; isPast: boolean; index: number }
+    | { type: "now" };
+
+  let nowDividerInserted = false;
+  const renderedItems: RenderedItem[] = [];
+
+  if (nowMinutes !== null && events.length > 0) {
+    for (let i = 0; i < events.length; i++) {
+      const event = events[i];
+      const eventMins = parseTimeToMinutes(event.time);
+      const isPast = eventMins !== null && eventMins < nowMinutes;
+
+      // Insert "now" divider at the transition from past to upcoming
+      if (!nowDividerInserted && eventMins !== null && eventMins >= nowMinutes) {
+        const hasPastEvents = renderedItems.some((r) => r.type === "event" && r.isPast);
+        if (hasPastEvents) {
+          renderedItems.push({ type: "now" });
+        }
+        nowDividerInserted = true;
+      }
+
+      renderedItems.push({ type: "event", event, isPast, index: i });
+    }
+  }
+
+  const useEnhanced = nowMinutes !== null && renderedItems.length > 0;
+
   return (
-    <div className="bg-neutral-900 rounded-xl p-4 border border-neutral-800">
+    <div className="bg-neutral-900 rounded-xl p-4 border border-neutral-800 h-full">
       <div className="flex items-center gap-2 mb-3">
         <Calendar size={13} className="text-neutral-500 shrink-0" />
         <p className="text-xs text-neutral-500 uppercase tracking-wide">Schedule Today</p>
@@ -40,24 +85,58 @@ export default function ScheduleToday() {
         <p className="text-sm text-red-400/70">Failed to load — check Google credentials</p>
       ) : events.length > 0 ? (
         <div className="space-y-2.5">
-          {events.map((event, i) => (
-            <div key={i} className="flex gap-3 items-start">
-              <span className="text-xs font-[family-name:var(--font-mono)] text-neutral-500 shrink-0 w-16 pt-px">
-                {event.time}
-              </span>
-              <div className="min-w-0">
-                <p className="text-sm text-neutral-200 leading-snug truncate">{event.title}</p>
-                {(event.location || !event.isPrimary) && (
-                  <p className="text-xs text-neutral-600 truncate mt-0.5">
-                    {event.location}
-                    {!event.isPrimary && (
-                      <span className={event.location ? " · " : ""}>{event.calendarName}</span>
+          {useEnhanced ? (
+            renderedItems.map((item, idx) => {
+              if (item.type === "now") {
+                return (
+                  <div key="now-divider" className="flex items-center gap-2 py-0.5">
+                    <span className="text-[10px] text-blue-400 font-[family-name:var(--font-mono)] shrink-0">now</span>
+                    <div className="flex-1 h-px bg-blue-500/30" />
+                  </div>
+                );
+              }
+              const { event, isPast } = item;
+              return (
+                <div key={idx} className={`flex gap-3 items-start transition-opacity ${isPast ? "opacity-40" : ""}`}>
+                  <span className="text-xs font-[family-name:var(--font-mono)] text-neutral-500 shrink-0 w-16 pt-px">
+                    {event.time}
+                  </span>
+                  <div className="min-w-0">
+                    <p className={`text-sm leading-snug truncate ${isPast ? "text-neutral-400" : "text-neutral-200"}`}>
+                      {event.title}
+                    </p>
+                    {(event.location || !event.isPrimary) && (
+                      <p className="text-xs text-neutral-600 truncate mt-0.5">
+                        {event.location}
+                        {!event.isPrimary && (
+                          <span className={event.location ? " · " : ""}>{event.calendarName}</span>
+                        )}
+                      </p>
                     )}
-                  </p>
-                )}
+                  </div>
+                </div>
+              );
+            })
+          ) : (
+            events.map((event, i) => (
+              <div key={i} className="flex gap-3 items-start">
+                <span className="text-xs font-[family-name:var(--font-mono)] text-neutral-500 shrink-0 w-16 pt-px">
+                  {event.time}
+                </span>
+                <div className="min-w-0">
+                  <p className="text-sm text-neutral-200 leading-snug truncate">{event.title}</p>
+                  {(event.location || !event.isPrimary) && (
+                    <p className="text-xs text-neutral-600 truncate mt-0.5">
+                      {event.location}
+                      {!event.isPrimary && (
+                        <span className={event.location ? " · " : ""}>{event.calendarName}</span>
+                      )}
+                    </p>
+                  )}
+                </div>
               </div>
-            </div>
-          ))}
+            ))
+          )}
         </div>
       ) : (
         <p className="text-sm text-neutral-600">No events today</p>

--- a/web/src/components/dashboard/tasks-summary.tsx
+++ b/web/src/components/dashboard/tasks-summary.tsx
@@ -5,20 +5,67 @@ interface Props {
   tasks: Task[];
 }
 
+const PRIORITY_ORDER = { high: 0, medium: 1, low: 2 } as const;
+
+function priorityBorder(priority: Task["priority"]): string {
+  if (priority === "high") return "border-l-red-500";
+  if (priority === "medium") return "border-l-yellow-500";
+  return "border-l-neutral-600";
+}
+
+function priorityText(priority: Task["priority"]): string {
+  if (priority === "high") return "text-red-400";
+  if (priority === "medium") return "text-yellow-400";
+  return "text-neutral-500";
+}
+
 export default function TasksSummary({ tasks }: Props) {
   const high = tasks.filter((t) => t.priority === "high").length;
   const medium = tasks.filter((t) => t.priority === "medium").length;
   const low = tasks.filter((t) => t.priority === "low").length;
 
+  const sorted = [...tasks].sort(
+    (a, b) =>
+      (PRIORITY_ORDER[a.priority ?? "low"] ?? 2) -
+      (PRIORITY_ORDER[b.priority ?? "low"] ?? 2)
+  );
+  const topTasks = sorted.slice(0, 3);
+
   return (
     <Link href="/tasks" className="block bg-neutral-900 rounded-xl p-4 border border-neutral-800 hover:border-neutral-700 transition-colors">
       <p className="text-xs text-neutral-500 uppercase tracking-wide mb-3">Active tasks</p>
-      <p className="text-2xl font-semibold font-[family-name:var(--font-mono)] text-neutral-100">{tasks.length}</p>
-      {tasks.length > 0 && (
-        <div className="mt-3 flex gap-3 text-xs text-neutral-500">
-          {high > 0 && <span><span className="text-red-400">{high}</span> high</span>}
-          {medium > 0 && <span><span className="text-yellow-400">{medium}</span> med</span>}
-          {low > 0 && <span><span className="text-neutral-400">{low}</span> low</span>}
+
+      {/* Count + priority breakdown */}
+      <div className="flex items-baseline gap-3">
+        <p className="text-2xl font-semibold font-[family-name:var(--font-mono)] text-neutral-100">{tasks.length}</p>
+        {tasks.length > 0 && (
+          <div className="flex gap-2 text-xs text-neutral-500">
+            {high > 0 && <span><span className="text-red-400">{high}</span> high</span>}
+            {medium > 0 && <span><span className="text-yellow-400">{medium}</span> med</span>}
+            {low > 0 && <span><span className="text-neutral-400">{low}</span> low</span>}
+          </div>
+        )}
+      </div>
+
+      {/* Top 3 tasks */}
+      {topTasks.length > 0 && (
+        <div className="mt-3 space-y-1.5">
+          {topTasks.map((t) => (
+            <div
+              key={t.id}
+              className={`flex items-center gap-2 border-l-2 pl-2 ${priorityBorder(t.priority)}`}
+            >
+              <p className="text-xs text-neutral-300 truncate flex-1">{t.title}</p>
+              {t.due_date && (
+                <span className={`text-[10px] shrink-0 ${priorityText(t.priority)}`}>
+                  {t.due_date.slice(5)}
+                </span>
+              )}
+            </div>
+          ))}
+          {tasks.length > 3 && (
+            <p className="text-xs text-neutral-600 pl-2">+{tasks.length - 3} more</p>
+          )}
         </div>
       )}
     </Link>


### PR DESCRIPTION
## Summary

Closes #38. Full visual redesign of the dashboard into a high-density, data-forward personal command center.

- **Bento grid layout** — 3-column `lg` grid (Recovery ×2, Habits+Tasks ×1 sidebar, Schedule ×1, Fitness ×2, Emails full-width) replacing the flat linear stack
- **Header** — dynamic greeting (morning/afternoon/evening) + readiness score badge, color-coded by tier
- **Recovery card** — readiness score at `3.25rem`, sleep at `2.5rem`; colored top accent bar; inline 14-day HRV sparkline next to the metric; status banner (`"Recovery optimal — push hard today"` etc.); charts enlarged 100px → 160px with animations enabled
- **Habits card** — individual per-habit pills (green/dim) via registry join, turns fully green progress bar at 100%
- **Tasks card** — top 3 task names with priority-colored left borders (`red/yellow/neutral`), `+N more` overflow
- **Fitness card** — `TrendingDown`/`TrendingUp` lucide icons on weight and body fat deltas; muscle mass row added if available; avg HR surfaced in workout section
- **Schedule card** — past events dimmed at 40% opacity, `now ──` divider inserted at current time transition
- **Fun fact** — demoted from full card to a subtle ambient strip below the grid; hidden when no fact loads

## Test plan

- [ ] Load dashboard — verify bento grid renders on lg screen, stacks single-column on mobile
- [ ] Recovery scores render large and color-coded (green/amber/red by tier)
- [ ] HRV sparkline appears inline when trend data is present
- [ ] Status banner text matches readiness score tier
- [ ] Recovery trend charts animate on load, 160px height
- [ ] Habits show individual pills — green for completed, dim for pending
- [ ] Tasks show top 3 names with priority borders and `+N` overflow
- [ ] Fitness deltas show correct trend arrow direction (down = green for weight/bf)
- [ ] Schedule past events are dimmed; `now` divider appears mid-day
- [ ] Fun fact renders as strip (no card); hidden if API returns null

🤖 Generated with [Claude Code](https://claude.com/claude-code)