### PR TITLE
chore: make repo user-agnostic and add name personalisation

### DIFF
--- a/.claude/agents/journal-reminder.md
+++ b/.claude/agents/journal-reminder.md
@@ -1,6 +1,6 @@
 ---
 name: journal-reminder
-description: 7 PM daily journal reminder. Checks if Jason has journaled today; sends a push notification only if he hasn't.
+description: 7 PM daily journal reminder. Checks if the user has journaled today; sends a push notification only if they haven't.
 tools:
   - Bash(bash *)
 model: haiku
@@ -9,13 +9,13 @@ maxTurns: 5
 ---
 
 ## Purpose
-At 7 PM, check whether a journal entry exists for today in Supabase. If not, send a push notification reminding Jason to journal.
+At 7 PM, check whether a journal entry exists for today in Supabase. If not, send a push notification reminding you to journal.
 
 ## Instructions
 
 1. Check for today's journal entry by running:
    ```bash
-   cd "/Users/jason/Code Projects/mr-bridge-assistant" && python3 - <<'EOF'
+   python3 - <<'EOF'
    import sys, os, datetime
    sys.path.insert(0, "scripts")
    from _supabase import get_client
@@ -30,7 +30,7 @@ At 7 PM, check whether a journal entry exists for today in Supabase. If not, sen
    - If output is `exists` → do nothing. Entry already saved for today.
    - If output is `missing` → send a push notification:
      ```bash
-     bash "/Users/jason/Code Projects/mr-bridge-assistant/scripts/notify.sh" \
+     bash scripts/notify.sh \
        --title "Journal Reminder" \
        --message "Have you journaled today? Take 5 minutes before bed."
      ```

--- a/.claude/agents/morning-nudge.md
+++ b/.claude/agents/morning-nudge.md
@@ -1,6 +1,6 @@
 ---
 name: morning-nudge
-description: Morning session nudge agent. Fires a macOS push notification reminding Jason to open a Mr. Bridge session. Run at 8am daily.
+description: Morning session nudge agent. Fires a macOS push notification reminding you to open a Mr. Bridge session. Run at 8am daily.
 tools:
   - Bash(bash *)
 model: haiku
@@ -9,16 +9,16 @@ maxTurns: 3
 ---
 
 ## Purpose
-Fire a macOS push notification nudging Jason to open a Mr. Bridge session for the day, then check for any birthdays today and send a separate notification for each.
+Fire a macOS push notification nudging you to open a Mr. Bridge session for the day, then check for any birthdays today and send a separate notification for each.
 
 ## Instructions
 
 1. Run:
    ```bash
-   bash "/Users/jason/Code Projects/mr-bridge-assistant/scripts/notify.sh" --title "Mr. Bridge" --message "Morning. Open Claude Code to start your session."
+   bash scripts/notify.sh --title "Mr. Bridge" --message "Morning. Open Claude Code to start your session."
    ```
 2. Run (non-fatal — errors do not block completion):
    ```bash
-   python3 "/Users/jason/Code Projects/mr-bridge-assistant/scripts/check_birthday_notif.py"
+   python3 scripts/check_birthday_notif.py
    ```
 3. No memory reads or writes. Notifications only.

--- a/.claude/agents/nightly-postmortem.md
+++ b/.claude/agents/nightly-postmortem.md
@@ -23,6 +23,6 @@ Read today's habit log and fire a macOS push notification summarizing the day.
    - No entry for today: "No habits logged today."
 5. Run:
    ```bash
-   bash "/Users/jason/Code Projects/mr-bridge-assistant/scripts/notify.sh" --title "Mr. Bridge — Nightly Check-In" --message "<summary>"
+   bash scripts/notify.sh --title "Mr. Bridge — Nightly Check-In" --message "<summary>"
    ```
 6. Read only — do not write to any memory files.

--- a/.claude/agents/weekly-review.md
+++ b/.claude/agents/weekly-review.md
@@ -68,7 +68,7 @@ Compute a weekly summary of habits, study time, and tasks. Output to terminal an
 
 8. Send push notification (headline only):
 ```bash
