### PR TITLE
feat: recipe planner and meal guidance in chat (#47)

### DIFF
--- a/.claude/rules/mr-bridge-rules.md
+++ b/.claude/rules/mr-bridge-rules.md
@@ -18,13 +18,12 @@ Execute in this exact order:
    ```bash
    python3 scripts/fetch_briefing_data.py
    ```
-   Read the output — it contains profile, tasks, habits, body composition, workouts, recovery, and study log.
-3. Read `memory/meal_log.md` (recipes not yet in Supabase query — still local)
-4. Fetch today's Google Calendar events using `List Calendar Events` (claude.ai Google Calendar MCP)
+   Read the output — it contains profile, tasks, habits, body composition, workouts, recovery, study log, and recent meals.
+3. Fetch today's Google Calendar events using `List Calendar Events` (claude.ai Google Calendar MCP)
    — includes both personal (jaydud6) and professional (leung.ss.jason, shared) calendars — note the calendar/account source for each event
-5. Search for important unread emails using `Search Gmail Emails` (claude.ai Gmail MCP) — filter: unread, subjects containing meeting / urgent / invoice / action required / deadline
+4. Search for important unread emails using `Search Gmail Emails` (claude.ai Gmail MCP) — filter: unread, subjects containing meeting / urgent / invoice / action required / deadline
    — jaydud6 = personal (primary); leung.ss.jason = professional (aggregated via POP3, Gmail label: "professional") — note account source when surfacing emails
-6. Deliver session briefing (format below)
+5. Deliver session briefing (format below)
 
 ## Session Briefing Format
 ```
@@ -113,7 +112,6 @@ When operating in voice context (responses will be spoken aloud):
 
 ## Memory Update Rules
 - Data is stored in Supabase — do not write to local markdown files for live data
-- `memory/meal_log.md` is still the source for recipes (read-only during briefing)
 - Habit logging: run `python3 scripts/log_habit.py --habits <names> --date <YYYY-MM-DD>`
 - Task updates: use Supabase directly or a future task management command
 - After any Supabase write: confirm to user what was written and to which table
@@ -136,11 +134,9 @@ All live data is stored in Supabase. Local markdown files are archived originals
 | `habits` + `habit_registry` | Manual logging | `log_habit.py` |
 | `tasks` + `study_log` | Manual logging | (future command) |
 | `profile` | Migrated from `profile.md` | (edit via Supabase or future command) |
-| `recipes` | Migrated from `meal_log.md` | (edit via Supabase or future command) |
+| `recipes` + `meal_log` | Migrated from `meal_log.md` | `get_recipes` / `log_meal` tools (web chat) |
 | `chat_sessions` + `chat_messages` | Web interface | (future — issue #10) |
 | `timer_state` | Study timer | `study-timer` agent |
-
-`memory/meal_log.md` — still read during briefing for recipe reference until web interface ships.
 
 ## Reference Index
 | Resource | Location | Purpose |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Added
+- `get_recipes` chat tool — searches `recipes` table by name or ingredient; returns all saved recipes when no query provided; closes #47
+- `log_meal` chat tool — writes to `meal_log` table with meal type (breakfast/lunch/dinner/snack), optional free-text notes, optional recipe UUID link, and date (defaults to today); closes #47
+- `Recipe` and `MealLog` TypeScript interfaces in `web/src/lib/types.ts`
+
+### Changed
+- `web/src/app/api/chat/route.ts` — system prompt now includes recipes and meal planning as in-scope domains; instructs Claude to check saved recipes, pull fitness context, and include estimated macros with any recipe recommendation; improvises from pantry profile when no saved recipe matches
+- `scripts/fetch_briefing_data.py` — added recent meal log section (last 7 days) from Supabase; resolves recipe names for linked entries
+- `.claude/rules/mr-bridge-rules.md` — removed `memory/meal_log.md` local read from session start protocol (meals now fetched from Supabase via briefing script); updated data sources table for `recipes` + `meal_log`
+
+---
+
 - `web/src/lib/google-auth.ts` — shared `getGoogleAuthClient()` OAuth2 helper; extracted from duplicated credential setup in dashboard routes
 - `search_gmail` chat tool — flexible Gmail search via query string; returns message id, from, subject, date; closes #30
 - `get_email_body` chat tool — fetches full message by ID; walks MIME tree; decodes base64url; truncates to 4000 chars

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ mr-bridge-assistant/
 │   │   │   │   ├── chat/page.tsx          # Mr. Bridge chat
 │   │   │   │   └── journal/page.tsx       # Daily journal — guided 5-prompt flow
 │   │   │   ├── api/
-│   │   │   │   ├── chat/route.ts          # Claude API tool use (10 tools: tasks, habits, fitness, profile, Gmail, Calendar)
+│   │   │   │   ├── chat/route.ts          # Claude API tool use (12 tools: tasks, habits, fitness, profile, Gmail, Calendar, recipes, meals)
 │   │   │   │   ├── fun-fact/route.ts      # Claude Haiku daily fact + Supabase cache
 │   │   │   │   └── google/
 │   │   │   │       ├── calendar/route.ts  # Today's Google Calendar events
@@ -153,7 +153,7 @@ mr-bridge-assistant/
 │   └── gmail-multi-account.md            # POP3 aggregation + Calendar sharing setup (App Password, label ID resolution)
 │
 ├── memory/                                # Local files (gitignored, archived originals)
-│   ├── meal_log.md                        # Recipes — read locally during briefing; data also in Supabase `recipes` table
+│   ├── meal_log.md                        # Recipes — archived original; data lives in Supabase `recipes` table
 │   ├── profile.template.md
 │   ├── fitness_log.template.md
 │   ├── meal_log.template.md
@@ -180,7 +180,7 @@ mr-bridge-assistant/
     └── README.md
 ```
 
-> All live data (habits, tasks, fitness, recovery, recipes) is stored in **Supabase** — not local files. `memory/meal_log.md` is also read locally during session briefing until recipe display is added to the web interface.
+> All live data (habits, tasks, fitness, recovery, recipes, meals) is stored in **Supabase** — not local files.
 
 ## Getting Started
 

--- a/scripts/fetch_briefing_data.py
+++ b/scripts/fetch_briefing_data.py
@@ -187,6 +187,34 @@ def main():
             notes = f" — {s['notes']}" if s.get("notes") else ""
             print(f"- {s['date']} | {s['subject']} | {dur}{notes}")
 
+    # ── Meal Log — last 7 days ─────────────────────────────────────────────────
+    meal_logs = (
+        client.table("meal_log")
+        .select("date,meal_type,notes,recipe_id")
+        .gte("date", seven_days_ago)
+        .order("date", desc=True)
+        .execute()
+        .data
+    )
+    if meal_logs:
+        # Fetch recipe names for any linked recipe_ids
+        recipe_ids = list({m["recipe_id"] for m in meal_logs if m.get("recipe_id")})
+        recipe_names: dict[str, str] = {}
+        if recipe_ids:
+            recipes = (
+                client.table("recipes")
+                .select("id,name")
+                .in_("id", recipe_ids)
+                .execute()
+                .data
+            )
+            recipe_names = {r["id"]: r["name"] for r in recipes}
+
+        print("\n## RECENT MEALS (last 7 days)")
+        for m in meal_logs:
+            label = recipe_names.get(m["recipe_id"], m.get("notes") or "—") if m.get("recipe_id") else (m.get("notes") or "—")
+            print(f"- {m['date']} | {m.get('meal_type', '—')} | {label}")
+
 
 if __name__ == "__main__":
     main()

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -71,7 +71,16 @@ Tools available:
 - get_profile: profile key/value store
 - search_gmail: search Gmail with any query string, returns message IDs + metadata
 - get_email_body: fetch and decode the full plain-text body of an email by message ID
-- create_calendar_event: create a Google Calendar event on the primary calendar`;
+- create_calendar_event: create a Google Calendar event on the primary calendar
+- get_recipes: search saved recipes by ingredient, name, or tag; omit query to return all
+- log_meal: log a meal by type (breakfast/lunch/dinner/snack) with optional recipe link or notes
+
+Recipes and meal planning are in scope. When asked what to cook given ingredients on hand:
+1. Call get_recipes to check for saved recipes that match.
+2. Call get_fitness_summary to pull recent body composition, goals, and workout data — use this to calibrate the recommendation (e.g. prioritize protein post-workout, suggest lower-calorie options if in a deficit phase).
+3. Always provide a concrete recipe recommendation — either from saved recipes or improvised from your own knowledge. Do not redirect to external tools.
+4. Include estimated calories, protein, carbs, and fat for the suggested recipe. Flag if the meal is a poor fit for current fitness context (e.g. high-calorie meal after a rest day, low protein after a hard workout).
+5. Tailor suggestions to Jason's preferences: Korean/SE Asian leaning, high-quality proteins, pantry staples (garlic, gochujang, olive oil, butter, ginger, lemon). Improvise confidently when no saved recipe fits.`;
 
   // Strip extra fields (parts, id, etc.) that useChat adds — Anthropic only wants role + content
   // Also filter empty-content messages to prevent Anthropic 400 errors
@@ -507,6 +516,60 @@ Tools available:
         } catch (err) {
           return { error: err instanceof Error ? err.message : "Failed to create calendar event" };
         }
