### PR TITLE
feat: GE CS10G smart scale body composition sync (#68)

### DIFF
--- a/.claude/rules/mr-bridge-rules.md
+++ b/.claude/rules/mr-bridge-rules.md
@@ -145,7 +145,7 @@ All live data is stored in Supabase. Local markdown files are archived originals
 
 | Supabase Table | Source | Script |
 |----------------|--------|--------|
-| `fitness_log` | Google Fit + Renpho | `sync-googlefit.py`, `sync-renpho.py` |
+| `fitness_log` | Google Fit (weight) + Fitbit (weight/fat/BMI) | `sync-googlefit.py`, `sync-fitbit.py` |
 | `workout_sessions` | Fitbit | `sync-fitbit.py` |
 | `recovery_metrics` | Oura Ring | `sync-oura.py` |
 | `habits` + `habit_registry` | Manual logging | `log_habit.py` |

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,8 @@ OURA_ACCESS_TOKEN=<your-oura-personal-access-token>
 FITBIT_CLIENT_ID=<your-fitbit-client-id>
 FITBIT_CLIENT_SECRET=<your-fitbit-client-secret>
 FITBIT_REFRESH_TOKEN=<obtained-via-python3-scripts/sync-fitbit.py---setup>
+FITBIT_WEIGHT_UNIT=lbs  # lbs or kg — must match your Fitbit profile unit setting (default: lbs)
+GOOGLE_FIT_REFRESH_TOKEN=<obtained-via-python3-scripts/sync-googlefit.py---setup>
 
 # ── Notifications (ntfy.sh) ───────────────────────────────────────────────────
 # See docs/notifications-setup.md — pick any unique topic string

--- a/scripts/sync-fitbit.py
+++ b/scripts/sync-fitbit.py
@@ -1,18 +1,25 @@
 #!/usr/bin/env python3
 """
-Sync Fitbit workout sessions to Supabase (workout_sessions table).
+Sync Fitbit workout sessions + body composition to Supabase.
+  workout_sessions — activity/HR data (unchanged)
+  fitness_log      — body weight, body fat %, BMI (source: "fitbit_body")
+
 Usage:
   python3 scripts/sync-fitbit.py             # last 7 days
   python3 scripts/sync-fitbit.py --days 30
   python3 scripts/sync-fitbit.py --yes       # skip confirmation
-  python3 scripts/sync-fitbit.py --setup     # first-time OAuth setup
+  python3 scripts/sync-fitbit.py --probe     # print body data without writing
+  python3 scripts/sync-fitbit.py --setup     # first-time OAuth setup (required when scope changes)
 
-First-time setup:
+First-time setup / re-auth after scope change:
   1. Register app at https://dev.fitbit.com/apps/new
      - Application type: Personal
      - Redirect URI: http://localhost:8080
   2. Run: python3 scripts/sync-fitbit.py --setup
   3. Paste FITBIT_CLIENT_ID, FITBIT_CLIENT_SECRET, FITBIT_REFRESH_TOKEN into .env
+
+Note: The 'weight' scope was added to fetch body composition data from the GE CS10G
+smart scale. If body endpoints return 401, re-run with --setup to get a new token.
 
 Requires: python-dotenv, supabase
   pip3 install python-dotenv supabase
@@ -45,7 +52,7 @@ FITBIT_AUTH_URL = "https://www.fitbit.com/oauth2/authorize"
 FITBIT_TOKEN_URL = "https://api.fitbit.com/oauth2/token"
 FITBIT_API_BASE = "https://api.fitbit.com"
 REDIRECT_URI = "http://localhost:8080"
-SCOPES = "activity heartrate"
+SCOPES = "activity heartrate weight"
 
 
 # ── OAuth helpers ──────────────────────────────────────────────────────────────
@@ -227,13 +234,88 @@ def existing_keys(client) -> set:
     return {f"{r['date']}|{r['start_time']}|{r['activity']}" for r in rows}
 
 
+# ── Body composition ───────────────────────────────────────────────────────────
+
+def fetch_body_data(access_token, start_date, end_date, raw=False):
+    """Fetch weight, body fat %, and BMI from Fitbit for the given date range.
+
+    Actual Fitbit API response structure (verified from live API):
+      GET /1/user/-/body/log/weight/date/{start}/{end}.json
+        → { "weight": [ { "date": "YYYY-MM-DD", "weight": <float_kg_or_lb>,
+                           "fat": <float_%>, "bmi": <float>, "time": "HH:MM:SS", ... } ] }
+      Fat % is included inline in the weight entries — no separate fat endpoint needed.
+
+    Weight unit: Fitbit returns weight in the user's profile unit (lbs or kg).
+    FITBIT_WEIGHT_UNIT env var overrides: set to "lbs" if your Fitbit profile is imperial,
+    "kg" if metric. Defaults to "kg" (metric) if not set.
+
+    Returns a list of dicts ready to upsert into fitness_log.
+    If raw=True, prints raw API responses and returns [].
+    """
+    # Determine unit. Profile endpoint requires 'profile' scope (not included in 'weight'),
+    # so we rely on FITBIT_WEIGHT_UNIT env var. Default: kg (metric).
+    unit = os.environ.get("FITBIT_WEIGHT_UNIT", "lbs").lower().strip()
+    is_lbs = unit == "lbs"
+
+    try:
+        weight_data = fitbit_get(access_token, f"/1/user/-/body/log/weight/date/{start_date}/{end_date}.json")
+    except SystemExit:
+        print("[sync-fitbit] Could not fetch body weight. If you see 401, re-run with --setup to add 'weight' scope.")
+        return []
+
+    if raw:
+        print(f"\n[raw] /body/log/weight response:\n{json.dumps(weight_data, indent=2)}")
+        return []
+
+    rows = []
+    # Top-level key is "weight" (not "body-weight")
+    for entry in weight_data.get("weight", []):
+        dt = entry.get("date")
+        weight_val = entry.get("weight")
+        if not dt or weight_val is None:
+            continue
+        row: dict = {"date": dt}
+        row["weight_lb"] = round(weight_val if is_lbs else float(weight_val) * 2.20462, 1)
+        fat = entry.get("fat")
+        if fat is not None:
+            row["body_fat_pct"] = round(float(fat), 1)
+        bmi = entry.get("bmi")
+        if bmi is not None:
+            row["bmi"] = round(float(bmi), 1)
+        rows.append(row)
+
+    return rows
+
+
+def existing_body_dates(client) -> set:
+    rows = client.table("fitness_log").select("date").eq("source", "fitbit_body").execute().data
+    return {r["date"] for r in rows}
+
+
+def print_body_probe(rows):
+    if not rows:
+        print("[probe] No body composition data returned from Fitbit for this date range.")
+        return
+    print(f"\n{'Date':<12} {'Weight':>10} {'Fat%':>7} {'BMI':>6}")
+    print("-" * 40)
+    for r in sorted(rows, key=lambda x: x["date"]):
+        print(
+            f"{r['date']:<12}"
+            f" {str(r.get('weight_lb', 'None')) + ' lb' if r.get('weight_lb') is not None else 'None':>10}"
+            f" {str(r.get('body_fat_pct', 'None')) + '%' if r.get('body_fat_pct') is not None else 'None':>7}"
+            f" {str(r.get('bmi', 'None')):>6}"
+        )
+
+
 # ── Main ───────────────────────────────────────────────────────────────────────
 
 def main():
-    parser = argparse.ArgumentParser(description="Sync Fitbit workouts to Supabase")
+    parser = argparse.ArgumentParser(description="Sync Fitbit workouts + body composition to Supabase")
     parser.add_argument("--days", type=int, default=7)
     parser.add_argument("--setup", action="store_true", help="Run first-time OAuth setup")
     parser.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
+    parser.add_argument("--probe", action="store_true", help="Print body data without writing to Supabase")
+    parser.add_argument("--raw", action="store_true", help="Dump raw API responses for body endpoints (implies --probe)")
     args = parser.parse_args()
 
     if args.setup:
@@ -256,21 +338,50 @@ def main():
     start_str = start.strftime("%Y-%m-%d")
     end_str = end.strftime("%Y-%m-%d")
 
+    # ── Body composition ───────────────────────────────────────────────────────
+    print(f"[sync-fitbit] Fetching body composition {start_str} to {end_str}...")
+    body_rows = fetch_body_data(access_token, start_str, end_str, raw=args.raw)
+
+    if args.probe or args.raw:
+        print(f"\n[probe] Fitbit returned {len(body_rows)} date(s) with body data:")
+        print_body_probe(body_rows)
+        return
+
+    # ── Workouts ───────────────────────────────────────────────────────────────
     print(f"[sync-fitbit] Fetching workouts {start_str} to {end_str}...")
     workout_rows = fetch_workouts(access_token, start_str, end_str)
 
     client = get_client()
+
+    # Write body composition
+    existing_body = existing_body_dates(client)
+    new_body = [r for r in body_rows if r["date"] not in existing_body]
+
+    if new_body:
+        print(f"\nNew body composition entries ({len(new_body)}):")
+        for r in sorted(new_body, key=lambda x: x["date"]):
+            parts = []
+            if r.get("weight_lb") is not None:
+                parts.append(f"weight={r['weight_lb']} lb")
+            if r.get("body_fat_pct") is not None:
+                parts.append(f"fat={r['body_fat_pct']}%")
+            if r.get("bmi") is not None:
+                parts.append(f"BMI={r['bmi']}")
+            print(f"  {r['date']} — {' | '.join(parts) if parts else 'no fields'}")
+
+    # Write workouts
     existing = existing_keys(client)
     new_workouts = [r for r in workout_rows if r["_key"] not in existing]
 
-    if not new_workouts:
-        print("[sync-fitbit] No new workout data.")
-        return
+    if new_workouts:
+        print(f"\nNew workout entries ({len(new_workouts)}):")
+        for r in new_workouts:
+            hr_info = f" | Avg HR: {r['avg_hr']}" if r["avg_hr"] else ""
+            print(f"  {r['date']} {r['start_time']} — {r['activity']} ({r['duration_mins']} min, {r['calories']} cal{hr_info})")
 
-    print(f"\nNew workout entries ({len(new_workouts)}):")
-    for r in new_workouts:
-        hr_info = f" | Avg HR: {r['avg_hr']}" if r["avg_hr"] else ""
-        print(f"  {r['date']} {r['start_time']} — {r['activity']} ({r['duration_mins']} min, {r['calories']} cal{hr_info})")
+    if not new_body and not new_workouts:
+        print("[sync-fitbit] No new data.")
+        return
 
     if not args.yes:
         confirm = input("\nWrite to Supabase? [y/N] ").strip().lower()
@@ -278,11 +389,20 @@ def main():
             print("Aborted.")
             return
 
-    # Strip the internal dedup key before inserting
-    sb_rows = [{k: v for k, v in r.items() if k != "_key"} for r in new_workouts]
-    written = upsert(client, "workout_sessions", sb_rows)
-    log_sync(client, "fitbit", "ok", written)
-    print(f"[sync-fitbit] Synced {written} row(s) to Supabase.")
+    body_written = 0
+    if new_body:
+        sb_body = [{**r, "source": "fitbit_body"} for r in sorted(new_body, key=lambda x: x["date"])]
+        body_written = upsert(client, "fitness_log", sb_body)
+        log_sync(client, "fitbit_body", "ok", body_written)
+        print(f"[sync-fitbit] Synced {body_written} body composition row(s) to fitness_log.")
+
+    workout_written = 0
+    if new_workouts:
+        # Strip the internal dedup key before inserting
+        sb_rows = [{k: v for k, v in r.items() if k != "_key"} for r in new_workouts]
+        workout_written = upsert(client, "workout_sessions", sb_rows)
+        log_sync(client, "fitbit", "ok", workout_written)
+        print(f"[sync-fitbit] Synced {workout_written} workout row(s) to workout_sessions.")
 
 
 if __name__ == "__main__":

--- a/scripts/sync-googlefit.py
+++ b/scripts/sync-googlefit.py
@@ -1,7 +1,23 @@
 #!/usr/bin/env python3
 """
-Sync weight data from Google Fit to Supabase (fitness_log table).
-Usage: python3 scripts/sync-googlefit.py [--days 7] [--yes]
+Sync body composition data from Google Fit to Supabase (fitness_log table).
+Usage: python3 scripts/sync-googlefit.py [--days 7] [--yes] [--probe] [--setup]
+
+First-time setup / re-auth:
+  1. Download credentials.json from Google Cloud Console → OAuth 2.0 client → Download JSON
+     Place it at the project root.
+  2. Run: python3 scripts/sync-googlefit.py --setup
+  3. Add GOOGLE_FIT_REFRESH_TOKEN=<printed value> to .env
+  Note: Uses GOOGLE_FIT_REFRESH_TOKEN (fitness scope); falls back to GOOGLE_REFRESH_TOKEN.
+
+Data types queried (all covered by fitness.body.read scope):
+  com.google.weight               → weight_lb
+  com.google.body_fat_percentage  → body_fat_pct
+  com.google.bmi                  → bmi
+  com.google.lean_body_mass       → muscle_mass_lb (fat-free mass proxy)
+  com.google.hydration            → metadata.body_water_l
+  com.google.basal_metabolic_rate → metadata.bmr_kcal
+  com.google.height               → metadata.height_m
 
 Note: Workout data is sourced from Fitbit (scripts/sync-fitbit.py) — Google Fit
 workout tracking is unreliable due to background step/activity noise.
@@ -23,6 +39,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
 
 ROOT = Path(__file__).parent.parent
 load_dotenv(ROOT / ".env")
@@ -30,17 +47,60 @@ sys.path.insert(0, str(Path(__file__).parent))
 from _supabase import get_client, upsert, log_sync, urlopen_with_retry
 
 
+FITNESS_SCOPES = ["https://www.googleapis.com/auth/fitness.body.read"]
+
+BODY_DATA_TYPES = [
+    "com.google.weight",
+    "com.google.body_fat_percentage",
+    "com.google.bmi",
+    "com.google.lean_body_mass",
+    "com.google.hydration",
+    "com.google.basal_metabolic_rate",
+    "com.google.height",
+]
+
+
+def setup_oauth():
+    """Run first-time or re-auth OAuth flow. Prints GOOGLE_FIT_REFRESH_TOKEN for .env."""
+    creds_file = ROOT / "credentials.json"
+    if not creds_file.exists():
+        print("[error] credentials.json not found at project root.")
+        print("Download it from Google Cloud Console → APIs & Services → Credentials → your OAuth client → Download JSON")
+        sys.exit(1)
+    flow = InstalledAppFlow.from_client_secrets_file(str(creds_file), FITNESS_SCOPES)
+    creds = flow.run_local_server(port=0)
+    print("\nAdd this to your .env file:")
+    print(f"GOOGLE_FIT_REFRESH_TOKEN={creds.refresh_token}")
+
+
 def get_credentials():
+    refresh_token = os.environ.get("GOOGLE_FIT_REFRESH_TOKEN") or os.environ.get("GOOGLE_REFRESH_TOKEN")
+    if not refresh_token:
+        print("[error] GOOGLE_FIT_REFRESH_TOKEN not set in .env")
+        print("Run: python3 scripts/sync-googlefit.py --setup")
+        sys.exit(1)
+    client_id = os.environ.get("GOOGLE_FIT_CLIENT_ID") or os.environ.get("GOOGLE_CLIENT_ID")
+    client_secret = os.environ.get("GOOGLE_FIT_CLIENT_SECRET") or os.environ.get("GOOGLE_CLIENT_SECRET")
     creds = Credentials(
         token=None,
-        refresh_token=os.environ["GOOGLE_REFRESH_TOKEN"],
-        client_id=os.environ["GOOGLE_CLIENT_ID"],
-        client_secret=os.environ["GOOGLE_CLIENT_SECRET"],
+        refresh_token=refresh_token,
+        client_id=client_id,
+        client_secret=client_secret,
         token_uri="https://oauth2.googleapis.com/token",
-        scopes=["https://www.googleapis.com/auth/fitness.body.read"],
+        scopes=FITNESS_SCOPES,
     )
     creds.refresh(Request())
     return creds
+
+
+def fit_get(creds, endpoint):
+    url = f"https://www.googleapis.com/fitness/v1/users/me/{endpoint}"
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {creds.token}"})
+    try:
+        return urlopen_with_retry(req)
+    except urllib.error.HTTPError as e:
+        print(f"[error] Google Fit API returned {e.code}: {e.read().decode()}")
+        sys.exit(1)
 
 
 def fit_post(creds, endpoint, body):
@@ -57,25 +117,97 @@ def fit_post(creds, endpoint, body):
         sys.exit(1)
 
 
-def fetch_weight(creds, start_ms, end_ms):
+def discover_body_datasources(creds) -> dict[str, list[str]]:
+    """List all datasources and return a map of dataTypeName → [dataSourceId].
+
+    Uses the dataSources list API instead of assuming a default datasource exists.
+    This avoids the 'no default datasource found' error when a type has no data.
+    """
+    result = fit_get(creds, "dataSources")
+    type_to_sources: dict[str, list[str]] = {}
+    for ds in result.get("dataSource", []):
+        dt_name = ds.get("dataType", {}).get("name", "")
+        if dt_name in BODY_DATA_TYPES:
+            ds_id = ds.get("dataStreamId", "")
+            if ds_id:
+                type_to_sources.setdefault(dt_name, []).append(ds_id)
+    return type_to_sources
+
+
+def fetch_body_composition(creds, start_ms, end_ms) -> tuple[list[dict], dict[str, list[str]]]:
+    """Discover available body datasources, then aggregate by dataSourceId.
+
+    Returns (rows, type_to_sources) so the caller can print what was found.
+    Rows have one entry per date with all available fields populated.
+    """
+    type_to_sources = discover_body_datasources(creds)
+
+    if not type_to_sources:
+        return [], type_to_sources
+
+    # Build aggregate request using explicit dataSourceIds (avoids 'no default' errors)
+    aggregate_by = []
+    for dtype, source_ids in type_to_sources.items():
+        for sid in source_ids:
+            aggregate_by.append({"dataSourceId": sid})
+
     body = {
-        "aggregateBy": [{"dataTypeName": "com.google.weight"}],
+        "aggregateBy": aggregate_by,
         "bucketByTime": {"durationMillis": 86400000},
         "startTimeMillis": start_ms,
         "endTimeMillis": end_ms,
     }
     result = fit_post(creds, "dataset:aggregate", body)
+
     rows = []
     for bucket in result.get("bucket", []):
         date_str = datetime.fromtimestamp(
             int(bucket["startTimeMillis"]) / 1000, tz=timezone.utc
         ).strftime("%Y-%m-%d")
+
+        # Index points by data type name (match via dataSourceId substring)
+        by_type: dict[str, list] = {}
         for dataset in bucket.get("dataset", []):
-            for point in dataset.get("point", []):
-                kg = point["value"][0]["fpVal"]
-                lbs = round(kg * 2.20462, 1)
-                rows.append({"date": date_str, "weight_lb": lbs})
-    return rows
+            ds_id = dataset.get("dataSourceId", "")
+            for dtype in BODY_DATA_TYPES:
+                if dtype in ds_id:
+                    by_type.setdefault(dtype, []).extend(dataset.get("point", []))
+
+        def first_fp(dtype):
+            points = by_type.get(dtype, [])
+            if not points:
+                return None
+            vals = points[0].get("value", [])
+            return vals[0].get("fpVal") if vals else None
+
+        weight_kg = first_fp("com.google.weight")
+        lean_kg = first_fp("com.google.lean_body_mass")
+        fat_pct = first_fp("com.google.body_fat_percentage")
+        bmi_val = first_fp("com.google.bmi")
+        hydration_l = first_fp("com.google.hydration")
+        bmr = first_fp("com.google.basal_metabolic_rate")
+        height_m = first_fp("com.google.height")
+
+        meta = {}
+        if hydration_l is not None:
+            meta["body_water_l"] = round(hydration_l, 2)
+        if bmr is not None:
+            meta["bmr_kcal"] = round(bmr, 1)
+        if height_m is not None:
+            meta["height_m"] = round(height_m, 3)
+
+        row = {
+            "date": date_str,
+            "weight_lb": round(weight_kg * 2.20462, 1) if weight_kg is not None else None,
+            "body_fat_pct": round(fat_pct, 1) if fat_pct is not None else None,
+            "bmi": round(bmi_val, 1) if bmi_val is not None else None,
+            "muscle_mass_lb": round(lean_kg * 2.20462, 1) if lean_kg is not None else None,
+            "metadata": meta if meta else None,
+        }
+        if any(v is not None for k, v in row.items() if k not in ("date", "metadata")):
+            rows.append(row)
+
+    return rows, type_to_sources
 
 
 def existing_dates(client) -> set:
@@ -83,13 +215,49 @@ def existing_dates(client) -> set:
     return {r["date"] for r in rows}
 
 
+def print_probe(rows, type_to_sources):
+    print("\n[probe] Registered body datasources:")
+    if not type_to_sources:
+        print("  (none found — scale may not have synced to Google Fit yet)")
+    else:
+        for dtype, sources in sorted(type_to_sources.items()):
+            for s in sources:
+                print(f"  {dtype}")
+                print(f"    → {s}")
+
+    if not rows:
+        print("\n[probe] No data points in this date range.")
+        return
+    print(f"\n[probe] {len(rows)} date(s) with data:\n")
+    print(f"{'Date':<12} {'Weight':>10} {'Fat%':>7} {'BMI':>6} {'Lean':>10} {'Water(L)':>9} {'BMR':>7} {'Height':>8}")
+    print("-" * 72)
+    for r in sorted(rows, key=lambda x: x["date"]):
+        meta = r.get("metadata") or {}
+        print(
+            f"{r['date']:<12}"
+            f" {str(r['weight_lb']) + ' lb' if r['weight_lb'] is not None else 'None':>10}"
+            f" {str(r['body_fat_pct']) + '%' if r['body_fat_pct'] is not None else 'None':>7}"
+            f" {str(r['bmi']) if r['bmi'] is not None else 'None':>6}"
+            f" {str(r['muscle_mass_lb']) + ' lb' if r['muscle_mass_lb'] is not None else 'None':>10}"
+            f" {str(meta.get('body_water_l', 'None')):>9}"
+            f" {str(meta.get('bmr_kcal', 'None')):>7}"
+            f" {str(meta.get('height_m', 'None')):>8}"
+        )
+
+
 def main():
-    parser = argparse.ArgumentParser(description="Sync Google Fit weight to Supabase")
+    parser = argparse.ArgumentParser(description="Sync Google Fit body composition to Supabase")
     parser.add_argument("--days", type=int, default=7, help="Days to fetch (default: 7)")
     parser.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
+    parser.add_argument("--probe", action="store_true", help="Print API results without writing to Supabase")
+    parser.add_argument("--setup", action="store_true", help="Run OAuth setup to generate GOOGLE_FIT_REFRESH_TOKEN")
     args = parser.parse_args()
 
-    print(f"[sync-googlefit] Fetching weight for last {args.days} days...")
+    if args.setup:
+        setup_oauth()
+        return
+
+    print(f"[sync-googlefit] Fetching body composition for last {args.days} days...")
     creds = get_credentials()
     print("[sync-googlefit] Authenticated.")
 
@@ -98,19 +266,30 @@ def main():
     start_ms = int(start.timestamp() * 1000)
     end_ms = int(now.timestamp() * 1000)
 
-    weight_rows = fetch_weight(creds, start_ms, end_ms)
+    rows, type_to_sources = fetch_body_composition(creds, start_ms, end_ms)
+
+    if args.probe:
+        print_probe(rows, type_to_sources)
+        return
 
     client = get_client()
     existing = existing_dates(client)
-    new_weight = [r for r in weight_rows if r["date"] not in existing]
+    new_rows = [r for r in rows if r["date"] not in existing]
 
-    if not new_weight:
-        print("[sync-googlefit] No new weight data.")
+    if not new_rows:
+        print("[sync-googlefit] No new body composition data.")
         return
 
-    print(f"\nNew weight entries ({len(new_weight)}):")
-    for r in sorted(new_weight, key=lambda x: x["date"]):
-        print(f"  {r['date']} — {r['weight_lb']} lb")
+    print(f"\nNew body composition entries ({len(new_rows)}):")
+    for r in sorted(new_rows, key=lambda x: x["date"]):
+        parts = [f"weight={r['weight_lb']} lb"]
+        if r["body_fat_pct"] is not None:
+            parts.append(f"fat={r['body_fat_pct']}%")
+        if r["bmi"] is not None:
+            parts.append(f"BMI={r['bmi']}")
+        if r["muscle_mass_lb"] is not None:
+            parts.append(f"lean={r['muscle_mass_lb']} lb")
+        print(f"  {r['date']} — {' | '.join(parts)}")
 
     if not args.yes:
         confirm = input("\nWrite to Supabase? [y/N] ").strip().lower()
@@ -119,8 +298,8 @@ def main():
             return
 
     sb_rows = [
-        {"date": r["date"], "weight_lb": r["weight_lb"], "source": "google_fit"}
-        for r in sorted(new_weight, key=lambda x: x["date"])
+        {**{k: v for k, v in r.items() if v is not None}, "source": "google_fit"}
+        for r in sorted(new_rows, key=lambda x: x["date"])
     ]
     written = upsert(client, "fitness_log", sb_rows)
     log_sync(client, "google_fit", "ok", written)

--- a/scripts/sync-renpho.py
+++ b/scripts/sync-renpho.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
 """
-Sync Renpho body composition data into memory/fitness_log.md Baseline Metrics.
+DEPRECATED — replaced by GE CS10G smart scale via sync-fitbit.py (body composition)
+and sync-googlefit.py (weight). Retired as of 2026-04-11 (#68).
+
+This script remains for emergency manual CSV re-import only. It writes to the
+legacy memory/fitness_log.md markdown file, not Supabase.
+
+Original purpose: Sync Renpho CSV export into memory/fitness_log.md Baseline Metrics.
 Usage: python3 scripts/sync-renpho.py <path-to-renpho-export.csv>
-
-How to export from Renpho:
-  Renpho app → Me (bottom tab) → Export Data → select date range → export CSV
-  Drop the exported CSV file anywhere and pass its path as the argument.
-
-Extracts: date, weight, body fat %, BMI, muscle mass, visceral fat
-Appends new rows to the Baseline Metrics table (deduplicates by date).
 """
 
 import sys

--- a/supabase/migrations/20260411100000_fitness_log_unique_date_source.sql
+++ b/supabase/migrations/20260411100000_fitness_log_unique_date_source.sql
@@ -1,0 +1,3 @@
+-- Add unique constraint on (date, source) for fitness_log
+-- Enables idempotent upserts per data source (google_fit, fitbit_body, renpho, etc.)
+alter table fitness_log add constraint fitness_log_date_source_key unique (date, source);


### PR DESCRIPTION
## Summary

- **sync-googlefit.py**: Switched from single `dataTypeName` aggregate to datasource discovery (`GET /dataSources`) — queries all registered body datasources dynamically. Adds `--setup` (OAuth re-auth) and `--probe` flags. Now queries weight, fat %, BMI, lean mass, hydration, BMR, height.
- **sync-fitbit.py**: Added `weight` scope, `fetch_body_data()` pulling weight + fat % + BMI from Fitbit body log API (`/body/log/weight/date/`). Adds `--probe` and `--raw` diagnostic flags. `FITBIT_WEIGHT_UNIT` env var (default: lbs) controls unit conversion.
- **Supabase migration**: Added `UNIQUE (date, source)` constraint to `fitness_log`.
- **sync-renpho.py**: Deprecated — replaced by GE CS10G → Fitbit pipeline.
- **#69 filed**: Future deep body comp (skeletal muscle, visceral fat, bone mass, etc.) via Renpho API / HealthSync bridge.

## Findings from probe

| Platform | Weight | Fat % | BMI | Muscle | Visceral |
|---|---|---|---|---|---|
| Google Fit | ✅ | ✗ | ✗ | ✗ | ✗ |
| Fitbit | ✅ | ✅ | ✅ | ✗ | ✗ |

Google Fit receives weight-only from the scale. Fitbit is the body composition source.

## Live data written

| Date | Weight | Fat % | BMI | Source |
|---|---|---|---|---|
| 2026-04-05 | 149.8 lb | — | — | google_fit |
| 2026-04-10 | 152.0 lb | — | — | google_fit |
| 2026-04-11 | 151.9 lb | 20.4% | 26.3 | fitbit_body |

## Test plan

- [ ] `python3 scripts/sync-googlefit.py --probe --days 7` — shows datasource list + weight entries
- [ ] `python3 scripts/sync-fitbit.py --probe --days 7` — shows weight/fat/BMI entries
- [ ] `python3 scripts/sync-fitbit.py --raw --days 7` — dumps raw API responses for debugging
- [ ] Supabase `fitness_log` table: verify rows with correct source tags and fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)