-bash "/Users/jason/Code Projects/mr-bridge-assistant/scripts/notify.sh" \
+bash scripts/notify.sh \
   --title "Mr. Bridge — Weekly Review" \
   --message "Habits X% | Workouts X/4 | Japanese Xmin"
 ```

--- a/.claude/rules/mr-bridge-rules.md
+++ b/.claude/rules/mr-bridge-rules.md
@@ -2,8 +2,23 @@
 
 ## Identity
 - Name: Mr. Bridge
-- Role: Jason's personal AI assistant
+- Role: Your personal AI assistant
 - Style: Direct, structured, high-density, no filler, no emojis, no motivational language
+
+## Name Usage
+After reading the briefing output, check the PROFILE section for a `name` key.
+- If found: address the user by that name throughout the session (e.g. "Morning, Alex." in the briefing header, naturally in responses — not after every sentence).
+- If not found: at the end of the briefing, ask: "What should I call you?" Then store the answer:
+  ```bash
+  python3 - <<'EOF'
+  import sys
+  sys.path.insert(0, "scripts")
+  from _supabase import get_client
+  client = get_client()
+  client.table("profile").upsert({"key": "name", "value": "<name>"}, on_conflict="key").execute()
+  print("Name saved.")
+  EOF
+  ```
 
 ## Session Start Protocol
 Execute in this exact order:
@@ -20,10 +35,10 @@ Execute in this exact order:
    ```
    Read the output — it contains profile, tasks, habits, body composition, workouts, recovery, study log, and recent meals.
 3. Fetch today's Google Calendar events using `List Calendar Events` (claude.ai Google Calendar MCP)
-   — includes both personal (jaydud6) and professional (leung.ss.jason, shared) calendars — note the calendar/account source for each event
+   — includes your primary calendar and any shared/secondary calendars — note the calendar/account source for each event
 3b. Fetch upcoming birthdays: call `List Calendar Events` for the next **7 days** (timeMin = today, timeMax = today+7 days). Filter for events whose title matches `'s birthday` (case-insensitive) or whose calendar name contains "birthday". For each match, compute days_until = event date − today (0 = today, 1 = tomorrow, etc.). Strip the "'s birthday" suffix when displaying the person's name.
 4. Search for important unread emails using `Search Gmail Emails` (claude.ai Gmail MCP) — filter: unread, subjects containing meeting / urgent / invoice / action required / deadline
-   — jaydud6 = personal (primary); leung.ss.jason = professional (aggregated via POP3, Gmail label: "professional") — note account source when surfacing emails
+   — note account source when surfacing emails; secondary accounts aggregated via POP3 are labeled (e.g. "Professional") in your primary inbox
 5. Deliver session briefing (format below)
 
 ## Session Briefing Format
@@ -121,10 +136,10 @@ When operating in voice context (responses will be spoken aloud):
 - After any Supabase write: confirm to user what was written and to which table
 
 ## Study Timer Rules
-- Only offer to start a timer when Jason explicitly says he's starting a study session (e.g. "starting Japanese now", "about to do boot.dev", "starting a coding session")
+- Only offer to start a timer when you explicitly say you're starting a study session (e.g. "starting Japanese now", "about to do boot.dev", "starting a coding session")
 - Ask: "Start a study timer for [subject]?"
 - On confirmation, use the study-timer agent to write `memory/timer_state.json`
-- When Jason says "done", "stopping", or "finished studying", stop the timer and log duration to `memory/todo.md`
+- When you say "done", "stopping", or "finished studying", stop the timer and log duration to `memory/todo.md`
 - If a timer is running at session start, flag it in the briefing: "Timer still running: [subject] — started [time]"
 
 ## Data Sources

--- a/.claude/skills/log-habit/SKILL.md
+++ b/.claude/skills/log-habit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: log-habit
-description: Logs one or more habit completions to Supabase for today's date. Call when Jason reports completing a habit during a session.
+description: Logs one or more habit completions to Supabase for today's date. Call when the user reports completing a habit during a session.
 allowed-tools:
   - Bash
 user-invocable: false

