### PR TITLE
fix: use USER_TZ when formatting calendar event times

### DIFF
--- a/web/src/app/api/google/calendar/route.ts
+++ b/web/src/app/api/google/calendar/route.ts
@@ -1,6 +1,6 @@
 import { google } from "googleapis";
 import { NextResponse } from "next/server";
-import { startOfTodayRFC3339, endOfTodayRFC3339 } from "@/lib/timezone";
+import { startOfTodayRFC3339, endOfTodayRFC3339, USER_TZ } from "@/lib/timezone";
 import { getGoogleAuthClient } from "@/lib/google-auth";
 
 export interface CalendarEvent {
@@ -19,6 +19,7 @@ function formatTime(dateTimeStr: string | null | undefined, dateStr: string | nu
     hour: "numeric",
     minute: "2-digit",
     hour12: true,
+    timeZone: USER_TZ,
   });
 }
 


### PR DESCRIPTION
## Summary
- `formatTime` in the calendar API route called `toLocaleTimeString` without a `timeZone` option
- Running server-side, this defaulted to UTC — displaying 8:45 PM PDT as 3:45 AM
- Fix: import `USER_TZ` from `@/lib/timezone` and pass it as `timeZone` to `toLocaleTimeString`

## Test plan
- [ ] Open dashboard and confirm Schedule Today shows 8:45 PM for today's movie event
- [ ] Verify all-day events still show "All day"

🤖 Generated with [Claude Code](https://claude.com/claude-code)