### PR TITLE
feat: parallelize session boot — syncs, briefing queries, MCP calls

### DIFF
--- a/.claude/rules/mr-bridge-rules.md
+++ b/.claude/rules/mr-bridge-rules.md
@@ -23,22 +23,20 @@ After reading the briefing output, check the PROFILE section for a `name` key.
 ## Session Start Protocol
 Execute in this exact order:
 
-1. Run fitness sync scripts to pull fresh data into Supabase (silently, errors are non-fatal — proceed regardless):
+1. Run the fitness sync orchestrator (silently, errors are non-fatal — proceed regardless):
    ```bash
-   python3 scripts/sync-googlefit.py --yes
-   python3 scripts/sync-oura.py --yes
-   python3 scripts/sync-fitbit.py --yes
+   python3 scripts/run-syncs.py
    ```
+   This runs all three sync scripts (google_fit, oura, fitbit) in parallel and skips any source synced within the last 30 minutes.
 2. Fetch all briefing data from Supabase:
    ```bash
    python3 scripts/fetch_briefing_data.py
    ```
    Read the output — it contains profile, tasks, habits, body composition, workouts, recovery, study log, and recent meals.
-3. Fetch today's Google Calendar events using `List Calendar Events` (claude.ai Google Calendar MCP)
-   — includes your primary calendar and any shared/secondary calendars — note the calendar/account source for each event
-3b. Fetch upcoming birthdays: call `List Calendar Events` for the next **7 days** (timeMin = today, timeMax = today+7 days). Filter for events whose title matches `'s birthday` (case-insensitive) or whose calendar name contains "birthday". For each match, compute days_until = event date − today (0 = today, 1 = tomorrow, etc.). Strip the "'s birthday" suffix when displaying the person's name.
-4. Search for important unread emails using `Search Gmail Emails` (claude.ai Gmail MCP) — filter: unread, subjects containing meeting / urgent / invoice / action required / deadline
-   — note account source when surfacing emails; secondary accounts aggregated via POP3 are labeled (e.g. "Professional") in your primary inbox
+3. Issue the following three external fetches **in a single message turn as parallel tool calls** (they are independent — do not run them sequentially):
+   - **Calendar events**: `List Calendar Events` for today (primary + any shared/secondary calendars) — note calendar/account source for each event
+   - **Upcoming birthdays**: `List Calendar Events` for the next 7 days (timeMin = today, timeMax = today+7 days) — filter for titles matching `'s birthday` (case-insensitive) or calendar name containing "birthday"; compute days_until = event date − today; strip "'s birthday" suffix for display
+   - **Important unread emails**: `Search Gmail Emails` — filter: unread, subjects containing meeting / urgent / invoice / action required / deadline — note account source; secondary POP3 accounts are labeled (e.g. "Professional") in your primary inbox
 5. Deliver session briefing (format below)
 
 ## Session Briefing Format

--- a/scripts/fetch_briefing_data.py
+++ b/scripts/fetch_briefing_data.py
@@ -8,6 +8,8 @@ Usage: python3 scripts/fetch_briefing_data.py
 from __future__ import annotations
 
 import sys
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, timedelta
 from pathlib import Path
 
@@ -29,23 +31,160 @@ def main():
     yesterday = str(date.today() - timedelta(days=1))
     seven_days_ago = str(date.today() - timedelta(days=7))
 
-    # ── Profile ────────────────────────────────────────────────────────────────
-    profile_rows = client.table("profile").select("key,value").execute().data
-    profile = {r["key"]: r["value"] for r in profile_rows}
+    # ── Query functions (closures) ─────────────────────────────────────────────
 
