### PR TITLE
feat: birthday reminders from Google Calendar

### DIFF
--- a/.claude/agents/morning-nudge.md
+++ b/.claude/agents/morning-nudge.md
@@ -5,11 +5,11 @@ tools:
   - Bash(bash *)
 model: haiku
 permissionMode: acceptEdits
-maxTurns: 2
+maxTurns: 3
 ---
 
 ## Purpose
-Fire a macOS push notification nudging Jason to open a Mr. Bridge session for the day.
+Fire a macOS push notification nudging Jason to open a Mr. Bridge session for the day, then check for any birthdays today and send a separate notification for each.
 
 ## Instructions
 
@@ -17,4 +17,8 @@ Fire a macOS push notification nudging Jason to open a Mr. Bridge session for th
    ```bash
    bash "/Users/jason/Code Projects/mr-bridge-assistant/scripts/notify.sh" --title "Mr. Bridge" --message "Morning. Open Claude Code to start your session."
    ```
-2. No memory reads or writes. Notification only.
+2. Run (non-fatal — errors do not block completion):
+   ```bash
+   python3 "/Users/jason/Code Projects/mr-bridge-assistant/scripts/check_birthday_notif.py"
+   ```
+3. No memory reads or writes. Notifications only.

--- a/.claude/rules/mr-bridge-rules.md
+++ b/.claude/rules/mr-bridge-rules.md
@@ -21,6 +21,7 @@ Execute in this exact order:
    Read the output — it contains profile, tasks, habits, body composition, workouts, recovery, study log, and recent meals.
 3. Fetch today's Google Calendar events using `List Calendar Events` (claude.ai Google Calendar MCP)
    — includes both personal (jaydud6) and professional (leung.ss.jason, shared) calendars — note the calendar/account source for each event
+3b. Fetch upcoming birthdays: call `List Calendar Events` for the next **7 days** (timeMin = today, timeMax = today+7 days). Filter for events whose title matches `'s birthday` (case-insensitive) or whose calendar name contains "birthday". For each match, compute days_until = event date − today (0 = today, 1 = tomorrow, etc.). Strip the "'s birthday" suffix when displaying the person's name.
 4. Search for important unread emails using `Search Gmail Emails` (claude.ai Gmail MCP) — filter: unread, subjects containing meeting / urgent / invoice / action required / deadline
    — jaydud6 = personal (primary); leung.ss.jason = professional (aggregated via POP3, Gmail label: "professional") — note account source when surfacing emails
 5. Deliver session briefing (format below)
@@ -31,6 +32,9 @@ Execute in this exact order:
 
 ### Schedule Today
 [Calendar events: time + title, or "No events"]
+
+### Upcoming Birthdays
+[Name — today / in N days. Omit this section entirely if no birthdays in the next 7 days.]
 
 ### Important Emails
 [Unread emails matching filter, or "Inbox clear"]

