### PR TITLE
fix: restore fun fact top banner and fix stale daily cache

### DIFF
--- a/web/src/app/(protected)/page.tsx
+++ b/web/src/app/(protected)/page.tsx
@@ -98,6 +98,9 @@ export default async function DashboardPage() {
 
   return (
     <div className="space-y-5">
+      {/* Fun fact banner */}
+      <FunFact />
+
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
@@ -138,8 +141,6 @@ export default async function DashboardPage() {
         </div>
       </div>
 
-      {/* Fun fact — demoted to ambient strip */}
-      <FunFact />
     </div>
   );
 }

--- a/web/src/app/api/fun-fact/route.ts
+++ b/web/src/app/api/fun-fact/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import { anthropic } from "@ai-sdk/anthropic";
 import { generateText } from "ai";
 import { createServiceClient } from "@/lib/supabase/service";

--- a/web/src/components/dashboard/fun-fact.tsx
+++ b/web/src/components/dashboard/fun-fact.tsx
@@ -18,15 +18,14 @@ export default function FunFact() {
   if (!loading && !fact) return null;
 
   return (
-    <div className="flex items-start gap-3 pl-3 border-l border-neutral-800">
-      <Sparkles size={11} className="text-neutral-600 shrink-0 mt-0.5" />
+    <div className="flex items-center gap-2.5 px-4 py-2.5 rounded-lg bg-neutral-900 border border-neutral-800">
+      <Sparkles size={13} className="text-neutral-500 shrink-0" />
       {loading ? (
         <div className="flex-1 space-y-1.5 py-0.5">
           <div className="h-2.5 bg-neutral-800 rounded animate-pulse w-3/4" />
-          <div className="h-2.5 bg-neutral-800 rounded animate-pulse w-1/2" />
         </div>
       ) : (
-        <p className="text-xs text-neutral-600 italic leading-relaxed">{fact}</p>
+        <p className="text-xs text-neutral-400 italic leading-relaxed">{fact}</p>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- Moves `FunFact` to the top of the dashboard (above the greeting header) as a full-width banner
- Adds `export const dynamic = "force-dynamic"` to `/api/fun-fact/route.ts` — without this, Next.js caches the route response so the Supabase date check and AI generation never run after the first build, causing the fact to stay stale indefinitely
- Restyled component from the `border-l` ambient strip to a `bg-neutral-900 border border-neutral-800 rounded-lg` banner

## Test plan

- [ ] Fun fact appears at the top of the dashboard above the greeting
- [ ] Refreshing the page on a new day generates a fresh fact (not yesterday's)
- [ ] Loading skeleton shows while the API call is in flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)