### PR TITLE
feat: unified trends card — tabbed body comp / recovery chart (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Added
+- `web/src/components/dashboard/trends-card.tsx` — new full-width dashboard card replacing `FitnessSummary`; dual-tab (Body Comp / Recovery) time-series chart with 7d / 30d / 90d window toggle; Body Comp tab shows weight + body fat % on dual axes; Recovery tab shows HRV + readiness on dual axes; recent workout slim row at bottom; closes #72
+
+### Changed
+- `web/src/app/(protected)/page.tsx` — replaced `FitnessSummary` (2-col) with `TrendsCard` (full-width row); `ScheduleToday` moved to its own full-width row below; fitness trends query extended to 90 rows ascending; recovery trends query extended from 14 → 90 rows; `RecoverySummary` receives sliced last-14 entries to preserve existing chart label; dropped single-entry `fitnessResult` and `prevFitnessResult` queries
+
+---
+
+### Added
 - `.env.example` — root-level environment variable template covering Supabase, Google OAuth, Oura, Fitbit, ntfy.sh, and voice interface; replaces inline README block
 - `web/.env.local.example` — Next.js web app environment variable template; documents `NEXT_PUBLIC_SUPABASE_*`, `SUPABASE_SERVICE_ROLE_KEY`, `ANTHROPIC_API_KEY`, Google OAuth, and `USER_TIMEZONE` (previously undocumented)
 

--- a/web/src/app/(protected)/page.tsx
+++ b/web/src/app/(protected)/page.tsx
@@ -4,7 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 import HabitsCheckin from "@/components/dashboard/habits-checkin";
 import TasksSummary from "@/components/dashboard/tasks-summary";
-import FitnessSummary from "@/components/dashboard/fitness-summary";
+import TrendsCard from "@/components/dashboard/trends-card";
 import RecoverySummary from "@/components/dashboard/recovery-summary";
 import FunFact from "@/components/dashboard/fun-fact";
 import ScheduleToday from "@/components/dashboard/schedule-today";
@@ -40,30 +40,15 @@ export default async function DashboardPage() {
     registryResult,
     allHabitsResult,
     tasksResult,
-    fitnessResult,
-    prevFitnessResult,
     recoveryResult,
     recoveryTrendsResult,
+    fitnessTrendsResult,
     workoutResult,
   ] = await Promise.all([
     supabase.from("habits").select("*").eq("date", today),
     supabase.from("habit_registry").select("id, name, emoji").eq("active", true),
     supabase.from("habits").select("habit_id, date").eq("completed", true),
     supabase.from("tasks").select("*").eq("status", "active"),
-    supabase
-      .from("fitness_log")
-      .select("*")
-      .not("body_fat_pct", "is", null)
-      .order("date", { ascending: false })
-      .limit(1)
-      .maybeSingle(),
-    supabase
-      .from("fitness_log")
-      .select("*")
-      .not("body_fat_pct", "is", null)
-      .order("date", { ascending: false })
-      .range(1, 1)
-      .maybeSingle(),
     supabase
       .from("recovery_metrics")
       .select("*")
@@ -75,7 +60,13 @@ export default async function DashboardPage() {
       .from("recovery_metrics")
       .select("date, avg_hrv, readiness, total_sleep_hrs, light_hrs, deep_hrs, rem_hrs")
       .order("date", { ascending: false })
-      .limit(14),
+      .limit(90),
+    supabase
+      .from("fitness_log")
+      .select("date, weight_lb, body_fat_pct")
+      .not("body_fat_pct", "is", null)
+      .order("date", { ascending: true })
+      .limit(90),
     supabase
       .from("workout_sessions")
       .select("*")
@@ -89,10 +80,9 @@ export default async function DashboardPage() {
   const allCompletedHabits = (allHabitsResult.data ?? []) as { habit_id: string; date: string }[];
   const habitStreaks = computeStreaks(allCompletedHabits, today);
   const tasks = (tasksResult.data ?? []) as Task[];
-  const latestFitness = fitnessResult.data as FitnessLog | null;
-  const prevFitness = prevFitnessResult.data as FitnessLog | null;
   const recovery = recoveryResult.data as RecoveryMetrics | null;
   const recoveryTrends = ((recoveryTrendsResult.data ?? []) as RecoveryMetrics[]).reverse();
+  const fitnessTrends = (fitnessTrendsResult.data ?? []) as FitnessLog[];
   const recentWorkout = workoutResult.data as WorkoutSession | null;
 
   const greeting = getGreeting(USER_TZ);
@@ -118,7 +108,7 @@ export default async function DashboardPage() {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
         {/* Recovery detail — 2/3 width */}
         <div className="lg:col-span-2">
-          <RecoverySummary recovery={recovery} trends={recoveryTrends} />
+          <RecoverySummary recovery={recovery} trends={recoveryTrends.slice(-14)} />
         </div>
 
         {/* Right sidebar: Habits check-in + Tasks stacked */}
@@ -133,15 +123,17 @@ export default async function DashboardPage() {
           <TasksSummary tasks={tasks} />
         </div>
 
-        {/* Row 2: Schedule (1 col) + Fitness (2 col) */}
-        <div className="lg:col-span-1">
-          <ScheduleToday />
-        </div>
-        <div className="lg:col-span-2">
-          <FitnessSummary latest={latestFitness} previous={prevFitness} recentWorkout={recentWorkout} />
+        {/* Row 2: Trends — full width */}
+        <div className="lg:col-span-3">
+          <TrendsCard fitnessData={fitnessTrends} recoveryData={recoveryTrends} recentWorkout={recentWorkout} />
         </div>
 
-        {/* Row 3: Emails — full width */}
+        {/* Row 3: Schedule — full width */}
+        <div className="lg:col-span-3">
+          <ScheduleToday />
+        </div>
+
+        {/* Row 4: Emails — full width */}
         <div className="lg:col-span-3">
           <ImportantEmails />
         </div>

--- a/web/src/components/dashboard/trends-card.tsx
+++ b/web/src/components/dashboard/trends-card.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import {
+  ComposedChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import type { FitnessLog, RecoveryMetrics, WorkoutSession } from "@/lib/types";
+
+interface Props {
+  fitnessData: FitnessLog[];
+  recoveryData: RecoveryMetrics[];
+  recentWorkout: WorkoutSession | null;
+}
+
+type Tab = "bodycomp" | "recovery";
+type Window = "7d" | "30d" | "90d";
+
+const WINDOW_DAYS: Record<Window, number> = { "7d": 7, "30d": 30, "90d": 90 };
+
+interface TooltipProps {
+  active?: boolean;
+  payload?: { name: string; value: number | null; color: string }[];
+  label?: string;
+}
+
+function CustomTooltip({ active, payload, label }: TooltipProps) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="bg-neutral-900 border border-neutral-700 rounded-lg px-3 py-2 text-xs">
+      <p className="text-neutral-400 mb-1">{label}</p>
+      {payload.map((p) => (
+        <p key={p.name} style={{ color: p.color }}>
+          {p.name}: {p.value != null ? p.value : "—"}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+const axisProps = {
+  tick: { fill: "#737373", fontSize: 11 },
+  tickLine: false,
+  axisLine: false,
+} as const;
+
+const gridProps = {
+  strokeDasharray: "3 3",
+  stroke: "#262626",
+  vertical: false,
+} as const;
+
+export default function TrendsCard({ fitnessData, recoveryData, recentWorkout }: Props) {
+  const [tab, setTab] = useState<Tab>("bodycomp");
+  const [window, setWindow] = useState<Window>("30d");
+
+  const cutoff = useMemo(() => {
+    const d = new Date();
+    d.setDate(d.getDate() - WINDOW_DAYS[window]);
+    return d.toISOString().slice(0, 10);
+  }, [window]);
+
+  const bodyCompData = useMemo(
+    () =>
+      fitnessData
+        .filter((d) => d.date >= cutoff)
+        .map((d) => ({
+          date: d.date.slice(5),
+          weight: d.weight_lb,
+          bodyFat: d.body_fat_pct,
+        })),
+    [fitnessData, cutoff]
+  );
+
+  const recoveryChartData = useMemo(
+    () =>
+      recoveryData
+        .filter((d) => d.date >= cutoff)
+        .map((d) => ({
+          date: d.date.slice(5),
+          hrv: d.avg_hrv,
+          readiness: d.readiness,
+        })),
+    [recoveryData, cutoff]
+  );
+
+  const hasBodyComp = bodyCompData.length > 0;
+  const hasRecovery = recoveryChartData.length > 0;
+  const isEmpty = tab === "bodycomp" ? !hasBodyComp : !hasRecovery;
+
+  return (
+    <div className="bg-neutral-900 rounded-xl border border-neutral-800 p-4 h-full">
+      {/* Header row */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex gap-1">
+          {(["bodycomp", "recovery"] as Tab[]).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`text-xs px-3 py-1 rounded-full transition-colors ${
+                tab === t
+                  ? "bg-neutral-700 text-neutral-100"
+                  : "text-neutral-500 hover:text-neutral-300"
+              }`}
+            >
+              {t === "bodycomp" ? "Body Comp" : "Recovery"}
+            </button>
+          ))}
+        </div>
+        <div className="flex gap-1">
+          {(["7d", "30d", "90d"] as Window[]).map((w) => (
+            <button
+              key={w}
+              onClick={() => setWindow(w)}
+              className={`text-xs px-2.5 py-1 rounded-full transition-colors font-[family-name:var(--font-mono)] ${
+                window === w
+                  ? "bg-neutral-700 text-neutral-100"
+                  : "text-neutral-500 hover:text-neutral-300"
+              }`}
+            >
+              {w}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Chart */}
+      {isEmpty ? (
+        <div className="h-48 flex items-center justify-center text-sm text-neutral-600">
+          No data for this period
+        </div>
+      ) : tab === "bodycomp" ? (
+        <ResponsiveContainer width="100%" height={200}>
+          <ComposedChart data={bodyCompData} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
+            <CartesianGrid {...gridProps} />
+            <XAxis dataKey="date" {...axisProps} interval="preserveStartEnd" />
+            <YAxis yAxisId="weight" orientation="left" {...axisProps} domain={["auto", "auto"]} />
+            <YAxis yAxisId="bf" orientation="right" {...axisProps} domain={["auto", "auto"]} />
+            <Tooltip content={<CustomTooltip />} />
+            <Legend
+              iconType="circle"
+              iconSize={6}
+              wrapperStyle={{ fontSize: "11px", color: "#737373", paddingTop: "8px" }}
+            />
+            <Line
+              yAxisId="weight"
+              type="monotone"
+              dataKey="weight"
+              name="Weight (lb)"
+              stroke="#3b82f6"
+              strokeWidth={1.5}
+              dot={false}
+              activeDot={{ r: 3, strokeWidth: 0 }}
+              connectNulls
+            />
+            <Line
+              yAxisId="bf"
+              type="monotone"
+              dataKey="bodyFat"
+              name="Body fat %"
+              stroke="#f97316"
+              strokeWidth={1.5}
+              dot={false}
+              activeDot={{ r: 3, strokeWidth: 0 }}
+              connectNulls
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      ) : (
+        <ResponsiveContainer width="100%" height={200}>
+          <ComposedChart data={recoveryChartData} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
+            <CartesianGrid {...gridProps} />
+            <XAxis dataKey="date" {...axisProps} interval="preserveStartEnd" />
+            <YAxis yAxisId="hrv" orientation="left" {...axisProps} domain={["auto", "auto"]} />
+            <YAxis yAxisId="readiness" orientation="right" {...axisProps} domain={[0, 100]} />
+            <Tooltip content={<CustomTooltip />} />
+            <Legend
+              iconType="circle"
+              iconSize={6}
+              wrapperStyle={{ fontSize: "11px", color: "#737373", paddingTop: "8px" }}
+            />
+            <Line
+              yAxisId="hrv"
+              type="monotone"
+              dataKey="hrv"
+              name="HRV (ms)"
+              stroke="#3b82f6"
+              strokeWidth={1.5}
+              dot={false}
+              activeDot={{ r: 3, strokeWidth: 0 }}
+              connectNulls
+              animationDuration={600}
+            />
+            <Line
+              yAxisId="readiness"
+              type="monotone"
+              dataKey="readiness"
+              name="Readiness"
+              stroke="#a3e635"
+              strokeWidth={1.5}
+              dot={false}
+              activeDot={{ r: 3, strokeWidth: 0 }}
+              connectNulls
+              animationDuration={600}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      )}
+
+      {/* Recent workout row */}
+      {recentWorkout && (
+        <div className="mt-3 pt-3 border-t border-neutral-800 flex items-center justify-between">
+          <div>
+            <p className="text-xs text-neutral-500 mb-0.5">Last workout</p>
+            <p className="text-sm text-neutral-300 font-medium">{recentWorkout.activity}</p>
+          </div>
+          <div className="text-right">
+            <p className="text-xs font-[family-name:var(--font-mono)] text-neutral-400">
+              {recentWorkout.duration_mins != null && <span>{recentWorkout.duration_mins}m</span>}
+              {recentWorkout.calories != null && (
+                <span>{recentWorkout.duration_mins != null ? " · " : ""}{recentWorkout.calories} cal</span>
+              )}
+              {recentWorkout.avg_hr != null && <span> · {recentWorkout.avg_hr} bpm</span>}
+            </p>
+            <p className="text-xs text-neutral-600 mt-0.5">{recentWorkout.date}</p>
+          </div>
+          <Link
+            href="/fitness"
+            className="ml-4 text-xs text-neutral-500 hover:text-neutral-300 transition-colors"
+            onClick={(e) => e.stopPropagation()}
+          >
+            View all →
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replaces the static `FitnessSummary` card with a full-width `TrendsCard` component
- Dual-tab chart: **Body Comp** (weight + body fat %, dual-axis) and **Recovery** (HRV + readiness, dual-axis)
- Time window toggle: 7d / 30d / 90d, applied client-side from a 90-row data fetch
- `ScheduleToday` promoted to its own full-width row below the trends card
- `RecoverySummary` correctly receives last-14 entries; `TrendsCard` receives full 90-row dataset

## Test plan
- [ ] Body Comp tab renders weight and body fat lines with correct dual axes
- [ ] Recovery tab renders HRV and readiness lines with correct dual axes
- [ ] 7d / 30d / 90d toggles filter data correctly without page reload
- [ ] Recent workout row appears at bottom of card
- [ ] RecoverySummary still shows 14-day HRV sparkline and sleep breakdown correctly
- [ ] ScheduleToday renders in its own full-width row
- [ ] Empty states render correctly when no data for a given window

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)