--- a/.claude/skills/send-notification/SKILL.md
+++ b/.claude/skills/send-notification/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: send-notification
-description: Sends a macOS push notification via scripts/notify.sh. Accepts a title and message. Used by agents and commands to surface alerts to Jason.
+description: Sends a macOS push notification via scripts/notify.sh. Accepts a title and message. Used by agents and commands to surface alerts to the user.
 allowed-tools:
   - Bash(bash *)
 user-invocable: false
@@ -13,7 +13,7 @@ Send a macOS push notification using the Mr. Bridge notification script.
 Run the following, substituting the provided title and message:
 
 ```bash
-bash "/Users/jason/Code Projects/mr-bridge-assistant/scripts/notify.sh" \
+bash scripts/notify.sh \
   --title "<title>" \
   --message "<message>"
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,14 +289,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ---
 
-[Unreleased]: https://github.com/Theioz/mr-bridge-assistant/compare/v0.10.0...HEAD
-[0.10.0]: https://github.com/Theioz/mr-bridge-assistant/compare/v0.9.0...v0.10.0
-[0.9.0]: https://github.com/Theioz/mr-bridge-assistant/compare/v0.8.0...v0.9.0
-[0.8.0]: https://github.com/Theioz/mr-bridge-assistant/compare/v0.7.0...v0.8.0
-[0.7.0]: https://github.com/Theioz/mr-bridge-assistant/compare/v0.6.0...v0.7.0
-[0.6.0]: https://github.com/Theioz/mr-bridge-assistant/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/Theioz/mr-bridge-assistant/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/Theioz/mr-bridge-assistant/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/Theioz/mr-bridge-assistant/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/Theioz/mr-bridge-assistant/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/Theioz/mr-bridge-assistant/releases/tag/v0.1.0
+[Unreleased]: https://github.com/<your-username>/mr-bridge-assistant/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/<your-username>/mr-bridge-assistant/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/<your-username>/mr-bridge-assistant/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/<your-username>/mr-bridge-assistant/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/<your-username>/mr-bridge-assistant/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/<your-username>/mr-bridge-assistant/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/<your-username>/mr-bridge-assistant/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/<your-username>/mr-bridge-assistant/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/<your-username>/mr-bridge-assistant/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/<your-username>/mr-bridge-assistant/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/<your-username>/mr-bridge-assistant/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ mr-bridge-assistant/
 
 ### 1. Clone the repo
 ```bash
-git clone --recurse-submodules https://github.com/Theioz/mr-bridge-assistant.git
+git clone --recurse-submodules https://github.com/<your-username>/mr-bridge-assistant.git
 cd mr-bridge-assistant
 ```
 
@@ -278,7 +278,7 @@ git checkout -b feature/<name>
 ```
 
 After implementation, open a PR — direct pushes to `main` are blocked by branch protection.
