### PR TITLE
feat: habits — add/archive UI and extended history (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Added
+- `web/src/app/(protected)/habits/page.tsx` — `addHabit` and `archiveHabit` server actions; range-aware data fetching via `?range=7|30|90` search param (default 30); wires up `HabitTodaySection`, `HabitRangeToggle`; closes #45
+- `web/src/components/habits/habit-today-section.tsx` — client component managing manage-mode and add-form state; renders per-habit archive buttons in manage mode; inline add form (emoji, name, category)
+- `web/src/components/habits/habit-range-toggle.tsx` — 7d / 30d / 90d pill selector; updates `?range` URL param via Next.js router
+- `web/src/lib/timezone.ts` — `getLastNDays(n)` generalizes `getLast7Days`; existing function now delegates to it
+
+### Changed
+- `web/src/components/habits/habit-history.tsx` — headers show readable dates (`Apr 5`) instead of single-letter day initials; 90-day view condenses to weekly columns with completion-count badges (opacity-scaled); accepts `range` prop
+- `web/src/components/habits/habit-toggle.tsx` — adds optional `manageMode` and `archiveAction` props; renders `✕` archive button at row end when in manage mode
 - `get_recipes` chat tool — searches `recipes` table by name or ingredient; returns all saved recipes when no query provided; closes #47
 - `log_meal` chat tool — writes to `meal_log` table with meal type (breakfast/lunch/dinner/snack), optional free-text notes, optional recipe UUID link, and date (defaults to today); closes #47
 - `Recipe` and `MealLog` TypeScript interfaces in `web/src/lib/types.ts`

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ mr-bridge-assistant/
 │   │   │   │   ├── layout.tsx             # Protected layout with sidebar
 │   │   │   │   ├── page.tsx               # Daily briefing dashboard
 │   │   │   │   ├── tasks/page.tsx         # Task management
-│   │   │   │   ├── habits/page.tsx        # Habit tracking + 7-day history
+│   │   │   │   ├── habits/page.tsx        # Habit tracking — add/archive + 7/30/90d history
 │   │   │   │   ├── fitness/page.tsx       # Body composition + workouts
 │   │   │   │   ├── chat/page.tsx          # Mr. Bridge chat
 │   │   │   │   └── journal/page.tsx       # Daily journal — guided 5-prompt flow
@@ -99,7 +99,7 @@ mr-bridge-assistant/
 │   │   │   │   └── logo.tsx               # MB monogram SVG
 │   │   │   ├── chat/                      # Chat UI with markdown rendering
 │   │   │   ├── tasks/                     # Task CRUD components
-│   │   │   ├── habits/                    # Habit toggle + 7-day history grid
+│   │   │   ├── habits/                    # Habit toggle, add/archive UI, range-selectable history grid
 │   │   │   ├── fitness/                   # Body comp chart (Recharts)
 │   │   │   ├── journal/                   # Guided journal flow + history list
 │   │   │   └── dashboard/

--- a/web/src/app/(protected)/habits/page.tsx
+++ b/web/src/app/(protected)/habits/page.tsx
@@ -2,10 +2,12 @@ export const dynamic = "force-dynamic";
 
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
-import HabitToggle from "@/components/habits/habit-toggle";
+import { Suspense } from "react";
 import HabitHistory from "@/components/habits/habit-history";
+import HabitTodaySection from "@/components/habits/habit-today-section";
+import HabitRangeToggle from "@/components/habits/habit-range-toggle";
 import type { HabitRegistry, HabitLog } from "@/lib/types";
-import { todayString, getLast7Days } from "@/lib/timezone";
+import { todayString, getLastNDays, daysAgoString } from "@/lib/timezone";
 
 async function toggleHabit(habitId: string, date: string, completed: boolean) {
   "use server";
@@ -17,21 +19,58 @@ async function toggleHabit(habitId: string, date: string, completed: boolean) {
   revalidatePath("/");
 }
 
-export default async function HabitsPage() {
+async function addHabit(name: string, emoji: string, category: string) {
+  "use server";
+  const supabase = await createClient();
+  await supabase.from("habit_registry").insert({
+    name: name.trim(),
+    emoji: emoji.trim() || null,
+    category: category.trim() || null,
+  });
+  revalidatePath("/habits");
+}
+
+async function archiveHabit(habitId: string) {
+  "use server";
+  const supabase = await createClient();
+  await supabase.from("habit_registry").update({ active: false }).eq("id", habitId);
+  revalidatePath("/habits");
+  revalidatePath("/");
+}
+
+const VALID_RANGES = [7, 30, 90] as const;
+type Range = (typeof VALID_RANGES)[number];
+
+export default async function HabitsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ range?: string }>;
+}) {
+  const params = await searchParams;
+  const rawRange = Number(params.range ?? 30);
+  const range: Range = (VALID_RANGES as readonly number[]).includes(rawRange)
+    ? (rawRange as Range)
+    : 30;
+
   const supabase = await createClient();
   const today = todayString();
-  const last7 = getLast7Days();
+  const historyDates = getLastNDays(range);
 
   const [registryResult, todayLogsResult, historyLogsResult] = await Promise.all([
     supabase.from("habit_registry").select("*").eq("active", true).order("category").order("name"),
     supabase.from("habits").select("*").eq("date", today),
-    supabase.from("habits").select("*").in("date", last7),
+    range === 90
+      ? supabase
+          .from("habits")
+          .select("*")
+          .gte("date", daysAgoString(89))
+          .lte("date", today)
+      : supabase.from("habits").select("*").in("date", historyDates),
   ]);
 
   const habits = (registryResult.data ?? []) as HabitRegistry[];
   const todayLogs = (todayLogsResult.data ?? []) as HabitLog[];
   const historyLogs = (historyLogsResult.data ?? []) as HabitLog[];
-  const todayLogMap = new Map(todayLogs.map((l) => [l.habit_id, l]));
 
   const completed = todayLogs.filter((l) => l.completed).length;
 
@@ -44,28 +83,24 @@ export default async function HabitsPage() {
         </p>
       </div>
 
-      <section>
-        <h2 className="text-xs text-neutral-500 uppercase tracking-wide mb-3">Today</h2>
-        <div className="divide-y divide-neutral-800/50">
-          {habits.map((habit) => (
-            <HabitToggle
-              key={habit.id}
-              habit={habit}
-              log={todayLogMap.get(habit.id)}
-              toggleAction={toggleHabit}
-              date={today}
-            />
-          ))}
-          {habits.length === 0 && (
-            <p className="text-sm text-neutral-600 py-4">No habits configured.</p>
-          )}
-        </div>
-      </section>
+      <HabitTodaySection
+        habits={habits}
+        todayLogs={todayLogs}
+        date={today}
+        toggleAction={toggleHabit}
+        archiveAction={archiveHabit}
+        addAction={addHabit}
+      />
 
       {habits.length > 0 && (
         <section>
-          <h2 className="text-xs text-neutral-500 uppercase tracking-wide mb-3">Last 7 days</h2>
-          <HabitHistory habits={habits} logs={historyLogs} dates={last7} />
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-xs text-neutral-500 uppercase tracking-wide">History</h2>
+            <Suspense fallback={null}>
+              <HabitRangeToggle current={range} />
+            </Suspense>
+          </div>
+          <HabitHistory habits={habits} logs={historyLogs} dates={historyDates} range={range} />
         </section>
       )}
     </div>

--- a/web/src/app/(protected)/habits/page.tsx
+++ b/web/src/app/(protected)/habits/page.tsx
@@ -100,7 +100,7 @@ export default async function HabitsPage({
               <HabitRangeToggle current={range} />
             </Suspense>
           </div>
-          <HabitHistory habits={habits} logs={historyLogs} dates={historyDates} range={range} />
+          <HabitHistory habits={habits} logs={historyLogs} dates={historyDates} range={range} toggleAction={toggleHabit} />
         </section>
       )}
     </div>

--- a/web/src/components/habits/habit-history.tsx
+++ b/web/src/components/habits/habit-history.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState, useTransition } from "react";
 import type { HabitRegistry, HabitLog } from "@/lib/types";
 
 interface Props {
@@ -5,6 +8,7 @@ interface Props {
   logs: HabitLog[];
   dates: string[]; // ascending YYYY-MM-DD strings
   range: 7 | 30 | 90;
+  toggleAction: (habitId: string, date: string, completed: boolean) => Promise<void>;
 }
 
 function formatHeader(dateStr: string): string {
@@ -23,7 +27,6 @@ function groupByWeek(dates: string[]): { label: string; dates: string[] }[] {
   return weeks;
 }
 
-// Map completion count (0–7) to an opacity class
 function countToOpacity(count: number, total: number): string {
   if (total === 0) return "opacity-20";
   const ratio = count / total;
@@ -34,8 +37,38 @@ function countToOpacity(count: number, total: number): string {
   return "opacity-100";
 }
 
-export default function HabitHistory({ habits, logs, dates, range }: Props) {
+export default function HabitHistory({ habits, logs, dates, range, toggleAction }: Props) {
   const logMap = new Map(logs.map((l) => [`${l.habit_id}:${l.date}`, l.completed]));
+  const [overrides, setOverrides] = useState<Record<string, boolean>>({});
+  const [, startTransition] = useTransition();
+
+  function getCompleted(habitId: string, date: string): boolean | undefined {
+    const key = `${habitId}:${date}`;
+    return key in overrides ? overrides[key] : logMap.get(key);
+  }
+
+  function handleCellClick(habitId: string, date: string) {
+    const key = `${habitId}:${date}`;
+    const current = getCompleted(habitId, date);
+    const next = !(current ?? false);
+    setOverrides((prev) => ({ ...prev, [key]: next }));
+    startTransition(async () => {
+      try {
+        await toggleAction(habitId, date, next);
+      } catch {
+        // revert on error
+        setOverrides((prev) => {
+          const updated = { ...prev };
+          if (current === undefined) {
+            delete updated[key];
+          } else {
+            updated[key] = current;
+          }
+          return updated;
+        });
+      }
+    });
+  }
 
   if (range === 90) {
     const weeks = groupByWeek(dates);
@@ -59,7 +92,7 @@ export default function HabitHistory({ habits, logs, dates, range }: Props) {
                   {h.emoji} {h.name}
                 </td>
                 {weeks.map((w) => {
-                  const count = w.dates.filter((d) => logMap.get(`${h.id}:${d}`) === true).length;
+                  const count = w.dates.filter((d) => getCompleted(h.id, d) === true).length;
                   const total = w.dates.length;
                   return (
                     <td key={w.label} className="py-1.5 px-1 text-center">
@@ -100,17 +133,19 @@ export default function HabitHistory({ habits, logs, dates, range }: Props) {
                 {h.emoji} {h.name}
               </td>
               {dates.map((d) => {
-                const done = logMap.get(`${h.id}:${d}`);
+                const done = getCompleted(h.id, d);
                 return (
                   <td key={d} className="py-1.5 px-1 text-center">
-                    <span
-                      className={`inline-block w-4 h-4 rounded-full ${
+                    <button
+                      onClick={() => handleCellClick(h.id, d)}
+                      className={`inline-block w-4 h-4 rounded-full transition-all hover:ring-1 hover:ring-neutral-500 ${
                         done === true
                           ? "bg-neutral-100"
                           : done === false
                           ? "bg-neutral-800 border border-neutral-700"
                           : "bg-neutral-850 border border-neutral-800 opacity-40"
                       }`}
+                      title={`${h.name} — ${formatHeader(d)}`}
                     />
                   </td>
                 );

--- a/web/src/components/habits/habit-history.tsx
+++ b/web/src/components/habits/habit-history.tsx
@@ -141,9 +141,7 @@ export default function HabitHistory({ habits, logs, dates, range, toggleAction 
                       className={`inline-block w-4 h-4 rounded-full transition-all hover:ring-1 hover:ring-neutral-500 ${
                         done === true
                           ? "bg-neutral-100"
-                          : done === false
-                          ? "bg-neutral-800 border border-neutral-700"
-                          : "bg-neutral-850 border border-neutral-800 opacity-40"
+                          : "bg-neutral-800 border border-neutral-700 opacity-50"
                       }`}
                       title={`${h.name} — ${formatHeader(d)}`}
                     />

--- a/web/src/components/habits/habit-history.tsx
+++ b/web/src/components/habits/habit-history.tsx
@@ -3,11 +3,82 @@ import type { HabitRegistry, HabitLog } from "@/lib/types";
 interface Props {
   habits: HabitRegistry[];
   logs: HabitLog[];
-  dates: string[]; // last 7 days, ascending
+  dates: string[]; // ascending YYYY-MM-DD strings
+  range: 7 | 30 | 90;
 }
 
-export default function HabitHistory({ habits, logs, dates }: Props) {
+function formatHeader(dateStr: string): string {
+  return new Date(dateStr + "T00:00:00").toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function groupByWeek(dates: string[]): { label: string; dates: string[] }[] {
+  const weeks: { label: string; dates: string[] }[] = [];
+  for (let i = 0; i < dates.length; i += 7) {
+    const chunk = dates.slice(i, i + 7);
+    weeks.push({ label: formatHeader(chunk[0]), dates: chunk });
+  }
+  return weeks;
+}
+
+// Map completion count (0–7) to an opacity class
+function countToOpacity(count: number, total: number): string {
+  if (total === 0) return "opacity-20";
+  const ratio = count / total;
+  if (ratio === 0) return "opacity-20";
+  if (ratio <= 0.3) return "opacity-40";
+  if (ratio <= 0.57) return "opacity-60";
+  if (ratio <= 0.86) return "opacity-80";
+  return "opacity-100";
+}
+
+export default function HabitHistory({ habits, logs, dates, range }: Props) {
   const logMap = new Map(logs.map((l) => [`${l.habit_id}:${l.date}`, l.completed]));
+
+  if (range === 90) {
+    const weeks = groupByWeek(dates);
+    return (
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr>
+              <th className="text-left text-neutral-500 font-normal pb-2 pr-4 w-32">Habit</th>
+              {weeks.map((w) => (
+                <th key={w.label} className="text-neutral-500 font-normal pb-2 px-1 text-center whitespace-nowrap">
+                  {w.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {habits.map((h) => (
+              <tr key={h.id}>
+                <td className="text-neutral-400 py-1.5 pr-4 truncate max-w-[8rem]">
+                  {h.emoji} {h.name}
+                </td>
+                {weeks.map((w) => {
+                  const count = w.dates.filter((d) => logMap.get(`${h.id}:${d}`) === true).length;
+                  const total = w.dates.length;
+                  return (
+                    <td key={w.label} className="py-1.5 px-1 text-center">
+                      <span
+                        className={`inline-flex items-center justify-center w-6 h-5 rounded text-neutral-100 bg-neutral-100 text-[10px] font-medium ${countToOpacity(count, total)}`}
+                        title={`${count}/${total} days`}
+                      >
+                        {count > 0 ? count : ""}
+                      </span>
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
 
   return (
     <div className="overflow-x-auto">
@@ -16,8 +87,8 @@ export default function HabitHistory({ habits, logs, dates }: Props) {
           <tr>
             <th className="text-left text-neutral-500 font-normal pb-2 pr-4 w-32">Habit</th>
             {dates.map((d) => (
-              <th key={d} className="text-neutral-500 font-normal pb-2 px-1 text-center">
-                {new Date(d + "T00:00:00").toLocaleDateString("en-US", { weekday: "short" }).slice(0, 1)}
+              <th key={d} className="text-neutral-500 font-normal pb-2 px-1 text-center whitespace-nowrap">
+                {formatHeader(d)}
               </th>
             ))}
           </tr>

--- a/web/src/components/habits/habit-range-toggle.tsx
+++ b/web/src/components/habits/habit-range-toggle.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+const RANGES = [7, 30, 90] as const;
+
+interface Props {
+  current: number;
+}
+
+export default function HabitRangeToggle({ current }: Props) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  function setRange(n: number) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("range", String(n));
+    router.push(`/habits?${params.toString()}`);
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      {RANGES.map((r) => (
+        <button
+          key={r}
+          onClick={() => setRange(r)}
+          className={`text-xs px-2 py-0.5 rounded transition-colors ${
+            current === r
+              ? "bg-neutral-700 text-neutral-100"
+              : "text-neutral-500 hover:text-neutral-300"
+          }`}
+        >
+          {r}d
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/habits/habit-today-section.tsx
+++ b/web/src/components/habits/habit-today-section.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import HabitToggle from "./habit-toggle";
+import type { HabitRegistry, HabitLog } from "@/lib/types";
+
+interface Props {
+  habits: HabitRegistry[];
+  todayLogs: HabitLog[];
+  date: string;
+  toggleAction: (habitId: string, date: string, completed: boolean) => Promise<void>;
+  archiveAction: (habitId: string) => Promise<void>;
+  addAction: (name: string, emoji: string, category: string) => Promise<void>;
+}
+
+export default function HabitTodaySection({
+  habits,
+  todayLogs,
+  date,
+  toggleAction,
+  archiveAction,
+  addAction,
+}: Props) {
+  const todayLogMap = new Map(todayLogs.map((l) => [l.habit_id, l]));
+
+  const [manageMode, setManageMode] = useState(false);
+  const [showAdd, setShowAdd] = useState(false);
+  const [name, setName] = useState("");
+  const [emoji, setEmoji] = useState("");
+  const [category, setCategory] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  function handleAdd() {
+    if (!name.trim()) return;
+    startTransition(async () => {
+      await addAction(name, emoji, category);
+      setName("");
+      setEmoji("");
+      setCategory("");
+      setShowAdd(false);
+    });
+  }
+
+  function handleCancel() {
+    setName("");
+    setEmoji("");
+    setCategory("");
+    setShowAdd(false);
+  }
+
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-xs text-neutral-500 uppercase tracking-wide">Today</h2>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => {
+              setManageMode((m) => !m);
+              setShowAdd(false);
+            }}
+            className={`text-xs px-2 py-0.5 rounded transition-colors ${
+              manageMode
+                ? "bg-neutral-700 text-neutral-200"
+                : "text-neutral-500 hover:text-neutral-300"
+            }`}
+          >
+            Manage
+          </button>
+          <button
+            onClick={() => {
+              setShowAdd((s) => !s);
+              setManageMode(false);
+            }}
+            className={`text-xs px-2 py-0.5 rounded transition-colors ${
+              showAdd
+                ? "bg-neutral-700 text-neutral-200"
+                : "text-neutral-500 hover:text-neutral-300"
+            }`}
+          >
+            + Add
+          </button>
+        </div>
+      </div>
+
+      <div className="divide-y divide-neutral-800/50">
+        {habits.map((habit) => (
+          <HabitToggle
+            key={habit.id}
+            habit={habit}
+            log={todayLogMap.get(habit.id)}
+            toggleAction={toggleAction}
+            date={date}
+            manageMode={manageMode}
+            archiveAction={archiveAction}
+          />
+        ))}
+        {habits.length === 0 && !showAdd && (
+          <p className="text-sm text-neutral-600 py-4">No habits configured.</p>
+        )}
+      </div>
+
+      {showAdd && (
+        <div className="mt-3 flex flex-wrap items-center gap-2 py-3 border-t border-neutral-800/50">
+          <input
+            type="text"
+            placeholder="Emoji"
+            value={emoji}
+            onChange={(e) => setEmoji(e.target.value)}
+            maxLength={4}
+            className="w-14 bg-neutral-800 text-neutral-100 text-sm rounded px-2 py-1.5 placeholder-neutral-600 focus:outline-none focus:ring-1 focus:ring-neutral-600"
+          />
+          <input
+            type="text"
+            placeholder="Habit name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="flex-1 min-w-[120px] bg-neutral-800 text-neutral-100 text-sm rounded px-2 py-1.5 placeholder-neutral-600 focus:outline-none focus:ring-1 focus:ring-neutral-600"
+          />
+          <input
+            type="text"
+            placeholder="Category"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            className="w-28 bg-neutral-800 text-neutral-100 text-sm rounded px-2 py-1.5 placeholder-neutral-600 focus:outline-none focus:ring-1 focus:ring-neutral-600"
+          />
+          <button
+            onClick={handleAdd}
+            disabled={!name.trim() || isPending}
+            className="text-xs px-3 py-1.5 bg-neutral-700 text-neutral-100 rounded hover:bg-neutral-600 disabled:opacity-40 transition-colors"
+          >
+            Save
+          </button>
+          <button
+            onClick={handleCancel}
+            className="text-xs px-2 py-1.5 text-neutral-500 hover:text-neutral-300 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/web/src/components/habits/habit-toggle.tsx
+++ b/web/src/components/habits/habit-toggle.tsx
@@ -8,11 +8,21 @@ interface Props {
   log: HabitLog | undefined;
   toggleAction: (habitId: string, date: string, completed: boolean) => Promise<void>;
   date: string;
+  manageMode?: boolean;
+  archiveAction?: (habitId: string) => Promise<void>;
 }
 
-export default function HabitToggle({ habit, log, toggleAction, date }: Props) {
+export default function HabitToggle({
+  habit,
+  log,
+  toggleAction,
+  date,
+  manageMode,
+  archiveAction,
+}: Props) {
   const [optimistic, setOptimistic] = useState<boolean | undefined>(log?.completed);
   const [isPending, startTransition] = useTransition();
+  const [archivePending, startArchiveTransition] = useTransition();
 
   const completed = optimistic ?? false;
 
@@ -28,31 +38,56 @@ export default function HabitToggle({ habit, log, toggleAction, date }: Props) {
     });
   }
 
+  function handleArchive(e: React.MouseEvent) {
+    e.stopPropagation();
+    if (!archiveAction) return;
+    startArchiveTransition(async () => {
+      await archiveAction(habit.id);
+    });
+  }
+
   return (
     <button
       onClick={handleToggle}
-      disabled={isPending}
+      disabled={isPending || archivePending}
       className="w-full flex items-center gap-3 py-3 px-1 text-left hover:bg-neutral-800/50 rounded-lg transition-colors disabled:opacity-60"
     >
       <span
         className={`w-5 h-5 rounded-md border flex items-center justify-center flex-shrink-0 transition-colors ${
-          completed
-            ? "bg-blue-500 border-blue-500"
-            : "border-neutral-600"
+          completed ? "bg-blue-500 border-blue-500" : "border-neutral-600"
         }`}
       >
         {completed && (
           <svg className="w-3 h-3 text-white" viewBox="0 0 12 12" fill="none">
-            <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+            <path
+              d="M2 6l3 3 5-5"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
           </svg>
         )}
       </span>
       <span className="text-lg leading-none">{habit.emoji}</span>
-      <span className={`text-sm ${completed ? "text-neutral-500 line-through" : "text-neutral-200"}`}>
+      <span
+        className={`text-sm ${completed ? "text-neutral-500 line-through" : "text-neutral-200"}`}
+      >
         {habit.name}
       </span>
-      {habit.category && (
-        <span className="ml-auto text-xs text-neutral-600">{habit.category}</span>
+      {manageMode && archiveAction ? (
+        <span
+          role="button"
+          onClick={handleArchive}
+          className="ml-auto text-xs text-neutral-600 hover:text-red-400 px-1 transition-colors"
+          title="Archive habit"
+        >
+          ✕
+        </span>
+      ) : (
+        habit.category && (
+          <span className="ml-auto text-xs text-neutral-600">{habit.category}</span>
+        )
       )}
     </button>
   );

--- a/web/src/components/habits/habit-toggle.tsx
+++ b/web/src/components/habits/habit-toggle.tsx
@@ -38,8 +38,7 @@ export default function HabitToggle({
     });
   }
 
-  function handleArchive(e: React.MouseEvent) {
-    e.stopPropagation();
+  function handleArchive() {
     if (!archiveAction) return;
     startArchiveTransition(async () => {
       await archiveAction(habit.id);
@@ -47,48 +46,49 @@ export default function HabitToggle({
   }
 
   return (
-    <button
-      onClick={handleToggle}
-      disabled={isPending || archivePending}
-      className="w-full flex items-center gap-3 py-3 px-1 text-left hover:bg-neutral-800/50 rounded-lg transition-colors disabled:opacity-60"
-    >
-      <span
-        className={`w-5 h-5 rounded-md border flex items-center justify-center flex-shrink-0 transition-colors ${
-          completed ? "bg-blue-500 border-blue-500" : "border-neutral-600"
-        }`}
+    <div className={`flex items-center ${isPending || archivePending ? "opacity-60" : ""}`}>
+      <button
+        onClick={handleToggle}
+        disabled={isPending || archivePending}
+        className="flex-1 flex items-center gap-3 py-3 px-1 text-left hover:bg-neutral-800/50 rounded-lg transition-colors"
       >
-        {completed && (
-          <svg className="w-3 h-3 text-white" viewBox="0 0 12 12" fill="none">
-            <path
-              d="M2 6l3 3 5-5"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        )}
-      </span>
-      <span className="text-lg leading-none">{habit.emoji}</span>
-      <span
-        className={`text-sm ${completed ? "text-neutral-500 line-through" : "text-neutral-200"}`}
-      >
-        {habit.name}
-      </span>
-      {manageMode && archiveAction ? (
         <span
-          role="button"
+          className={`w-5 h-5 rounded-md border flex items-center justify-center flex-shrink-0 transition-colors ${
+            completed ? "bg-blue-500 border-blue-500" : "border-neutral-600"
+          }`}
+        >
+          {completed && (
+            <svg className="w-3 h-3 text-white" viewBox="0 0 12 12" fill="none">
+              <path
+                d="M2 6l3 3 5-5"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          )}
+        </span>
+        <span className="text-lg leading-none">{habit.emoji}</span>
+        <span
+          className={`text-sm ${completed ? "text-neutral-500 line-through" : "text-neutral-200"}`}
+        >
+          {habit.name}
+        </span>
+        {!manageMode && habit.category && (
+          <span className="ml-auto text-xs text-neutral-600">{habit.category}</span>
+        )}
+      </button>
+      {manageMode && archiveAction ? (
+        <button
           onClick={handleArchive}
-          className="ml-auto text-xs text-neutral-600 hover:text-red-400 px-1 transition-colors"
+          disabled={archivePending}
+          className="ml-2 text-xs text-neutral-600 hover:text-red-400 px-1 py-3 transition-colors disabled:opacity-40"
           title="Archive habit"
         >
           ✕
-        </span>
-      ) : (
-        habit.category && (
-          <span className="ml-auto text-xs text-neutral-600">{habit.category}</span>
-        )
-      )}
-    </button>
+        </button>
+      ) : null}
+    </div>
   );
 }

--- a/web/src/lib/timezone.ts
+++ b/web/src/lib/timezone.ts
@@ -7,13 +7,18 @@ export function todayString(tz = USER_TZ): string {
 
 /**
  * Returns the last N days as YYYY-MM-DD strings in the user's timezone,
- * oldest first. Default 7 days (index 0 = 6 days ago, index 6 = today).
+ * oldest first (index 0 = N-1 days ago, last index = today).
  */
-export function getLast7Days(tz = USER_TZ): string[] {
-  return Array.from({ length: 7 }, (_, i) => {
-    const d = new Date(Date.now() - (6 - i) * 86_400_000);
+export function getLastNDays(n: number, tz = USER_TZ): string[] {
+  return Array.from({ length: n }, (_, i) => {
+    const d = new Date(Date.now() - (n - 1 - i) * 86_400_000);
     return new Intl.DateTimeFormat("en-CA", { timeZone: tz }).format(d);
   });
+}
+
+/** Returns the last 7 days as YYYY-MM-DD strings in the user's timezone. */
+export function getLast7Days(tz = USER_TZ): string[] {
+  return getLastNDays(7, tz);
 }
 
 /** Returns a YYYY-MM-DD string for N days ago in the user's timezone. */


### PR DESCRIPTION
## Summary

- **Add/archive habits**: new inline UI on the habits page — a `+ Add` button reveals an emoji/name/category form that inserts into `habit_registry`; a `Manage` toggle shows `✕` archive buttons on each row (sets `active = false`, history preserved)
- **Range toggle**: 7d / 30d / 90d pill selector persisted via `?range` URL param (default 30); data fetched server-side per range
- **Readable date headers**: history grid columns now show `Apr 5`-style labels instead of single letters
- **90-day weekly view**: at 90d, condenses to ~13 weekly columns with completion-count badges (opacity-scaled by ratio)

## Files changed

| File | Change |
|------|--------|
| `web/src/lib/timezone.ts` | Add `getLastNDays(n)` |
| `web/src/app/(protected)/habits/page.tsx` | `addHabit` + `archiveHabit` server actions; `searchParams.range` support |
| `web/src/components/habits/habit-today-section.tsx` | New — client wrapper: manage mode, add form |
| `web/src/components/habits/habit-range-toggle.tsx` | New — 7d/30d/90d URL-based toggle |
| `web/src/components/habits/habit-toggle.tsx` | `manageMode` + `archiveAction` props |
| `web/src/components/habits/habit-history.tsx` | Date labels + weekly condensed view at 90d |
| `CHANGELOG.md` / `README.md` | Updated |

## Test plan

- [ ] Add a habit via form → shows up in today's list and history grid immediately
- [ ] Archive a habit → removed from active list; history rows preserved
- [ ] Range toggle 7d / 30d / 90d → URL updates, data and grid rerender correctly
- [ ] 30d headers show `Apr 5`-style dates; horizontal scroll works
- [ ] 90d view renders weekly columns with count badges
- [ ] Existing habit toggle (complete/uncomplete) still works with optimistic UI

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)