+    def q_profile():
+        return client.table("profile").select("key,value").execute().data
+
+    def q_tasks():
+        return (
+            client.table("tasks")
+            .select("title,priority,due_date,status")
+            .eq("status", "active")
+            .order("due_date", desc=False)
+            .execute()
+            .data
+        )
+
+    def q_habit_registry():
+        return client.table("habit_registry").select("id,name").eq("active", True).execute().data
+
+    def q_habits():
+        return (
+            client.table("habits")
+            .select("habit_id,date,completed")
+            .gte("date", seven_days_ago)
+            .lte("date", today)
+            .execute()
+            .data
+        )
+
+    def q_fitness_log():
+        return (
+            client.table("fitness_log")
+            .select("date,weight_lb,body_fat_pct,bmi,muscle_mass_lb,visceral_fat,source")
+            .not_.is_("body_fat_pct", "null")
+            .order("date", desc=True)
+            .limit(2)
+            .execute()
+            .data
+        )
+
+    def q_workout_yesterday():
+        return (
+            client.table("workout_sessions")
+            .select("activity,duration_mins,calories,avg_hr,start_time")
+            .eq("date", yesterday)
+            .order("start_time")
+            .execute()
+            .data
+        )
+
+    def q_workout_today():
+        return (
+            client.table("workout_sessions")
+            .select("activity,duration_mins,calories,avg_hr,start_time")
+            .eq("date", today)
+            .order("start_time")
+            .execute()
+            .data
+        )
+
+    def q_recovery():
+        return (
+            client.table("recovery_metrics")
+            .select("*")
+            .order("date", desc=True)
+            .limit(1)
+            .execute()
+            .data
+        )
+
+    def q_study_log():
+        return (
+            client.table("study_log")
+            .select("date,subject,duration_mins,notes")
+            .gte("date", seven_days_ago)
+            .order("date", desc=True)
+            .execute()
+            .data
+        )
+
+    def q_meal_log():
+        return (
+            client.table("meal_log")
+            .select("date,meal_type,notes,recipe_id")
+            .gte("date", seven_days_ago)
+            .order("date", desc=True)
+            .execute()
+            .data
+        )
+
+    def q_recipes(recipe_ids: list):
+        return (
+            client.table("recipes")
+            .select("id,name")
+            .in_("id", recipe_ids)
+            .execute()
+            .data
+        )
+
+    # ── Parallel execution ─────────────────────────────────────────────────────
+
+    tier1 = {
+        "profile":            q_profile,
+        "tasks":              q_tasks,
+        "habit_registry":     q_habit_registry,
+        "fitness_log":        q_fitness_log,
+        "workout_yesterday":  q_workout_yesterday,
+        "workout_today":      q_workout_today,
+        "recovery":           q_recovery,
+        "study_log":          q_study_log,
+        "meal_log":           q_meal_log,
+    }
+
+    results: dict = {}
+
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        # Tier 1 — all 9 independent queries in parallel
+        futs = {pool.submit(fn): key for key, fn in tier1.items()}
+        for fut in as_completed(futs):
+            key = futs[fut]
+            try:
+                results[key] = fut.result()
+            except Exception as e:
+                print(f"[fetch_briefing_data] Warning: {key} query failed: {e}", file=sys.stderr)
+                results[key] = None
+
+        # Tier 2 — habits (depends on registry for formatting) + recipes (conditional)
+        tier2_futs: dict = {pool.submit(q_habits): "habits"}
+        recipe_ids = []
+        if results.get("meal_log"):
+            recipe_ids = list({m["recipe_id"] for m in results["meal_log"] if m.get("recipe_id")})
+        if recipe_ids:
+            tier2_futs[pool.submit(lambda ids=recipe_ids: q_recipes(ids))] = "recipes"
+        else:
+            results["recipes"] = []
+
+        for fut in as_completed(tier2_futs):
+            key = tier2_futs[fut]
+            try:
+                results[key] = fut.result()
+            except Exception as e:
+                print(f"[fetch_briefing_data] Warning: {key} query failed: {e}", file=sys.stderr)
+                results[key] = None
+
+    # ── Print sections (identical format, fixed order) ─────────────────────────
+
+    # Profile
+    profile_rows = results.get("profile") or []
+    profile = {r["key"]: r["value"] for r in profile_rows}
     print("## PROFILE")
     for k, v in profile.items():
         print(f"- {k}: {v}")
 
-    # ── Active Tasks ───────────────────────────────────────────────────────────
-    tasks = (
-        client.table("tasks")
-        .select("title,priority,due_date,status")
-        .eq("status", "active")
-        .order("due_date", desc=False)
-        .execute()
-        .data
-    )
+    # Active Tasks
+    tasks = results.get("tasks") or []
     print("\n## ACTIVE TASKS")
     if tasks:
         for t in tasks:
@@ -54,37 +193,25 @@ def main():
     else:
         print("- None")
 
-    # ── Habits — last 7 days ───────────────────────────────────────────────────
-    registry = client.table("habit_registry").select("id,name").eq("active", True).execute().data
+    # Habits — last 7 days
+    registry = results.get("habit_registry") or []
     habit_names = {r["id"]: r["name"] for r in registry}
+    habit_logs = results.get("habits") or []
 
-    habit_logs = (
-        client.table("habits")
-        .select("habit_id,date,completed")
-        .gte("date", seven_days_ago)
-        .lte("date", today)
-        .execute()
-        .data
-    )
-
-    # Build {habit_name: [True/False/None for each of last 7 days]}
-    from collections import defaultdict
     habit_by_name: dict[str, dict[str, bool]] = defaultdict(dict)
     for row in habit_logs:
         name = habit_names.get(row["habit_id"], row["habit_id"])
         habit_by_name[name][row["date"]] = row["completed"]
 
     dates_7 = [(date.today() - timedelta(days=i)).isoformat() for i in range(6, -1, -1)]
-
     print("\n## HABITS — LAST 7 DAYS")