--- a/scripts/check_birthday_notif.py
+++ b/scripts/check_birthday_notif.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Check Google Calendar for birthdays today and fire a push notification for each.
+Called by the morning-nudge agent at 8 AM. Exits silently with no notification if
+no birthdays are found today. Errors are non-fatal — printed to stderr, exit 0.
+
+Requires: google-auth, google-auth-oauthlib, google-api-python-client, python-dotenv
+  pip3 install google-auth google-auth-oauthlib google-api-python-client python-dotenv
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from datetime import date, timezone, datetime, timedelta
+from pathlib import Path
+
+from dotenv import load_dotenv
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+ROOT = Path(__file__).parent.parent
+load_dotenv(ROOT / ".env")
+NOTIFY_SCRIPT = ROOT / "scripts" / "notify.sh"
+
+
+def get_credentials() -> Credentials:
+    creds = Credentials(
+        token=None,
+        refresh_token=os.environ["GOOGLE_REFRESH_TOKEN"],
+        client_id=os.environ["GOOGLE_CLIENT_ID"],
+        client_secret=os.environ["GOOGLE_CLIENT_SECRET"],
+        token_uri="https://oauth2.googleapis.com/token",
+        scopes=["https://www.googleapis.com/auth/calendar.readonly"],
+    )
+    creds.refresh(Request())
+    return creds
+
+
+def is_birthday_event(title: str, cal_name: str) -> bool:
+    return bool(re.search(r"'s birthday$", title, re.IGNORECASE)) or \
+        "birthday" in cal_name.lower()
+
+
+def person_name(title: str) -> str:
+    """Strip "'s birthday" suffix to get just the person's name."""
+    return re.sub(r"'s birthday$", "", title, flags=re.IGNORECASE).strip()
+
+
+def today_rfc3339_range() -> tuple[str, str]:
+    """Return (timeMin, timeMax) RFC3339 strings spanning today in UTC."""
+    today = date.today()
+    time_min = datetime(today.year, today.month, today.day, tzinfo=timezone.utc).isoformat()
+    time_max = (datetime(today.year, today.month, today.day, tzinfo=timezone.utc) + timedelta(days=1)).isoformat()
+    return time_min, time_max
+
+
+def main() -> None:
+    try:
+        creds = get_credentials()
+    except Exception as e:
+        print(f"[check_birthday_notif] credential error: {e}", file=sys.stderr)
+        return
+
+    try:
+        service = build("calendar", "v3", credentials=creds, cache_discovery=False)
+        cal_list = service.calendarList().list(minAccessRole="reader").execute()
+        calendars = cal_list.get("items", [])
+    except Exception as e:
+        print(f"[check_birthday_notif] calendar list error: {e}", file=sys.stderr)
+        return
+
+    time_min, time_max = today_rfc3339_range()
+    birthdays_today: list[str] = []
+
+    for cal in calendars:
+        cal_id = cal.get("id", "")
+        cal_name = cal.get("summaryOverride") or cal.get("summary") or cal_id
+        try:
+            events_result = service.events().list(
+                calendarId=cal_id,
+                timeMin=time_min,
+                timeMax=time_max,
+                singleEvents=True,
+                maxResults=20,
+            ).execute()
+        except Exception:
+            continue
+
+        for event in events_result.get("items", []):
+            if event.get("status") == "cancelled":
+                continue
+            title = event.get("summary", "")
+            if is_birthday_event(title, cal_name):
+                birthdays_today.append(person_name(title))
+
+    for name in birthdays_today:
+        try:
+            subprocess.run(
+                ["bash", str(NOTIFY_SCRIPT), "--title", "Birthday Today", "--message", f"It's {name}'s birthday today."],
+                check=True,
+            )
+        except Exception as e:
+            print(f"[check_birthday_notif] notify error for {name}: {e}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/web/src/app/api/google/calendar/route.ts
+++ b/web/src/app/api/google/calendar/route.ts
@@ -9,6 +9,7 @@ export interface CalendarEvent {
   location?: string;
   calendarName: string;
   isPrimary: boolean;
+  isBirthday: boolean;
 }
 
 function formatTime(dateTimeStr: string | null | undefined, dateStr: string | null | undefined): string {
@@ -49,14 +50,21 @@ export async function GET() {
         const isPrimary = cal.primary === true;
         return (res.data.items ?? [])
           .filter((e) => e.status !== "cancelled")
-          .map((e) => ({
-            time: formatTime(e.start?.dateTime, e.start?.date),
-            title: e.summary ?? "(No title)",
-            calendarName: calName,
-            isPrimary,
-            startDateTime: e.start?.dateTime ?? e.start?.date ?? "",
-            ...(e.location ? { location: e.location } : {}),
-          }));
+          .map((e) => {
+            const title = e.summary ?? "(No title)";
+            const isBirthday =
+              /'s birthday$/i.test(title) ||
+              calName.toLowerCase().includes("birthday");
+            return {
+              time: formatTime(e.start?.dateTime, e.start?.date),
+              title,
+              calendarName: calName,
+              isPrimary,
+              isBirthday,
+              startDateTime: e.start?.dateTime ?? e.start?.date ?? "",
+              ...(e.location ? { location: e.location } : {}),
+            };
+          });
       })
     );
 

