### PR TITLE
fix: center dashboard content and widen max-width for bento grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ mr-bridge-assistant/
 ├── CHANGELOG.md
 ├── README.md
 ├── .gitignore
-├── .mcp.json                              # MCP servers: Google Calendar, Gmail, DeepWiki
+├── .mcp.json                              # MCP servers: DeepWiki (Google Calendar + Gmail via claude.ai hosted MCP)
 ├── .gitmodules
 │
 ├── supabase/                              # Database schema + migrations
@@ -72,7 +72,8 @@ mr-bridge-assistant/
 │       ├── 20260410163801_initial_schema.sql
 │       ├── 20260410164609_add_unique_constraints.sql
 │       ├── 20260410170000_study_log_unique_constraint.sql
-│       └── 20260411000000_add_journal_entries.sql
+│       ├── 20260411000000_add_journal_entries.sql
+│       └── 20260411000001_recovery_metrics_extended.sql
 │
 ├── web/                                   # Next.js web interface (deployed on Vercel)
 │   ├── src/
@@ -86,7 +87,7 @@ mr-bridge-assistant/
 │   │   │   │   ├── chat/page.tsx          # Mr. Bridge chat
 │   │   │   │   └── journal/page.tsx       # Daily journal — guided 5-prompt flow
 │   │   │   ├── api/
-│   │   │   │   ├── chat/route.ts          # Claude API + Supabase tool use (10 tools)
+│   │   │   │   ├── chat/route.ts          # Claude API tool use (10 tools: tasks, habits, fitness, profile, Gmail, Calendar)
 │   │   │   │   ├── fun-fact/route.ts      # Claude Haiku daily fact + Supabase cache
 │   │   │   │   └── google/
 │   │   │   │       ├── calendar/route.ts  # Today's Google Calendar events
@@ -106,7 +107,9 @@ mr-bridge-assistant/
 │   │   │       ├── schedule-today.tsx     # Google Calendar card
 │   │   │       ├── important-emails.tsx   # Gmail card
 │   │   │       ├── recovery-summary.tsx   # Oura recovery & sleep card
+│   │   │       ├── recovery-trends.tsx    # Sleep & readiness trend charts (Recharts)
 │   │   │       ├── fitness-summary.tsx    # Body comp + last workout card
+│   │   │       ├── inline-sparkline.tsx   # Mini trend sparkline (used in summary cards)
 │   │   │       ├── habits-summary.tsx     # Today's habit progress card
 │   │   │       ├── tasks-summary.tsx      # Active tasks card
 │   │   │       └── recent-chat.tsx        # Last chat message card
@@ -148,8 +151,8 @@ mr-bridge-assistant/
 │   ├── fitness-tracker-setup.md           # Google Fit, Oura, Fitbit, Renpho setup
 │   └── google-oauth-setup.md             # OAuth token setup + refresh guide
 │
-├── memory/                                # Local files (gitignored)
-│   ├── meal_log.md                        # Recipes — still read locally during briefing
+├── memory/                                # Local files (gitignored, archived originals)
+│   ├── meal_log.md                        # Recipes — read locally during briefing; data also in Supabase `recipes` table
 │   ├── profile.template.md
 │   ├── fitness_log.template.md
 │   ├── meal_log.template.md
@@ -176,7 +179,7 @@ mr-bridge-assistant/
     └── README.md
 ```
 
-> All live data (habits, tasks, fitness, recovery) is stored in **Supabase** — not local files. `memory/meal_log.md` is still read locally for recipes (not yet migrated to Supabase).
+> All live data (habits, tasks, fitness, recovery, recipes) is stored in **Supabase** — not local files. `memory/meal_log.md` is also read locally during session briefing until recipe display is added to the web interface.
 
 ## Getting Started
 
@@ -226,16 +229,13 @@ PICOVOICE_ACCESS_KEY=
 pip3 install -r scripts/requirements.txt
 ```
 
-### 5. Set up your profile and recipes
-Copy the meal log template and fill it in (recipes are still read locally):
-```bash
-cp memory/meal_log.template.md memory/meal_log.md
-```
-Add your profile data directly to Supabase via the dashboard or run:
+### 5. Migrate profile and recipes to Supabase
+If you have existing markdown data files, migrate them to Supabase:
 ```bash
 python3 scripts/migrate_to_supabase.py --dry-run   # preview first
-python3 scripts/migrate_to_supabase.py             # migrate from existing markdown files
+python3 scripts/migrate_to_supabase.py             # migrate profile, recipes, habits, tasks, fitness
 ```
+Or add profile data directly via the Supabase dashboard. Recipes populate the `recipes` table; the session briefing also reads `memory/meal_log.md` locally as a fallback until recipe display ships in the web interface.
 
 ### 6. Set up push notifications (Android, macOS, Windows)
 See [docs/notifications-setup.md](docs/notifications-setup.md). Add `NTFY_TOPIC` as a GitHub Actions secret for the Sunday weekly review cloud nudge.
@@ -283,7 +283,7 @@ Feature backlog is tracked via [GitHub Issues](https://github.com/Theioz/mr-brid
 
 A Next.js web app deployed on Vercel providing a full daily briefing UI:
 
-- **Dashboard** — Fun Fact (Claude Haiku), Schedule Today (Google Calendar), Important Emails (Gmail), Recovery & Sleep (Oura), Fitness Snapshot, Habits, Tasks
+- **Dashboard** — Fun Fact (Claude Haiku), Schedule Today (Google Calendar), Important Emails (Gmail), Recovery & Sleep + Trends (Oura), Fitness Snapshot, Habits, Tasks, Recent Chat
 - **Chat** — streams responses from Claude Sonnet with markdown rendering
 - **Tasks** — add, complete, and archive tasks
 - **Habits** — daily check-in with blue toggle states, 7-day history grid

--- a/web/src/app/(protected)/layout.tsx
+++ b/web/src/app/(protected)/layout.tsx
@@ -20,7 +20,7 @@ export default async function ProtectedLayout({
     <div className="flex min-h-screen bg-neutral-950 text-neutral-100">
       <Nav />
       <main className="flex-1 ml-12 lg:ml-48 px-5 lg:px-8 pt-8 pb-8 min-w-0">
-        <div className="max-w-4xl">{children}</div>
+        <div className="max-w-6xl mx-auto">{children}</div>
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary

- Adds `mx-auto` to the protected layout content wrapper (`web/src/app/(protected)/layout.tsx`) so dashboard content centers horizontally on wide viewports
- Bumps `max-w-4xl` (896px) → `max-w-6xl` (1152px) to give the 3-column bento grid adequate room without excessive dead space on ultra-wide displays

## Analysis

- **Nav** (`nav.tsx`): no changes needed — already responsive (`w-12` icon rail / `lg:w-48` sidebar) with matching `ml-12 lg:ml-48` offset in layout
- **Bento grid** (`page.tsx`): collapses cleanly — `grid-cols-1` at sm/md stacks all cards, `lg:grid-cols-3` kicks in with col-span assignments; no intermediate breakpoint needed

## Test plan

- [ ] Open dashboard on a wide viewport (>1280px) — content should be centered with equal margins on both sides
- [ ] Verify no layout shift at sm (mobile) and md (tablet) — cards should stack in a single column
- [ ] Verify 3-col bento grid renders correctly at lg+
- [ ] Confirm nav icon rail shows at narrow widths, full sidebar at lg+

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)