-    print(f"{'Habit':<20} " + "  ".join(d[5:] for d in dates_7))  # MM-DD headers
-    for name in [r["name"] for r in registry]:
+    print(f"{'Habit':<20} " + "  ".join(d[5:] for d in dates_7))
+    for row in registry:
+        name = row["name"]
         row_data = habit_by_name.get(name, {})
-        cells = []
         streak = 0
         for d in reversed(dates_7):
-            val = row_data.get(d)
-            if val is True:
+            if row_data.get(d) is True:
                 streak += 1
             else:
                 break
@@ -94,17 +221,8 @@ def main():
             day_cells.append("Y" if val is True else ("N" if val is False else "—"))
         print(f"{name:<20} " + "    ".join(day_cells) + f"  (streak: {streak})")
 
-    # ── Body Composition — last 2 Renpho entries ──────────────────────────────
-    body_comp = (
-        client.table("fitness_log")
-        .select("date,weight_lb,body_fat_pct,bmi,muscle_mass_lb,visceral_fat,source")
-        .not_.is_("body_fat_pct", "null")
-        .order("date", desc=True)
-        .limit(2)
-        .execute()
-        .data
-    )
-
+    # Body Composition
+    body_comp = results.get("fitness_log") or []
     print("\n## BODY COMPOSITION (last Renpho entry)")
     if body_comp:
         latest = body_comp[0]
@@ -127,16 +245,10 @@ def main():
     else:
         print("No Renpho data available.")
 
-    # ── Workouts ───────────────────────────────────────────────────────────────
-    for label, day in [("YESTERDAY'S ACTIVITY", yesterday), ("TODAY'S ACTIVITY", today)]:
-        workouts = (
-            client.table("workout_sessions")
-            .select("activity,duration_mins,calories,avg_hr,start_time")
-            .eq("date", day)
-            .order("start_time")
-            .execute()
-            .data
-        )
+    # Workouts
+    for label, key in [("YESTERDAY'S ACTIVITY", "workout_yesterday"), ("TODAY'S ACTIVITY", "workout_today")]:
+        day = yesterday if key == "workout_yesterday" else today
+        workouts = results.get(key) or []
         print(f"\n## {label} ({day})")
         if workouts:
             for w in workouts:
@@ -145,15 +257,8 @@ def main():
         else:
             print("- None")
 
-    # ── Recovery ───────────────────────────────────────────────────────────────
-    recovery = (
-        client.table("recovery_metrics")
-        .select("*")
-        .order("date", desc=True)
-        .limit(1)
-        .execute()
-        .data
-    )
+    # Recovery
+    recovery = results.get("recovery") or []
     print("\n## RECOVERY (last night)")
     if recovery:
         r = recovery[0]
@@ -171,15 +276,8 @@ def main():
     else:
         print("No recovery data. Run: python3 scripts/sync-oura.py --yes")
 
-    # ── Study Log — recent ─────────────────────────────────────────────────────
-    study = (
-        client.table("study_log")
-        .select("date,subject,duration_mins,notes")
-        .gte("date", seven_days_ago)
-        .order("date", desc=True)
-        .execute()
-        .data
-    )
+    # Study Log
+    study = results.get("study_log") or []
     if study:
         print("\n## RECENT STUDY LOG")
         for s in study:
@@ -187,28 +285,12 @@ def main():
             notes = f" — {s['notes']}" if s.get("notes") else ""
             print(f"- {s['date']} | {s['subject']} | {dur}{notes}")
 
-    # ── Meal Log — last 7 days ─────────────────────────────────────────────────
-    meal_logs = (
-        client.table("meal_log")
-        .select("date,meal_type,notes,recipe_id")
-        .gte("date", seven_days_ago)
-        .order("date", desc=True)
-        .execute()
-        .data
-    )
+    # Meal Log
+    meal_logs = results.get("meal_log") or []
     if meal_logs:
-        # Fetch recipe names for any linked recipe_ids
-        recipe_ids = list({m["recipe_id"] for m in meal_logs if m.get("recipe_id")})
         recipe_names: dict[str, str] = {}
-        if recipe_ids:
-            recipes = (
-                client.table("recipes")
-                .select("id,name")
-                .in_("id", recipe_ids)
-                .execute()
-                .data
-            )
-            recipe_names = {r["id"]: r["name"] for r in recipes}
+        for rec in (results.get("recipes") or []):
+            recipe_names[rec["id"]] = rec["name"]
 
         print("\n## RECENT MEALS (last 7 days)")
         for m in meal_logs:

--- a/scripts/run-syncs.py
+++ b/scripts/run-syncs.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Parallel sync orchestrator for Mr. Bridge session startup.
+
+Checks sync_log for recent runs and skips sources synced within the last
+30 minutes. Remaining syncs run in parallel via subprocesses.
+
+Usage: python3 scripts/run-syncs.py
+"""
+from __future__ import annotations
+
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+import subprocess
+
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+from _supabase import get_client, log_sync
+
+SKIP_WINDOW_SECS = 30 * 60  # 30 minutes
+
+SYNCS: list[tuple[str, list[str]]] = [
+    ("google_fit", ["scripts/sync-googlefit.py", "--yes"]),
+    ("oura",       ["scripts/sync-oura.py",      "--yes"]),
+    ("fitbit",     ["scripts/sync-fitbit.py",    "--yes"]),
+]
+
+
+def last_sync_age(client, source: str) -> float | None:
+    """Return seconds since last successful sync for source, or None if never."""
+    rows = (
+        client.table("sync_log")
+        .select("synced_at")
+        .eq("source", source)
+        .eq("status", "ok")
+        .order("synced_at", desc=True)
+        .limit(1)
+        .execute()
+        .data
+    )
+    if not rows:
+        return None
+    raw = rows[0]["synced_at"]
+    # dateutil handles arbitrary ISO 8601 variants (fractional seconds, Z suffix)
+    from dateutil import parser as dtparser
+    last = dtparser.parse(raw)
+    return (datetime.now(timezone.utc) - last).total_seconds()
+
+
+def run_sync(source: str, cmd: list[str]) -> tuple[str, int, str]:
+    """Run one sync script as a subprocess. Returns (source, returncode, output)."""
+    result = subprocess.run(
+        [sys.executable] + cmd,
+        capture_output=True,
+        text=True,
+        cwd=str(ROOT),
+    )
+    return source, result.returncode, result.stdout + result.stderr
+
+
+def main() -> None:
+    client = None
+    try:
+        client = get_client()
+        to_run: list[tuple[str, list[str]]] = []
+        skipped: list[str] = []
+
+        for source, cmd in SYNCS:
+            age = last_sync_age(client, source)
+            if age is not None and age < SKIP_WINDOW_SECS:
+                skipped.append(source)
+            else:
+                to_run.append((source, cmd))
+
+    except Exception as e:
+        print(f"[run-syncs] Warning: could not check sync_log ({e}); running all syncs")
+        to_run = list(SYNCS)
+        skipped = []
+
+    if skipped:
+        print(f"[run-syncs] Skipped (synced within 30m): {', '.join(skipped)}")
+
+    if not to_run:
+        print("[run-syncs] All syncs up to date.")
+        return
+
+    print(f"[run-syncs] Running in parallel: {', '.join(s for s, _ in to_run)}")
+
+    with ThreadPoolExecutor(max_workers=len(to_run)) as pool:
+        futures = {pool.submit(run_sync, source, cmd): source for source, cmd in to_run}
+        for future in as_completed(futures):
+            source, rc, output = future.result()
+            status = "ok" if rc == 0 else f"FAILED (exit {rc})"
+            print(f"[run-syncs] {source}: {status}")
+            if rc != 0 and output.strip():
+                print(output.strip())
+            elif rc == 0 and client is not None:
+                # Ensure a sync_log entry exists so skip-if-recent works next run,
+                # even if the individual script returned early (no new data to write).
+                try:
+                    log_sync(client, source, "ok", 0)
+                except Exception:
+                    pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #17

## Summary
- **`scripts/run-syncs.py`** (new): parallel sync orchestrator — runs all three sync scripts concurrently via `ThreadPoolExecutor` + `subprocess`, skips any source synced within the last 30 minutes (checks `sync_log`), writes a fallback `sync_log` entry so skip logic fires even when a script exits early with no new data
- **`scripts/fetch_briefing_data.py`**: parallelizes all 10 Supabase queries — 9 independent queries fire in tier 1 simultaneously, `habits` and `recipes` (dependent) fire in tier 2; output format is byte-for-byte identical
- **`.claude/rules/mr-bridge-rules.md`**: replaces three sequential sync calls with `run-syncs.py`; adds explicit instruction to issue GCal events, GCal birthdays, and Gmail search as parallel MCP tool calls in a single message turn

## Performance
| Scenario | Before | After |
|---|---|---|
| Cold boot (fetch briefing) | ~1.9s | ~0.7s |
| Session syncs (cold, parallel) | ~3.5s | ~2.5s (oura bottleneck) |
| Session syncs (warm, all skip) | ~3.5s | ~0.2s |

## Test plan
- [x] `time python3 scripts/fetch_briefing_data.py` — 1.89s → 0.68s (2.8× faster)
- [x] Output diff vs baseline — identical
- [x] `python3 scripts/run-syncs.py` cold run — oura + fitbit run in parallel
- [x] Second run immediately after — oura + fitbit skipped; google_fit still runs (pre-existing auth failure, never writes ok to sync_log)
- [x] Failure resilience — google_fit fails, other two complete and script exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)