--- a/web/src/components/dashboard/schedule-today.tsx
+++ b/web/src/components/dashboard/schedule-today.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Calendar } from "lucide-react";
+import { Calendar, Gift } from "lucide-react";
 import type { CalendarEvent } from "@/app/api/google/calendar/route";
 
 function parseTimeToMinutes(timeStr: string): number | null {
@@ -98,11 +98,13 @@ export default function ScheduleToday() {
               const { event, isPast } = item;
               return (
                 <div key={idx} className={`flex gap-3 items-start transition-opacity ${isPast ? "opacity-40" : ""}`}>
-                  <span className="text-xs font-[family-name:var(--font-mono)] text-neutral-500 shrink-0 w-16 pt-px">
-                    {event.time}
+                  <span className="text-xs font-[family-name:var(--font-mono)] text-neutral-500 shrink-0 w-16 pt-px flex items-center">
+                    {event.isBirthday
+                      ? <Gift size={12} className="text-rose-400" />
+                      : event.time}
                   </span>
                   <div className="min-w-0">
-                    <p className={`text-sm leading-snug truncate ${isPast ? "text-neutral-400" : "text-neutral-200"}`}>
+                    <p className={`text-sm leading-snug truncate ${isPast ? "text-neutral-400" : event.isBirthday ? "text-rose-300" : "text-neutral-200"}`}>
                       {event.title}
                     </p>
                     {(event.location || !event.isPrimary) && (
@@ -120,11 +122,13 @@ export default function ScheduleToday() {
           ) : (
             events.map((event, i) => (
               <div key={i} className="flex gap-3 items-start">
-                <span className="text-xs font-[family-name:var(--font-mono)] text-neutral-500 shrink-0 w-16 pt-px">
-                  {event.time}
+                <span className="text-xs font-[family-name:var(--font-mono)] text-neutral-500 shrink-0 w-16 pt-px flex items-center">
+                  {event.isBirthday
+                    ? <Gift size={12} className="text-rose-400" />
+                    : event.time}
                 </span>
                 <div className="min-w-0">
-                  <p className="text-sm text-neutral-200 leading-snug truncate">{event.title}</p>
+                  <p className={`text-sm leading-snug truncate ${event.isBirthday ? "text-rose-300" : "text-neutral-200"}`}>{event.title}</p>
                   {(event.location || !event.isPrimary) && (
                     <p className="text-xs text-neutral-600 truncate mt-0.5">
                       {event.location}


### PR DESCRIPTION
Closes #46

## Summary
- **Calendar API** (`web/src/app/api/google/calendar/route.ts`): adds `isBirthday: boolean` to `CalendarEvent` — detected by title pattern `/'s birthday$/i` or calendar name containing "birthday"
- **Schedule Today** (`web/src/components/dashboard/schedule-today.tsx`): birthday events render with a rose `Gift` icon in the time column and `text-rose-300` title instead of the standard neutral style
- **Session briefing** (`.claude/rules/mr-bridge-rules.md`): new step 3b fetches the next 7 days of calendar events and filters for birthdays; new `### Upcoming Birthdays` section in the briefing format (omitted when the window is empty)
- **`scripts/check_birthday_notif.py`** (new): Python script that checks today's calendar events for birthdays and fires `notify.sh` for each — covers both macOS and Android (ntfy.sh); non-fatal on errors
- **morning-nudge agent** (`.claude/agents/morning-nudge.md`): calls `check_birthday_notif.py` as a second step at 8am; `maxTurns` bumped 2 → 3

## Test plan
- [ ] Add a test birthday event to Google Calendar for today; `GET /api/google/calendar` returns `isBirthday: true` for it
- [ ] Open the dashboard — birthday event shows Gift icon and rose title; other events unaffected
- [ ] Open a session with a birthday in the next 7 days — `### Upcoming Birthdays` appears with correct name and day count; absent when none
- [ ] Run `python3 scripts/check_birthday_notif.py` on a day with a birthday — macOS notification fires; ntfy push received on Android
- [ ] Run on a day without birthdays — no notification, clean exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)