+      },
+    }),
+
+    get_recipes: tool({
+      description: "Search saved recipes by ingredient, name, or tag. Omit query to return all recipes.",
+      parameters: jsonSchema<{ query?: string }>({
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Ingredient, recipe name, or tag to search for." },
+        },
+      }),
+      execute: async ({ query }) => {
+        let req = supabase
+          .from("recipes")
+          .select("id, name, cuisine, ingredients, instructions, tags");
+        if (query) {
+          req = req.or(`name.ilike.%${query}%,ingredients.ilike.%${query}%`);
+        }
+        const { data, error } = await req.order("name");
+        if (error) return { error: error.message };
+        return data ?? [];
+      },
+    }),
+
+    log_meal: tool({
+      description: "Log a meal to the meal_log table.",
+      parameters: jsonSchema<{
+        meal_type: "breakfast" | "lunch" | "dinner" | "snack";
+        notes?: string;
+        recipe_id?: string;
+        date?: string;
+      }>({
+        type: "object",
+        required: ["meal_type"],
+        properties: {
+          meal_type: { type: "string", enum: ["breakfast", "lunch", "dinner", "snack"], description: "Meal type." },
+          notes: { type: "string", description: "Free-text meal description." },
+          recipe_id: { type: "string", description: "UUID of a saved recipe." },
+          date: { type: "string", description: "Date in YYYY-MM-DD format. Defaults to today." },
+        },
+      }),
+      execute: async ({ meal_type, notes, recipe_id, date }) => {
+        const { data, error } = await supabase
+          .from("meal_log")
+          .insert({
+            meal_type,
+            notes: notes ?? null,
+            recipe_id: recipe_id ?? null,
+            date: date ?? todayString(),
+          })
+          .select()
+          .single();
+        if (error) return { error: error.message };
+        return data;
       },
     }),
   };

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -93,6 +93,26 @@ export interface Profile {
   updated_at: string;
 }
 