-Feature backlog is tracked via [GitHub Issues](https://github.com/Theioz/mr-bridge-assistant/issues).
+Feature backlog is tracked via GitHub Issues in your fork.
 
 ## Web Interface
 
@@ -322,3 +322,7 @@ python voice/bridge_voice.py
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md) for full version history.
+
+---
+
+<sub>Originally built by [Jason Leung](https://github.com/Theioz).</sub>

--- a/docs/fitness-tracker-setup.md
+++ b/docs/fitness-tracker-setup.md
@@ -1,6 +1,6 @@
 # Fitness Tracker Setup
 
-Three sync scripts pull data into `memory/fitness_log.md`. Run them manually before sessions to get fresh data.
+Three sync scripts pull data from fitness APIs and write directly to Supabase. Run them manually before sessions to get fresh data.
 
 ---
 
@@ -15,7 +15,6 @@ Google Fit scopes were added to the refresh token during setup (see `docs/google
 
 **Run:**
 ```bash
-cd "/Users/jason/Code Projects/mr-bridge-assistant"
 python3 scripts/sync-googlefit.py           # last 7 days (default)
 python3 scripts/sync-googlefit.py --days 30 # last 30 days
 ```
@@ -79,7 +78,7 @@ python3 scripts/sync-oura.py           # last 7 days (default)
 python3 scripts/sync-oura.py --days 30  # last 30 days
 ```
 
-**Recovery Metrics written to fitness_log.md:**
+**Recovery Metrics written to `recovery_metrics` table in Supabase:**
 | Column | Source |
 |--------|--------|
 | Readiness | `/daily_readiness` score (0–100) |
@@ -125,9 +124,4 @@ Run Renpho sync after each weigh-in (weekly or as needed):
 python3 scripts/sync-renpho.py ~/Downloads/renpho_export.csv
 ```
 
-After syncing, commit the updated fitness_log.md:
-```bash
-git add memory/fitness_log.md
-git commit -m "sync: fitness data $(date +%Y-%m-%d)"
-git push
-```
+All sync data writes to Supabase — no file commits needed.

--- a/docs/gmail-multi-account.md
+++ b/docs/gmail-multi-account.md
@@ -1,40 +1,42 @@
 # Gmail & Calendar — Multi-Account Setup
 
-Covers how `jaydud6@gmail.com` (personal, primary) and `leung.ss.jason@gmail.com` (professional) are unified into a single Mr. Bridge session. The OAuth token stays on `jaydud6@gmail.com` — no second credential set is required.
+Covers how a primary Gmail account and a secondary (e.g. professional) Gmail account are unified into a single Mr. Bridge session. The OAuth token stays on your primary account — no second credential set is required.
+
+Replace `<your-primary@gmail.com>` and `<your-secondary@gmail.com>` with your actual addresses throughout this guide.
 
 ---
 
 ## Gmail — POP3 aggregation
 
-Gmail's "Check mail from other accounts" pulls `leung.ss.jason@gmail.com` into `jaydud6@gmail.com` via POP3. Professional emails land in the personal inbox with a `Professional` label, which the dashboard uses to badge them as `work`.
+Gmail's "Check mail from other accounts" pulls your secondary account into your primary inbox via POP3. Secondary emails land in the primary inbox with a `Professional` label, which the dashboard uses to badge them as `work`.
 
 > **Note:** Gmailify (Google's OAuth-based import) does not accept normal Google passwords and requires an OAuth flow that is not straightforward to complete. Use POP3 instead.
 
-### Step 1 — Enable POP3 on leung.ss.jason
+### Step 1 — Enable POP3 on your secondary account
 
-1. Sign into `leung.ss.jason@gmail.com`
+1. Sign into `<your-secondary@gmail.com>`
 2. Settings (gear) → **See all settings** → **Forwarding and POP/IMAP** tab
 3. Under **POP Download** → select **Enable POP for all mail**
 4. Save changes
 
-### Step 2 — Generate an App Password for leung.ss.jason
+### Step 2 — Generate an App Password for your secondary account
 
 Gmail's POP3 requires an App Password, not your regular account password (this is true even if 2-Step Verification was already enabled).
 
-1. Go to **myaccount.google.com** while signed into `leung.ss.jason@gmail.com`
+1. Go to **myaccount.google.com** while signed into `<your-secondary@gmail.com>`
 2. Security → **2-Step Verification** — enable it if not already on
 3. Search for **"App passwords"** at the top of the page
 4. Create a new App Password (name it anything, e.g. "Mr Bridge POP3")
 5. Copy the 16-character code — you'll use it in the next step
 
-### Step 3 — Add leung.ss.jason as a mail source in jaydud6
+### Step 3 — Add your secondary account as a mail source in your primary
 
-1. Sign into `jaydud6@gmail.com`
+1. Sign into `<your-primary@gmail.com>`
 2. Settings → **See all settings** → **Accounts and Import** tab
 3. Under **Check mail from other accounts** → click **Add a mail account**
-4. Enter `leung.ss.jason@gmail.com` → Next → select **Import emails from my other account (Gmailify)** if offered, or choose **POP3**
+4. Enter `<your-secondary@gmail.com>` → Next → select **Import emails from my other account (Gmailify)** if offered, or choose **POP3**
 5. Use these POP3 settings:
-   - **Username:** `leung.ss.jason@gmail.com`
+   - **Username:** `<your-secondary@gmail.com>`
    - **Password:** the 16-character App Password from Step 2
    - **POP Server:** `pop.gmail.com`
    - **Port:** `995`
@@ -45,9 +47,9 @@ Gmail's POP3 requires an App Password, not your regular account password (this i
 
 ### Step 4 — Verify
 
-- In jaydud6's Gmail settings, click **Check mail now** next to `leung.ss.jason@gmail.com (POP3)` to trigger an immediate pull
-- Send a test email to `leung.ss.jason@gmail.com` with subject `urgent: test`
-- It should appear in `jaydud6@gmail.com`'s inbox within seconds (after "Check mail now") or within 30–60 min on the normal polling schedule
+- In your primary Gmail settings, click **Check mail now** next to your secondary address to trigger an immediate pull
+- Send a test email to `<your-secondary@gmail.com>` with subject `urgent: test`
+- It should appear in your primary inbox within seconds (after "Check mail now") or within 30–60 min on the normal polling schedule
 - Confirm it has the `Professional` label applied
 
 ### Sync delay
@@ -56,11 +58,11 @@ POP3 polls approximately every 30–60 minutes. Not real-time. Acceptable for se
 
 ### How emails surface in Mr. Bridge
 
-| Email type | Source | Label in jaydud6 | Dashboard? |
+| Email type | Source | Label in primary inbox | Dashboard? |
 |---|---|---|---|
-| Personal, high-signal | jaydud6 directly | none | Yes, if subject matches filter |
-| Professional | leung.ss.jason via POP3 | `Professional` | Yes, if subject matches filter — shown with `work` badge |
-| Personal, noise | jaydud6 directly | none | No — subject keyword filter blocks it |
+| Personal, high-signal | primary directly | none | Yes, if subject matches filter |
+| Professional | secondary via POP3 | `Professional` | Yes, if subject matches filter — shown with `work` badge |
+| Personal, noise | primary directly | none | No — subject keyword filter blocks it |
 
 **Dashboard query:** `is:unread subject:(meeting OR urgent OR invoice OR "action required" OR deadline)`
 
@@ -70,34 +72,34 @@ POP3 polls approximately every 30–60 minutes. Not real-time. Acceptable for se
 
 ## Google Calendar — Calendar sharing
 
-The professional calendar is shared with `jaydud6@gmail.com`. The existing OAuth token sees all calendars including shared ones. Calendar sharing is real-time — no sync delay.
+The secondary calendar is shared with your primary account. The existing OAuth token sees all calendars including shared ones. Calendar sharing is real-time — no sync delay.
 
-### Step 1 — Share leung.ss.jason's calendar with jaydud6
+### Step 1 — Share your secondary calendar with your primary account
 
-1. Sign into `leung.ss.jason@gmail.com` → **calendar.google.com**
+1. Sign into `<your-secondary@gmail.com>` → **calendar.google.com**
 2. Settings (gear) → **Settings**
-3. In the left sidebar under **Settings for my calendars** → click **Jason Leung** (or the calendar name)
+3. In the left sidebar under **Settings for my calendars** → click your calendar name
 4. Under **Share with specific people or groups** → click **Add people and groups**
-5. Enter `jaydud6@gmail.com`, set permission to **See all event details** → Send
+5. Enter `<your-primary@gmail.com>`, set permission to **See all event details** → Send
 6. Repeat for any other calendars to share (work project calendars, etc.)
 
-### Step 2 — Accept the shared calendar in jaydud6
+### Step 2 — Accept the shared calendar in your primary account
 
-- A sharing invite arrives as an email to `jaydud6@gmail.com` — click **Accept**
-- Or: open Google Calendar as jaydud6 and look for the calendar under **Other calendars** in the sidebar
+- A sharing invite arrives as an email to `<your-primary@gmail.com>` — click **Accept**
+- Or: open Google Calendar as your primary account and look for the calendar under **Other calendars** in the sidebar
 
 ### Step 3 — Verify
 
-1. Create a test event in `leung.ss.jason@gmail.com`'s calendar
-2. Confirm it appears immediately in `jaydud6@gmail.com`'s Google Calendar view
+1. Create a test event in your secondary account's calendar
+2. Confirm it appears immediately in your primary account's Google Calendar view
 3. Open the Mr. Bridge web dashboard → Schedule Today card should show the event with the calendar name shown as a subtitle
 
 ### How events surface in Mr. Bridge
 
-`/api/google/calendar` lists all calendars accessible to `jaydud6@gmail.com` (primary + shared) and unions their events for today. Events are re-sorted by start time after the merge. Each event includes:
+`/api/google/calendar` lists all calendars accessible to your primary account (primary + shared) and unions their events for today. Events are re-sorted by start time after the merge. Each event includes:
 
-- `calendarName` — the name of the calendar it came from (e.g. "Jason Leung")
-- `isPrimary` — `true` only for jaydud6's own primary calendar
+- `calendarName` — the name of the calendar it came from
+- `isPrimary` — `true` only for your primary calendar
 
 Non-primary calendar events show the `calendarName` as a subtitle in the Schedule Today dashboard card for source attribution.
 
@@ -108,4 +110,4 @@ Non-primary calendar events show the `calendarName` as a subtitle in the Schedul
 Steps 4 and 5 of the Session Start Protocol reflect multi-account coverage:
 
 - **Calendar**: `List Calendar Events` returns events from all connected calendars. Note the source for non-primary events.
-- **Gmail**: `Search Gmail Emails` covers both accounts (professional emails arrive via POP3 with label `Professional`). Note "personal" or "work" when surfacing emails in the briefing.
+- **Gmail**: `Search Gmail Emails` covers both accounts (secondary emails arrive via POP3 with label `Professional`). Note "personal" or "work" when surfacing emails in the briefing.

--- a/docs/google-oauth-setup.md
+++ b/docs/google-oauth-setup.md
@@ -20,7 +20,7 @@ These credentials are **not needed for the Claude Code CLI** (which uses claude.
 Download `credentials.json` from the OAuth client (Actions → Download JSON) and place it at the project root, then run:
 
 ```bash
-cd "/Users/jason/Code Projects/mr-bridge-assistant"
+cd /path/to/mr-bridge-assistant
 python3 - <<'EOF'
 import json
 from google_auth_oauthlib.flow import InstalledAppFlow

--- a/docs/notifications-setup.md
+++ b/docs/notifications-setup.md
@@ -50,7 +50,7 @@ Optionally install ntfy-desktop for a unified cross-platform experience:
 Once any device is set up, test from your Mac terminal:
 
 ```bash
-cd "/Users/jason/Code Projects/mr-bridge-assistant"
+cd /path/to/mr-bridge-assistant
 bash scripts/notify.sh --title "Mr. Bridge" --message "Test notification"
 ```
 

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -36,6 +36,15 @@ export async function POST(req: Request) {
 
   const supabase = createServiceClient();
 
+  // Fetch user name from profile for personalised system prompt
+  let userName: string | null = null;
+  const { data: nameRow } = await supabase
+    .from("profile")
+    .select("value")
+    .eq("key", "name")
+    .maybeSingle();
+  if (nameRow) userName = nameRow.value as string;
+
   // Load the last 20 messages from this session as context
   let contextMessages: { role: "user" | "assistant"; content: string }[] = [];
   if (sessionId) {
@@ -54,12 +63,14 @@ export async function POST(req: Request) {
     }
   }
 
-  const systemPrompt = `You are Mr. Bridge, Jason's personal AI assistant.
+  const userLabel = userName ?? "the user";
+  const systemPrompt = `You are Mr. Bridge, ${userLabel}'s personal AI assistant.
+${userName ? `Address the user as "${userName}" — use their name naturally in conversation, not robotically after every sentence.` : 'If you learn the user\'s name during the conversation, use it naturally going forward.'}
 
 Style: Direct, structured, high-density. No filler, no emojis, no motivational language.
 Quantify wherever possible. Conservative estimates. Lead with the answer, then reasoning.
 
-You have access to Jason's Supabase data via tools. Use them when asked about current data — do not say you lack access.
+You have access to the user's Supabase data via tools. Use them when asked about current data — do not say you lack access.
 
 Tools available:
 - get_tasks: active/completed/archived tasks
@@ -78,9 +89,10 @@ Tools available:
 Recipes and meal planning are in scope. When asked what to cook given ingredients on hand:
 1. Call get_recipes to check for saved recipes that match.
 2. Call get_fitness_summary to pull recent body composition, goals, and workout data — use this to calibrate the recommendation (e.g. prioritize protein post-workout, suggest lower-calorie options if in a deficit phase).
-3. Always provide a concrete recipe recommendation — either from saved recipes or improvised from your own knowledge. Do not redirect to external tools.
-4. Include estimated calories, protein, carbs, and fat for the suggested recipe. Flag if the meal is a poor fit for current fitness context (e.g. high-calorie meal after a rest day, low protein after a hard workout).
-5. Tailor suggestions to Jason's preferences: Korean/SE Asian leaning, high-quality proteins, pantry staples (garlic, gochujang, olive oil, butter, ginger, lemon). Improvise confidently when no saved recipe fits.`;
+3. Call get_profile to check for dietary preferences, pantry staples, and cuisine preferences stored in the user's profile.
+4. Always provide a concrete recipe recommendation — either from saved recipes or improvised from your own knowledge. Do not redirect to external tools.
+5. Include estimated calories, protein, carbs, and fat for the suggested recipe. Flag if the meal is a poor fit for current fitness context (e.g. high-calorie meal after a rest day, low protein after a hard workout).
+6. Improvise confidently when no saved recipe fits, using any dietary preferences from the profile as guidance.`;
 
   // Strip extra fields (parts, id, etc.) that useChat adds — Anthropic only wants role + content
   // Also filter empty-content messages to prevent Anthropic 400 errors

--- a/web/src/app/api/google/calendar/route.ts
+++ b/web/src/app/api/google/calendar/route.ts
@@ -32,7 +32,7 @@ export async function GET() {
     const timeMin = startOfTodayRFC3339();
     const timeMax = endOfTodayRFC3339();
 
-    // List all calendars so events from shared accounts (e.g. leung.ss.jason) are included
+    // List all calendars so events from shared/secondary accounts are included
     const calListRes = await calendar.calendarList.list({ minAccessRole: "reader" });
     const calendars = calListRes.data.items ?? [];
 


### PR DESCRIPTION
## Summary

- **Remove all hardcoded personal paths** — agent/skill files now use relative paths (`scripts/notify.sh`); docs use `/path/to/mr-bridge-assistant` placeholder
- **De-personalise all identity references** — "Jason's personal AI assistant" → "your personal AI assistant" across rules, agents, skills, and the web chat system prompt; `jaydud6` / `leung.ss.jason` email addresses replaced with `<your-primary>` / `<your-secondary>` placeholders throughout `docs/gmail-multi-account.md`
- **GitHub URLs genericised** — README clone URL and all CHANGELOG version comparison links now use `<your-username>` placeholder; hidden credit added in README footer (`Originally built by Jason Leung`)
- **Fix outdated fitness-tracker-setup.md** — references to `memory/fitness_log.md` and the stale `git commit` workflow replaced with Supabase-only language
- **Add first-run name personalisation** — new "Name Usage" rule in `mr-bridge-rules.md`: reads `name` key from the PROFILE section at session start; if missing, asks the user and upserts into the `profile` table. Web chat (`api/chat/route.ts`) fetches the name from Supabase before building the system prompt so responses are personalised (e.g. "Welcome back, Alex.") from the first message

## Test plan

- [ ] Clone into a fresh directory and verify no `/Users/jason` paths appear in any doc or agent file
- [ ] Run `python3 scripts/fetch_briefing_data.py` with no `name` key in the `profile` table — confirm Mr. Bridge asks for a name at end of briefing
- [ ] Add `name` key to the `profile` table and re-run — confirm briefing header uses the name
- [ ] Open web chat with `name` in profile — confirm system prompt includes the name and responses use it naturally
- [ ] Open web chat without `name` in profile — confirm fallback to generic language with no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)