### PR TITLE
feat: HRV drop alert, task due-date notifications, upcoming birthday widget

### DIFF
--- a/scripts/check_daily_alerts.py
+++ b/scripts/check_daily_alerts.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Daily task due-date push notifications.
+
+Queries tasks table for active tasks with due_date <= today and fires one
+notify.sh call per task. Distinguishes "due today" vs "overdue". Runs at most
+once per day — tracked via profile key task_alerts_last_notified.
+
+Requires: supabase, python-dotenv
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+from _supabase import get_client
+
+NOTIFY_SCRIPT = ROOT / "scripts" / "notify.sh"
+
+
+def get_profile_value(client, key: str) -> str | None:
+    rows = (
+        client.table("profile")
+        .select("value")
+        .eq("key", key)
+        .limit(1)
+        .execute()
+        .data
+    )
+    return rows[0]["value"] if rows else None
+
+
+def set_profile_value(client, key: str, value: str) -> None:
+    client.table("profile").upsert({"key": key, "value": value}, on_conflict="key").execute()
+
+
+def main() -> None:
+    try:
+        client = get_client()
+    except Exception as e:
+        print(f"[check_daily_alerts] Supabase connection error: {e}", file=sys.stderr)
+        return
+
+    today_str = date.today().isoformat()
+
+    # Once-per-day guard
+    last_notified = get_profile_value(client, "task_alerts_last_notified")
+    if last_notified == today_str:
+        return
+
+    # Query active tasks with a due date on or before today
+    try:
+        rows = (
+            client.table("tasks")
+            .select("id, name, due_date")
+            .eq("status", "active")
+            .not_("due_date", "is", None)
+            .lte("due_date", today_str)
+            .order("due_date", desc=False)
+            .execute()
+            .data
+        )
+    except Exception as e:
+        print(f"[check_daily_alerts] tasks query error: {e}", file=sys.stderr)
+        return
+
+    if not rows:
+        # Still mark as run so we don't re-query all day
+        set_profile_value(client, "task_alerts_last_notified", today_str)
+        return
+
+    fired = 0
+    for task in rows:
+        due = task.get("due_date", "")
+        name = task.get("name", "(unnamed task)")
+        is_today = due == today_str
+        title = "Task Due Today" if is_today else "Task Overdue"
+        message = f"{name} — due {due}" if not is_today else f"{name} — due today"
+        try:
+            subprocess.run(
+                ["bash", str(NOTIFY_SCRIPT), "--title", title, "--message", message],
+                check=True,
+            )
+            fired += 1
+        except Exception as e:
+            print(f"[check_daily_alerts] notify error for task '{name}': {e}", file=sys.stderr)
+
+    set_profile_value(client, "task_alerts_last_notified", today_str)
+    if fired:
+        print(f"[check_daily_alerts] Fired {fired} task alert(s).")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_hrv_alert.py
+++ b/scripts/check_hrv_alert.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Check today's HRV against a 7-day rolling baseline. Fires a push notification
+via notify.sh if today's HRV is more than hrv_alert_threshold% below baseline.
+
+Alert fires at most once per day — tracked via profile key hrv_alert_last_notified.
+Threshold is configurable via profile key hrv_alert_threshold (default: 20).
+
+Requires: supabase, python-dotenv
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+from _supabase import get_client
+
+NOTIFY_SCRIPT = ROOT / "scripts" / "notify.sh"
+DEFAULT_THRESHOLD = 20  # percent
+
+
+def get_profile_value(client, key: str) -> str | None:
+    rows = (
+        client.table("profile")
+        .select("value")
+        .eq("key", key)
+        .limit(1)
+        .execute()
+        .data
+    )
+    return rows[0]["value"] if rows else None
+
+
+def set_profile_value(client, key: str, value: str) -> None:
+    client.table("profile").upsert({"key": key, "value": value}, on_conflict="key").execute()
+
+
+def main() -> None:
+    try:
+        client = get_client()
+    except Exception as e:
+        print(f"[check_hrv_alert] Supabase connection error: {e}", file=sys.stderr)
+        return
+
+    # Once-per-day guard
+    today_str = date.today().isoformat()
+    last_notified = get_profile_value(client, "hrv_alert_last_notified")
+    if last_notified == today_str:
+        return
+
+    # Read threshold from profile (default 20%)
+    threshold_raw = get_profile_value(client, "hrv_alert_threshold")
+    try:
+        threshold = float(threshold_raw) if threshold_raw else DEFAULT_THRESHOLD
+    except ValueError:
+        threshold = DEFAULT_THRESHOLD
+
+    # Fetch last 8 days of HRV (desc), filter out nulls
+    cutoff = (date.today() - timedelta(days=7)).isoformat()
+    rows = (
+        client.table("recovery_metrics")
+        .select("date, avg_hrv")
+        .not_("avg_hrv", "is", None)
+        .gte("date", cutoff)
+        .order("date", desc=True)
+        .limit(8)
+        .execute()
+        .data
+    )
+
+    if not rows:
+        return
+
+    # Most recent row = today (or most recent available)
+    most_recent_date = rows[0]["date"]
+    if most_recent_date != today_str:
+        # Oura data lags — today's data isn't in yet, nothing to check
+        return
+
+    today_hrv = rows[0]["avg_hrv"]
+    if today_hrv is None:
+        return
+
+    # Baseline = average of the prior 7 days (rows[1:8])
+    baseline_rows = [r["avg_hrv"] for r in rows[1:] if r["avg_hrv"] is not None]
+    if len(baseline_rows) < 3:
+        # Not enough history to compute a reliable baseline
+        return
+
+    baseline = sum(baseline_rows) / len(baseline_rows)
+    drop_pct = (baseline - today_hrv) / baseline * 100
+
+    if drop_pct <= threshold:
+        return
+
+    # Fire alert
+    title = "HRV Drop Alert"
+    message = (
+        f"HRV is {today_hrv:.0f}ms — {drop_pct:.0f}% below 7-day avg "
+        f"({baseline:.0f}ms). Consider rest or deload."
+    )
+    try:
+        subprocess.run(
+            ["bash", str(NOTIFY_SCRIPT), "--title", title, "--message", message],
+            check=True,
+        )
+        set_profile_value(client, "hrv_alert_last_notified", today_str)
+        print(f"[check_hrv_alert] Alert fired: {message}")
+    except Exception as e:
+        print(f"[check_hrv_alert] notify error: {e}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run-syncs.py
+++ b/scripts/run-syncs.py
@@ -27,6 +27,12 @@ SYNCS: list[tuple[str, list[str]]] = [
     ("fitbit",     ["scripts/sync-fitbit.py",    "--yes"]),
 ]
 
+# Alert scripts run after syncs — order matters (HRV needs fresh Oura data)
+ALERTS: list[list[str]] = [
+    ["scripts/check_hrv_alert.py"],
+    ["scripts/check_daily_alerts.py"],
+]
+
 
 def last_sync_age(client, source: str) -> float | None:
     """Return seconds since last successful sync for source, or None if never."""
@@ -84,6 +90,7 @@ def main() -> None:
 
     if not to_run:
         print("[run-syncs] All syncs up to date.")
+        _run_alerts()
         return
 
     print(f"[run-syncs] Running in parallel: {', '.join(s for s, _ in to_run)}")
@@ -103,6 +110,28 @@ def main() -> None:
                     log_sync(client, source, "ok", 0)
                 except Exception:
                     pass
+
+    _run_alerts()
+
+
+def _run_alerts() -> None:
+    """Run alert scripts sequentially after syncs. Errors are non-fatal."""
+    for cmd in ALERTS:
+        try:
+            result = subprocess.run(
+                [sys.executable] + cmd,
+                capture_output=True,
+                text=True,
+                cwd=str(ROOT),
+            )
+            if result.returncode != 0:
+                print(f"[run-syncs] alert {cmd[0]} FAILED (exit {result.returncode})")
+                if result.stderr.strip():
+                    print(result.stderr.strip())
+            elif result.stdout.strip():
+                print(result.stdout.strip())
+        except Exception as e:
+            print(f"[run-syncs] alert {cmd[0]} error: {e}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/web/src/app/(protected)/page.tsx
+++ b/web/src/app/(protected)/page.tsx
@@ -9,6 +9,7 @@ import RecoverySummary from "@/components/dashboard/recovery-summary";
 import FunFact from "@/components/dashboard/fun-fact";
 import ScheduleToday from "@/components/dashboard/schedule-today";
 import ImportantEmails from "@/components/dashboard/important-emails";
+import UpcomingBirthdayWidget from "@/components/dashboard/upcoming-birthday";
 import type { HabitLog, HabitRegistry, Task, FitnessLog, RecoveryMetrics, WorkoutSession } from "@/lib/types";
 import { todayString, USER_TZ } from "@/lib/timezone";
 import { computeStreaks } from "@/lib/streaks";
@@ -103,6 +104,9 @@ export default async function DashboardPage() {
         <h1 className="text-xl font-semibold text-neutral-100">{greeting}</h1>
         <p className="text-sm text-neutral-500 mt-0.5">{dateStr}</p>
       </div>
+
+      {/* Upcoming birthday — renders nothing if no birthday in next 60 days */}
+      <UpcomingBirthdayWidget />
 
       {/* Bento grid */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">

--- a/web/src/app/api/google/calendar/upcoming-birthday/route.ts
+++ b/web/src/app/api/google/calendar/upcoming-birthday/route.ts
@@ -1,0 +1,97 @@
+import { google } from "googleapis";
+import { NextResponse } from "next/server";
+import { getGoogleAuthClient } from "@/lib/google-auth";
+import { todayString, USER_TZ } from "@/lib/timezone";
+
+export interface UpcomingBirthday {
+  name: string;
+  date: string;       // YYYY-MM-DD
+  daysUntil: number;
+}
+
+function tzOffsetString(tz: string): string {
+  const now = new Date();
+  const utc = new Date(now.toLocaleString("en-US", { timeZone: "UTC" }));
+  const local = new Date(now.toLocaleString("en-US", { timeZone: tz }));
+  const diffMins = Math.round((local.getTime() - utc.getTime()) / 60_000);
+  const sign = diffMins >= 0 ? "+" : "-";
+  const abs = Math.abs(diffMins);
+  const h = String(Math.floor(abs / 60)).padStart(2, "0");
+  const m = String(abs % 60).padStart(2, "0");
+  return `${sign}${h}:${m}`;
+}
+
+function isBirthdayEvent(title: string, calName: string): boolean {
+  return /'s birthday$/i.test(title) || calName.toLowerCase().includes("birthday");
+}
+
+function personName(title: string): string {
+  return title.replace(/'s birthday$/i, "").trim();
+}
+
+/** Parse YYYY-MM-DD or ISO dateTime, return just the date portion as YYYY-MM-DD. */
+function parseEventDate(event: { start?: { date?: string | null; dateTime?: string | null } }): string | null {
+  const d = event.start?.date ?? event.start?.dateTime;
+  if (!d) return null;
+  return d.slice(0, 10);
+}
+
+export async function GET() {
+  try {
+    const auth = getGoogleAuthClient();
+    const calendar = google.calendar({ version: "v3", auth });
+
+    const today = todayString();
+    const offset = tzOffsetString(USER_TZ);
+    const timeMin = `${today}T00:00:00${offset}`;
+
+    const lookaheadDate = new Date(Date.now() + 60 * 86_400_000);
+    const lookaheadStr = new Intl.DateTimeFormat("en-CA", { timeZone: USER_TZ }).format(lookaheadDate);
+    const timeMax = `${lookaheadStr}T23:59:59${offset}`;
+
+    const calListRes = await calendar.calendarList.list({ minAccessRole: "reader" });
+    const calendars = calListRes.data.items ?? [];
+
+    const candidates: UpcomingBirthday[] = [];
+
+    await Promise.all(
+      calendars.map(async (cal) => {
+        const calName = cal.summaryOverride ?? cal.summary ?? cal.id ?? "Unknown";
+        try {
+          const res = await calendar.events.list({
+            calendarId: cal.id!,
+            timeMin,
+            timeMax,
+            singleEvents: true,
+            orderBy: "startTime",
+            maxResults: 50,
+          });
+          for (const e of res.data.items ?? []) {
+            if (e.status === "cancelled") continue;
+            const title = e.summary ?? "";
+            if (!isBirthdayEvent(title, calName)) continue;
+            const dateStr = parseEventDate(e);
+            if (!dateStr) continue;
+            const daysUntil = Math.round(
+              (new Date(dateStr).getTime() - new Date(today).getTime()) / 86_400_000
+            );
+            candidates.push({ name: personName(title), date: dateStr, daysUntil });
+          }
+        } catch {
+          // non-accessible calendar — skip
+        }
+      })
+    );
+
+    if (candidates.length === 0) {
+      return NextResponse.json({ birthday: null });
+    }
+
+    // Sort by daysUntil ascending, pick nearest
+    candidates.sort((a, b) => a.daysUntil - b.daysUntil);
+    return NextResponse.json({ birthday: candidates[0] });
+  } catch (err) {
+    console.error("[upcoming-birthday] error:", err);
+    return NextResponse.json({ birthday: null, error: "Failed to fetch birthday" });
+  }
+}

--- a/web/src/components/dashboard/upcoming-birthday.tsx
+++ b/web/src/components/dashboard/upcoming-birthday.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Gift } from "lucide-react";
+import type { UpcomingBirthday } from "@/app/api/google/calendar/upcoming-birthday/route";
+
+function formatDisplayDate(dateStr: string): string {
+  // dateStr is YYYY-MM-DD; append T12:00 to avoid UTC-shift on date-only strings
+  const d = new Date(`${dateStr}T12:00:00`);
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+export default function UpcomingBirthdayWidget() {
+  const [birthday, setBirthday] = useState<UpcomingBirthday | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/google/calendar/upcoming-birthday")
+      .then((r) => r.json())
+      .then((d) => setBirthday(d.birthday ?? null))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading || !birthday) return null;
+
+  const isToday = birthday.daysUntil === 0;
+  const label = isToday
+    ? "Today!"
+    : `in ${birthday.daysUntil} day${birthday.daysUntil === 1 ? "" : "s"} (${formatDisplayDate(birthday.date)})`;
+
+  return (
+    <div className={`flex items-center gap-2 px-3 py-2 rounded-lg border text-sm ${
+      isToday
+        ? "bg-rose-950/40 border-rose-800/50 text-rose-300"
+        : "bg-neutral-900 border-neutral-800 text-neutral-400"
+    }`}>
+      <Gift size={13} className={isToday ? "text-rose-400 shrink-0" : "text-rose-500/70 shrink-0"} />
+      <span>
+        <span className={isToday ? "text-rose-300 font-medium" : "text-neutral-200"}>
+          {birthday.name}&apos;s birthday
+        </span>
+        {" — "}
+        <span className={isToday ? "text-rose-400 font-semibold" : "text-neutral-500"}>
+          {label}
+        </span>
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **#60 — HRV drop alert**: `check_hrv_alert.py` queries last 8 days of `recovery_metrics`, computes 7-day rolling baseline, fires push notification if today's HRV drops more than `hrv_alert_threshold`% (default 20). Once-per-day guard via `profile` key `hrv_alert_last_notified`.
- **#59 — Task due-date notifications**: `check_daily_alerts.py` queries active tasks with `due_date <= today`, fires one notification per task ("Task Due Today" / "Task Overdue"). Once-per-day guard via `profile` key `task_alerts_last_notified`.
- Both alert scripts wired into `run-syncs.py` — run sequentially after syncs complete via `_run_alerts()`.
- **Birthday dashboard widget**: new `/api/google/calendar/upcoming-birthday` route scans 60 days ahead and returns the nearest birthday event. `UpcomingBirthdayWidget` component renders between the header and bento grid — highlighted in rose on the birthday itself, subtle otherwise.

## Test plan
- [ ] Verify `check_hrv_alert.py` fires when today's HRV is manually set below threshold in `recovery_metrics`
- [ ] Verify `check_hrv_alert.py` is silent when `hrv_alert_last_notified` = today in profile
- [ ] Verify `check_daily_alerts.py` fires per-task for active tasks with past/today due dates
- [ ] Verify `check_daily_alerts.py` is silent on second run (once-per-day guard)
- [ ] Confirm both alert scripts run automatically via `python3 scripts/run-syncs.py`
- [ ] Confirm `/api/google/calendar/upcoming-birthday` returns correct nearest birthday
- [ ] Confirm birthday widget appears on dashboard, hides when no upcoming birthdays
- [ ] Confirm today birthday renders with rose highlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)