+export interface Recipe {
+  id: string;
+  name: string;
+  cuisine: string | null;
+  ingredients: string | null;
+  instructions: string | null;
+  tags: string[] | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface MealLog {
+  id: string;
+  date: string;
+  meal_type: 'breakfast' | 'lunch' | 'dinner' | 'snack' | null;
+  recipe_id: string | null;
+  notes: string | null;
+  metadata: Record<string, unknown>;
+}
+
 export interface JournalResponses {
   best_moment?: string;
   challenge?: string;


### PR DESCRIPTION
## Summary

- Adds `get_recipes` chat tool — searches `recipes` table by name or ingredient; returns all saved recipes when no query provided
- Adds `log_meal` chat tool — writes to `meal_log` table with meal type, optional notes, optional recipe UUID, and date
- Updates system prompt to bring recipes/meals fully in scope; Claude checks saved recipes, pulls fitness context, and includes estimated macros with recommendations; improvises confidently when no saved recipe matches
- Adds `Recipe` and `MealLog` TypeScript interfaces to `types.ts`
- Updates `fetch_briefing_data.py` to include last 7 days of meal logs from Supabase
- Cleans up `mr-bridge-rules.md` — removes stale `meal_log.md` local read from session protocol

## Test plan

- [ ] "I have chicken tenders, napa cabbage, parsley, and pantry staples — what should I make?" returns a recipe suggestion with macros, no scope refusal
- [ ] "What recipes do I have saved with salmon?" returns Salmon Rice Bowl + Salmon Burrata Pasta
- [ ] "Log that I had chicken stir-fry for lunch" confirms a `meal_log` write
- [ ] `python3 scripts/fetch_briefing_data.py` includes a `RECENT MEALS` section
- [ ] TypeScript build passes (`npm run build` in `web/`)

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)