### PR TITLE
feat: expand Oura sync + dashboard redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+- `scripts/sync-oura.py` — `daily_activity` end_date is exclusive; changed `end_str` to `now + 1 day` so today's steps/calories are included in the sync
+- `scripts/sync-oura.py` — `all_dates` union now includes `activity` dates so today's activity row is written even when readiness/sleep haven't finalized yet
+
 ### Added
+- `scripts/sync-oura.py` — `fetch_heartrate()`: fetches intraday HR samples via `heartrate` endpoint (start_datetime/end_datetime params), groups by date, stores `hr_avg_day`, `hr_min_day`, `hr_max_day` in `recovery_metrics.metadata`
+- `scripts/sync-oura.py` — `fetch_oura_workouts()`: fetches Oura-detected workouts via `workout` endpoint; writes to `workout_sessions` table (source=`oura`) with intensity, distance, MET, and zone breakdown in metadata; deduplicates by clearing oura rows in range before re-insert
+- `scripts/sync-oura.py` — `oura_get_datetime()`: new helper for endpoints that use `start_datetime`/`end_datetime` params instead of `start_date`/`end_date`
 - `scripts/fetch_weather.py` — Open-Meteo weather helper (no API key); resolves location from profile in order: `location_lat`/`location_lon` → `location_city` (geocoded) → `Identity/Location` (geocoded via Open-Meteo free geocoding API); `fetch_weather()` accepts optional `profile` dict to skip second Supabase round-trip; `format_weather_line()` produces single-line briefing format; closes #77
 - `scripts/check_weather_alert.py` — once-per-day push notifications for precip >0.2in, thunderstorm (WMO 95–99), high >95°F, low <28°F, wind >30mph; guard via `weather_alert_last_notified` profile key; closes #77
 - `web/src/app/api/weather/route.ts` — Next.js API route; same location resolution logic; 30-minute Next.js cache via `next: { revalidate: 1800 }`

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ mr-bridge-assistant/
 │   │   │       ├── weather-card.tsx       # Weather inline with greeting header (Open-Meteo)
 │   │   │       ├── schedule-today.tsx     # Google Calendar card
 │   │   │       ├── important-emails.tsx   # Gmail card
-│   │   │       ├── recovery-summary.tsx   # Oura recovery & sleep card
-│   │   │       ├── recovery-trends.tsx    # Sleep & readiness trend charts (Recharts)
+│   │   │       ├── recovery-summary.tsx   # Oura: 3 scores (readiness/sleep/activity), metrics grid (HRV, RHR, SpO2, steps, temp Δ, sleep stages, daytime HR), stress row, 14-day sleep chart
+│   │   │       ├── recovery-trends.tsx    # 14-day stacked sleep breakdown chart (light/deep/REM)
 │   │   │       ├── fitness-summary.tsx    # Body comp + last workout card
 │   │   │       ├── inline-sparkline.tsx   # Mini trend sparkline (used in summary cards)
 │   │   │       ├── habits-summary.tsx     # Today's habit progress card
@@ -180,7 +180,7 @@ mr-bridge-assistant/
 │   ├── migrate_to_supabase.py             # One-time migration: markdown → Supabase
 │   ├── run-syncs.py                       # Parallel sync orchestrator (skip-if-recent logic)
 │   ├── sync-googlefit.py                  # Google Fit weight → Supabase fitness_log
-│   ├── sync-oura.py                       # Oura recovery metrics → Supabase recovery_metrics
+│   ├── sync-oura.py                       # Oura Ring sync → recovery_metrics + workout_sessions; endpoints: sleep, readiness, activity, spo2, stress, resilience, heartrate, workout
 │   ├── sync-fitbit.py                     # Fitbit workouts → Supabase workout_sessions
 │   ├── sync-renpho.py                     # Renpho CSV → Supabase fitness_log (deprecated)
 │   ├── check_birthday_notif.py            # Birthday push alerts from Google Calendar

--- a/scripts/sync-oura.py
+++ b/scripts/sync-oura.py
@@ -29,7 +29,7 @@ from _supabase import get_client, upsert, log_sync, urlopen_with_retry
 
 
 def oura_get(endpoint: str, start_date: str, end_date: str, required: bool = True) -> dict | None:
-    """Fetch an Oura v2 endpoint. Returns None (instead of exiting) when required=False and a 4xx occurs."""
+    """Fetch an Oura v2 endpoint with start_date/end_date params. Returns None when required=False and a 4xx occurs."""
     token = os.environ.get("OURA_ACCESS_TOKEN", "")
     if not token:
         print("[error] OURA_ACCESS_TOKEN not set in .env")
@@ -43,6 +43,27 @@ def oura_get(endpoint: str, start_date: str, end_date: str, required: bool = Tru
         return urlopen_with_retry(req)
     except urllib.error.HTTPError as e:
         if not required and e.code in (400, 403, 404, 422):
+            print(f"[info] Oura {endpoint} not available ({e.code}) — skipping")
+            return None
+        print(f"[error] Oura API {endpoint} returned {e.code}: {e.read().decode()}")
+        sys.exit(1)
+
+
+def oura_get_datetime(endpoint: str, start_dt: str, end_dt: str) -> dict | None:
+    """Fetch an Oura v2 endpoint with start_datetime/end_datetime params (e.g. heartrate, workout)."""
+    token = os.environ.get("OURA_ACCESS_TOKEN", "")
+    if not token:
+        print("[error] OURA_ACCESS_TOKEN not set in .env")
+        sys.exit(1)
+    url = (
+        f"https://api.ouraring.com/v2/usercollection/{endpoint}"
+        f"?start_datetime={start_dt}&end_datetime={end_dt}"
+    )
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+    try:
+        return urlopen_with_retry(req)
+    except urllib.error.HTTPError as e:
+        if e.code in (400, 403, 404, 422):
             print(f"[info] Oura {endpoint} not available ({e.code}) — skipping")
             return None
         print(f"[error] Oura API {endpoint} returned {e.code}: {e.read().decode()}")
@@ -207,9 +228,108 @@ def fetch_vo2_max(start: str, end: str) -> dict:
     return result
 
 
+def fetch_heartrate(start_dt: str, end_dt: str) -> dict:
+    """
+    Fetch intraday heart rate samples and group by date.
+    Returns dict keyed by date with hr_avg_day, hr_min_day, hr_max_day.
+    Uses datetime params (start_datetime/end_datetime).
+    """
+    data = oura_get_datetime("heartrate", start_dt, end_dt)
+    if not data:
+        return {}
+
+    # Group bpm samples by date
+    by_date: dict[str, list[int]] = {}
+    for item in data.get("data", []):
+        ts = item.get("timestamp", "")
+        bpm = item.get("bpm")
+        if not ts or bpm is None:
+            continue
+        day = ts[:10]  # YYYY-MM-DD
+        by_date.setdefault(day, []).append(bpm)
+
+    result: dict[str, dict] = {}
+    for day, samples in by_date.items():
+        if not samples:
+            continue
+        result[day] = {
+            "hr_avg_day": int(round(sum(samples) / len(samples))),
+            "hr_min_day": min(samples),
+            "hr_max_day": max(samples),
+        }
+    return result
+
+
+def fetch_oura_workouts(start_dt: str, end_dt: str) -> list[dict]:
+    """
+    Fetch Oura-detected workouts. Returns list of dicts ready for workout_sessions upsert.
+    Uses datetime params (start_datetime/end_datetime).
+    """
+    data = oura_get_datetime("workout", start_dt, end_dt)
+    if not data:
+        return []
+
+    rows = []
+    for d in data.get("data", []):
+        day = d.get("day")
+        if not day:
+            continue
+        start_iso = d.get("start_datetime", "")
+        end_iso = d.get("end_datetime", "")
+
+        duration_mins = None
+        if start_iso and end_iso:
+            try:
+                fmt = "%Y-%m-%dT%H:%M:%S%z"
+                dt_start = datetime.strptime(start_iso[:19], "%Y-%m-%dT%H:%M:%S")
+                dt_end   = datetime.strptime(end_iso[:19],   "%Y-%m-%dT%H:%M:%S")
+                duration_mins = int((dt_end - dt_start).total_seconds() / 60)
+            except Exception:
+                pass
+
+        rows.append({
+            "date":         day,
+            "start_time":   fmt_time(start_iso),
+            "activity":     d.get("activity") or "unknown",
+            "duration_mins": duration_mins,
+            "calories":     int(d["calories"]) if d.get("calories") is not None else None,
+            "avg_hr":       None,  # Oura workout endpoint doesn't expose avg_hr
+            "notes":        d.get("label"),
+            "source":       "oura",
+            "metadata": {
+                "oura_id":              d.get("id"),
+                "intensity":            d.get("intensity"),
+                "distance_meters":      d.get("distance"),
+                "avg_met":              d.get("average_met_level"),
+                "low_intensity_mins":   secs_to_mins(d.get("low_intensity_time")),
+                "med_intensity_mins":   secs_to_mins(d.get("medium_intensity_time")),
+                "high_intensity_mins":  secs_to_mins(d.get("high_intensity_time")),
+            },
+        })
+    return rows
+
+
 def existing_dates(client) -> set:
     rows = client.table("recovery_metrics").select("date").execute().data
     return {r["date"] for r in rows}
+
+
+def sync_oura_workouts(client, workout_rows: list[dict], start_date: str, end_date: str) -> int:
+    """
+    Replace all oura-source workout_sessions rows in the date range, then insert fresh.
+    Returns number of rows written.
+    """
+    if not workout_rows:
+        return 0
+    # Clear existing oura workouts in the range to avoid duplicates
+    client.table("workout_sessions") \
+        .delete() \
+        .eq("source", "oura") \
+        .gte("date", start_date) \
+        .lte("date", end_date) \
+        .execute()
+    result = client.table("workout_sessions").insert(workout_rows).execute()
+    return len(result.data) if result.data else len(workout_rows)
 
 
 def main():
@@ -218,23 +338,30 @@ def main():
     parser.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
     args = parser.parse_args()
 
-    end = datetime.now()
-    start = end - timedelta(days=args.days)
+    now = datetime.now()
+    start = now - timedelta(days=args.days)
     start_str = start.strftime("%Y-%m-%d")
-    end_str = end.strftime("%Y-%m-%d")
+    # daily_activity end_date is exclusive — add 1 day to include today
+    end_str = (now + timedelta(days=1)).strftime("%Y-%m-%d")
+    # datetime range for heartrate and workout endpoints
+    start_dt = start.strftime("%Y-%m-%dT00:00:00")
+    end_dt   = now.strftime("%Y-%m-%dT23:59:59")
 
-    print(f"[sync-oura] Fetching {start_str} to {end_str}...")
+    print(f"[sync-oura] Fetching {start_str} to {now.strftime('%Y-%m-%d')}...")
 
-    sleep_detail      = fetch_sleep_detail(start_str, end_str)
+    sleep_detail         = fetch_sleep_detail(start_str, end_str)
     readiness, body_temp = fetch_readiness(start_str, end_str)
-    sleep_scores      = fetch_sleep_scores(start_str, end_str)
-    activity          = fetch_activity(start_str, end_str)
-    spo2              = fetch_spo2(start_str, end_str)
-    stress            = fetch_stress(start_str, end_str)
-    resilience        = fetch_resilience(start_str, end_str)
-    vo2               = fetch_vo2_max(start_str, end_str)
+    sleep_scores         = fetch_sleep_scores(start_str, end_str)
+    activity             = fetch_activity(start_str, end_str)
+    spo2                 = fetch_spo2(start_str, end_str)
+    stress               = fetch_stress(start_str, end_str)
+    resilience           = fetch_resilience(start_str, end_str)
+    vo2                  = fetch_vo2_max(start_str, end_str)
+    heartrate            = fetch_heartrate(start_dt, end_dt)
+    workout_rows         = fetch_oura_workouts(start_dt, end_dt)
 
-    all_dates = sorted(set(readiness) | set(sleep_detail))
+    # Include activity dates so today's steps/calories appear even before readiness is finalized
+    all_dates = sorted(set(readiness) | set(sleep_detail) | set(activity))
 
     if not all_dates:
         print("[sync-oura] No data returned from Oura.")
@@ -249,6 +376,7 @@ def main():
     for d in all_dates:
         sd  = sleep_detail.get(d, {})
         act = activity.get(d, {})
+        hr  = heartrate.get(d, {})
         tag = "NEW" if d in new_dates else "UPD"
         print(
             f"  [{tag}] {d} — "
@@ -263,8 +391,16 @@ def main():
             f"SpO2: {spo2.get(d)} | "
             f"Steps: {act.get('steps')} | "
             f"Active Cal: {act.get('active_cal')} | "
+            f"HR day avg/min/max: {hr.get('hr_avg_day')}/{hr.get('hr_min_day')}/{hr.get('hr_max_day')} | "
             f"VO2: {vo2.get(d)}"
         )
+
+    if workout_rows:
+        print(f"\nOura workouts to write: {len(workout_rows)}")
+        for w in workout_rows:
+            print(f"  {w['date']} — {w['activity']} {w['duration_mins']}min | Cal: {w['calories']} | {w['metadata'].get('intensity')}")
+    else:
+        print("\nOura workouts: none detected in range")
 
     if not args.yes:
         confirm = input("\nWrite to Supabase? [y/N] ").strip().lower()
@@ -277,6 +413,7 @@ def main():
         sd  = sleep_detail.get(d, {})
         act = activity.get(d, {})
         st  = stress.get(d, {})
+        hr  = heartrate.get(d, {})
 
         meta: dict = {}
         if sd.get("bedtime_end"):
@@ -305,6 +442,12 @@ def main():
             meta["resilience_level"] = resilience[d]
         if vo2.get(d) is not None:
             meta["vo2_max"] = vo2[d]
+        if hr.get("hr_avg_day") is not None:
+            meta["hr_avg_day"] = hr["hr_avg_day"]
+        if hr.get("hr_min_day") is not None:
+            meta["hr_min_day"] = hr["hr_min_day"]
+        if hr.get("hr_max_day") is not None:
+            meta["hr_max_day"] = hr["hr_max_day"]
 
         sb_rows.append({
             "date":            d,
@@ -327,8 +470,9 @@ def main():
         })
 
     written = upsert(client, "recovery_metrics", sb_rows, conflict="date")
-    log_sync(client, "oura", "ok", written)
-    print(f"[sync-oura] Upserted {written} row(s) to Supabase.")
+    workout_written = sync_oura_workouts(client, workout_rows, start_str, now.strftime("%Y-%m-%d"))
+    log_sync(client, "oura", "ok", written + workout_written)
+    print(f"[sync-oura] Upserted {written} recovery row(s), {workout_written} workout row(s) to Supabase.")
 
 
 if __name__ == "__main__":

--- a/web/src/app/(protected)/page.tsx
+++ b/web/src/app/(protected)/page.tsx
@@ -61,15 +61,15 @@ export default async function DashboardPage() {
       .maybeSingle(),
     supabase
       .from("recovery_metrics")
-      .select("date, avg_hrv, readiness, total_sleep_hrs, light_hrs, deep_hrs, rem_hrs")
+      .select("date, avg_hrv, readiness, sleep_score, total_sleep_hrs, light_hrs, deep_hrs, rem_hrs, steps, active_cal, spo2_avg, activity_score, metadata")
       .order("date", { ascending: false })
-      .limit(90),
+      .limit(365),
     supabase
       .from("fitness_log")
       .select("date, weight_lb, body_fat_pct")
       .not("body_fat_pct", "is", null)
       .order("date", { ascending: true })
-      .limit(90),
+      .limit(365),
     supabase
       .from("workout_sessions")
       .select("*")

--- a/web/src/components/dashboard/recovery-summary.tsx
+++ b/web/src/components/dashboard/recovery-summary.tsx
@@ -28,8 +28,7 @@ function accentBar(score: number | null): string {
   return "bg-red-500/50";
 }
 
-function statusLabel(recovery: RecoveryMetrics): string {
-  const r = recovery.readiness;
+function statusLabel(r: number | null): string {
   if (r == null) return "Readiness unknown";
   if (r >= 85) return "Recovery optimal — push hard today";
   if (r >= 70) return "Recovery good — normal training";
@@ -45,11 +44,46 @@ function statusColor(score: number | null): string {
   return "text-red-400/80 border-red-900 bg-red-950/20";
 }
 
-function fmtHrs(hrs: number | null): string {
+function fmtHrs(hrs: number | null | undefined): string {
   if (hrs == null) return "—";
   const h = Math.floor(hrs);
   const m = Math.round((hrs - h) * 60);
   return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+function fmtNum(n: number | null | undefined, decimals = 0): string {
+  if (n == null) return "—";
+  return decimals > 0 ? n.toFixed(decimals) : Math.round(n).toLocaleString();
+}
+
+// Safely read a value from the metadata jsonb blob
+function meta(recovery: RecoveryMetrics, key: string): number | string | null {
+  const val = recovery.metadata?.[key];
+  if (val == null) return null;
+  if (typeof val === "number" || typeof val === "string") return val;
+  return null;
+}
+
+interface MetricProps {
+  label: string;
+  value: string;
+  unit?: string;
+  children?: React.ReactNode;
+}
+
+function Metric({ label, value, unit, children }: MetricProps) {
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      <span className="text-neutral-500 text-xs w-[4.5rem] shrink-0">{label}</span>
+      <span className="font-[family-name:var(--font-mono)] text-neutral-200 shrink-0 text-sm">
+        {value}
+        {unit && value !== "—" && (
+          <span className="text-xs text-neutral-500 ml-0.5">{unit}</span>
+        )}
+      </span>
+      {children}
+    </div>
+  );
 }
 
 export default function RecoverySummary({ recovery, trends }: Props) {
@@ -57,7 +91,6 @@ export default function RecoverySummary({ recovery, trends }: Props) {
 
   return (
     <div className="bg-neutral-900 rounded-xl border border-neutral-800 overflow-hidden h-full">
-      {/* Color accent bar at top */}
       <div className={`h-0.5 w-full ${accentBar(recovery?.readiness ?? null)}`} />
 
       <div className="p-5">
@@ -65,7 +98,7 @@ export default function RecoverySummary({ recovery, trends }: Props) {
 
         {recovery ? (
           <div className="space-y-4">
-            {/* Big scores */}
+            {/* Three scores */}
             <div className={`flex items-end gap-8 rounded-xl p-4 ${scoreBg(recovery.readiness)}`}>
               <div>
                 <p className="text-xs text-neutral-500 uppercase tracking-wide mb-1">Readiness</p>
@@ -79,53 +112,106 @@ export default function RecoverySummary({ recovery, trends }: Props) {
                   {recovery.sleep_score ?? "—"}
                 </span>
               </div>
+              {recovery.activity_score != null && (
+                <div className="pb-1">
+                  <p className="text-xs text-neutral-500 uppercase tracking-wide mb-1">Activity</p>
+                  <span className={`text-[2.5rem] font-bold font-[family-name:var(--font-mono)] leading-none ${scoreColor(recovery.activity_score)}`}>
+                    {recovery.activity_score}
+                  </span>
+                </div>
+              )}
+              <div className="ml-auto text-right pb-1">
+                <p className={`text-xs font-medium ${statusColor(recovery.readiness).split(" ")[0]}`}>
+                  {statusLabel(recovery.readiness)}
+                </p>
+                <p className="text-xs text-neutral-600 mt-1">Oura · {recovery.date}</p>
+              </div>
             </div>
 
-            {/* Metrics grid */}
-            <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
-              {/* HRV with inline sparkline */}
-              <div className="flex items-center gap-2">
-                <span className="text-neutral-500 text-xs w-12 shrink-0">HRV</span>
-                <span className="font-[family-name:var(--font-mono)] text-neutral-200 shrink-0">
-                  {recovery.avg_hrv ?? "—"}
-                  {recovery.avg_hrv != null && <span className="text-xs text-neutral-500 ml-0.5">ms</span>}
-                </span>
+            {/* Metrics grid — 3 columns */}
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-x-6 gap-y-2.5">
+              {/* Row 1: HRV, RHR, SpO2 */}
+              <Metric label="HRV" value={fmtNum(recovery.avg_hrv)} unit="ms">
                 {trendHrv.length > 2 && (
                   <div className="flex-1 min-w-0">
                     <InlineSparkline data={trendHrv} color="#3b82f6" height={20} />
                   </div>
                 )}
-              </div>
+              </Metric>
+              <Metric label="RHR" value={fmtNum(recovery.resting_hr)} unit="bpm" />
+              <Metric
+                label="SpO2"
+                value={recovery.spo2_avg != null && recovery.spo2_avg > 0 ? fmtNum(recovery.spo2_avg, 1) : "—"}
+                unit="%"
+              />
 
-              <div className="flex items-center gap-2">
-                <span className="text-neutral-500 text-xs w-12 shrink-0">RHR</span>
-                <span className="font-[family-name:var(--font-mono)] text-neutral-200">
-                  {recovery.resting_hr ?? "—"}
-                  {recovery.resting_hr != null && <span className="text-xs text-neutral-500 ml-0.5">bpm</span>}
-                </span>
-              </div>
+              {/* Row 2: Steps, Active Cal, Body Temp */}
+              <Metric label="Steps" value={recovery.steps != null ? recovery.steps.toLocaleString() : "—"} />
+              <Metric label="Active Cal" value={fmtNum(recovery.active_cal)} unit="kcal" />
+              <Metric
+                label="Temp Δ"
+                value={
+                  recovery.body_temp_delta != null
+                    ? `${recovery.body_temp_delta > 0 ? "+" : ""}${(recovery.body_temp_delta * 9 / 5).toFixed(2)}`
+                    : "—"
+                }
+                unit={recovery.body_temp_delta != null ? "°F" : undefined}
+              />
 
-              <div className="flex items-center gap-2">
-                <span className="text-neutral-500 text-xs w-12 shrink-0">Total</span>
-                <span className="font-[family-name:var(--font-mono)] text-neutral-200">
-                  {fmtHrs(recovery.total_sleep_hrs)}
-                </span>
-              </div>
+              {/* Row 3: Sleep stages */}
+              <Metric label="Total Sleep" value={fmtHrs(recovery.total_sleep_hrs)} />
+              <Metric label="Deep" value={fmtHrs(recovery.deep_hrs)} />
+              <Metric label="REM" value={fmtHrs(recovery.rem_hrs)} />
 
-              <div className="flex items-center gap-2">
-                <span className="text-neutral-500 text-xs w-12 shrink-0">Deep</span>
-                <span className="font-[family-name:var(--font-mono)] text-neutral-200">
-                  {fmtHrs(recovery.deep_hrs)}
-                </span>
-              </div>
+              {/* Row 4: Sleep detail + daytime HR (from metadata) */}
+              <Metric
+                label="Efficiency"
+                value={meta(recovery, "sleep_efficiency") != null ? `${meta(recovery, "sleep_efficiency")}` : "—"}
+                unit={meta(recovery, "sleep_efficiency") != null ? "%" : undefined}
+              />
+              <Metric
+                label="Latency"
+                value={meta(recovery, "latency_mins") != null ? `${meta(recovery, "latency_mins")}` : "—"}
+                unit={meta(recovery, "latency_mins") != null ? "min" : undefined}
+              />
+              {meta(recovery, "hr_avg_day") != null ? (
+                <Metric
+                  label="Daytime HR"
+                  value={`${meta(recovery, "hr_avg_day")} (${meta(recovery, "hr_min_day")}–${meta(recovery, "hr_max_day")})`}
+                  unit="bpm"
+                />
+              ) : (
+                <Metric label="Light Sleep" value={fmtHrs(recovery.light_hrs)} />
+              )}
             </div>
+
+            {/* Stress row — only if data present */}
+            {(meta(recovery, "stress_high_mins") != null || meta(recovery, "stress_day_summary") != null) && (
+              <div className="flex items-center gap-4 text-xs text-neutral-500 pt-1 border-t border-neutral-800/60">
+                <span className="uppercase tracking-wide">Stress</span>
+                {meta(recovery, "stress_high_mins") != null && (
+                  <span className="font-[family-name:var(--font-mono)] text-neutral-300">
+                    {meta(recovery, "stress_high_mins")}m high
+                    {meta(recovery, "stress_recovery_mins") != null && (
+                      <span> · {meta(recovery, "stress_recovery_mins")}m recovery</span>
+                    )}
+                  </span>
+                )}
+                {meta(recovery, "stress_day_summary") != null && (
+                  <span className="text-neutral-500 capitalize">{String(meta(recovery, "stress_day_summary")).replace(/_/g, " ")}</span>
+                )}
+                {meta(recovery, "resilience_level") != null && (
+                  <span className="ml-auto text-neutral-500 capitalize">
+                    Resilience: {String(meta(recovery, "resilience_level")).replace(/_/g, " ")}
+                  </span>
+                )}
+              </div>
+            )}
 
             {/* Status banner */}
             <div className={`text-xs px-3 py-2 rounded-lg border ${statusColor(recovery.readiness)}`}>
-              {statusLabel(recovery)}
+              {statusLabel(recovery.readiness)}
             </div>
-
-            <p className="text-xs text-neutral-600">Oura · {recovery.date}</p>
 
             {trends && trends.length > 0 && (
               <>

--- a/web/src/components/dashboard/recovery-trends.tsx
+++ b/web/src/components/dashboard/recovery-trends.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import {
-  ComposedChart,
   BarChart,
   Bar,
-  Line,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -56,72 +54,25 @@ export default function RecoveryTrends({ data }: Props) {
 
   const chartData = data.map((d) => ({
     date: d.date.slice(5),
-    hrv: d.avg_hrv,
-    readiness: d.readiness,
     light: d.light_hrs != null ? parseFloat(d.light_hrs.toFixed(1)) : null,
     deep: d.deep_hrs != null ? parseFloat(d.deep_hrs.toFixed(1)) : null,
     rem: d.rem_hrs != null ? parseFloat(d.rem_hrs.toFixed(1)) : null,
   }));
 
   return (
-    <div className="space-y-4 mt-4">
-      {/* HRV + Readiness */}
-      <div>
-        <p className="text-xs text-neutral-500 mb-2">HRV / Readiness — 14 days</p>
-        <ResponsiveContainer width="100%" height={160}>
-          <ComposedChart data={chartData} margin={{ top: 4, right: 8, left: -20, bottom: 0 }}>
-            <CartesianGrid {...gridProps} />
-            <XAxis dataKey="date" {...axisProps} interval="preserveStartEnd" />
-            <YAxis yAxisId="hrv" orientation="left" {...axisProps} domain={["auto", "auto"]} />
-            <YAxis yAxisId="readiness" orientation="right" {...axisProps} domain={[0, 100]} />
-            <Tooltip content={<CustomTooltip />} />
-            <Line
-              yAxisId="hrv"
-              type="monotone"
-              dataKey="hrv"
-              name="HRV (ms)"
-              stroke="#3b82f6"
-              strokeWidth={2}
-              dot={false}
-              activeDot={{ r: 3, strokeWidth: 0 }}
-              connectNulls
-              isAnimationActive
-              animationDuration={800}
-              animationEasing="ease-out"
-            />
-            <Line
-              yAxisId="readiness"
-              type="monotone"
-              dataKey="readiness"
-              name="Readiness"
-              stroke="#a3e635"
-              strokeWidth={2}
-              dot={false}
-              activeDot={{ r: 3, strokeWidth: 0 }}
-              connectNulls
-              isAnimationActive
-              animationDuration={800}
-              animationEasing="ease-out"
-            />
-          </ComposedChart>
-        </ResponsiveContainer>
-      </div>
-
-      {/* Sleep breakdown */}
-      <div>
-        <p className="text-xs text-neutral-500 mb-2">Sleep breakdown — 14 days</p>
-        <ResponsiveContainer width="100%" height={160}>
-          <BarChart data={chartData} margin={{ top: 4, right: 8, left: -20, bottom: 0 }}>
-            <CartesianGrid {...gridProps} />
-            <XAxis dataKey="date" {...axisProps} interval="preserveStartEnd" />
-            <YAxis {...axisProps} domain={[0, "auto"]} />
-            <Tooltip content={<CustomTooltip />} />
-            <Bar dataKey="light" name="Light (h)" stackId="sleep" fill="#6366f1" radius={[0, 0, 0, 0]} isAnimationActive animationDuration={600} />
-            <Bar dataKey="deep" name="Deep (h)" stackId="sleep" fill="#3b82f6" radius={[0, 0, 0, 0]} isAnimationActive animationDuration={600} />
-            <Bar dataKey="rem" name="REM (h)" stackId="sleep" fill="#06b6d4" radius={[2, 2, 0, 0]} isAnimationActive animationDuration={600} />
-          </BarChart>
-        </ResponsiveContainer>
-      </div>
+    <div className="mt-4">
+      <p className="text-xs text-neutral-500 mb-2">Sleep — 14 days</p>
+      <ResponsiveContainer width="100%" height={160}>
+        <BarChart data={chartData} margin={{ top: 4, right: 8, left: -20, bottom: 0 }}>
+          <CartesianGrid {...gridProps} />
+          <XAxis dataKey="date" {...axisProps} interval="preserveStartEnd" />
+          <YAxis {...axisProps} domain={[0, "auto"]} />
+          <Tooltip content={<CustomTooltip />} />
+          <Bar dataKey="light" name="Light (h)" stackId="sleep" fill="#6366f1" radius={[0, 0, 0, 0]} isAnimationActive animationDuration={600} />
+          <Bar dataKey="deep" name="Deep (h)" stackId="sleep" fill="#3b82f6" radius={[0, 0, 0, 0]} isAnimationActive animationDuration={600} />
+          <Bar dataKey="rem" name="REM (h)" stackId="sleep" fill="#06b6d4" radius={[2, 2, 0, 0]} isAnimationActive animationDuration={600} />
+        </BarChart>
+      </ResponsiveContainer>
     </div>
   );
 }

--- a/web/src/components/dashboard/trends-card.tsx
+++ b/web/src/components/dashboard/trends-card.tsx
@@ -4,6 +4,8 @@ import { useState, useMemo } from "react";
 import Link from "next/link";
 import {
   ComposedChart,
+  BarChart,
+  Bar,
   Line,
   XAxis,
   YAxis,
@@ -20,10 +22,10 @@ interface Props {
   recentWorkout: WorkoutSession | null;
 }
 
-type Tab = "bodycomp" | "recovery";
-type Window = "7d" | "30d" | "90d";
+type Tab = "bodycomp" | "recovery" | "activity";
+type Window = "7d" | "30d" | "90d" | "1y";
 
-const WINDOW_DAYS: Record<Window, number> = { "7d": 7, "30d": 30, "90d": 90 };
+const WINDOW_DAYS: Record<Window, number> = { "7d": 7, "30d": 30, "90d": 90, "1y": 365 };
 
 interface TooltipProps {
   active?: boolean;
@@ -57,6 +59,12 @@ const gridProps = {
   vertical: false,
 } as const;
 
+const TAB_LABELS: Record<Tab, string> = {
+  bodycomp: "Body Comp",
+  recovery: "Recovery",
+  activity: "Activity",
+};
+
 export default function TrendsCard({ fitnessData, recoveryData, recentWorkout }: Props) {
   const [tab, setTab] = useState<Tab>("bodycomp");
   const [window, setWindow] = useState<Window>("30d");
@@ -87,20 +95,37 @@ export default function TrendsCard({ fitnessData, recoveryData, recentWorkout }:
           date: d.date.slice(5),
           hrv: d.avg_hrv,
           readiness: d.readiness,
+          spo2: d.spo2_avg != null && d.spo2_avg > 0 ? d.spo2_avg : null,
         })),
     [recoveryData, cutoff]
   );
 
-  const hasBodyComp = bodyCompData.length > 0;
-  const hasRecovery = recoveryChartData.length > 0;
-  const isEmpty = tab === "bodycomp" ? !hasBodyComp : !hasRecovery;
+  const activityChartData = useMemo(
+    () =>
+      recoveryData
+        .filter((d) => d.date >= cutoff && (d.steps != null || d.active_cal != null))
+        .map((d) => ({
+          date: d.date.slice(5),
+          steps: d.steps,
+          activeCal: d.active_cal,
+          activityScore: d.activity_score,
+        })),
+    [recoveryData, cutoff]
+  );
+
+  const isEmpty =
+    tab === "bodycomp"
+      ? bodyCompData.length === 0
+      : tab === "recovery"
+      ? recoveryChartData.length === 0
+      : activityChartData.length === 0;
 
   return (
     <div className="bg-neutral-900 rounded-xl border border-neutral-800 p-4 h-full">
       {/* Header row */}
       <div className="flex items-center justify-between mb-4">
         <div className="flex gap-1">
-          {(["bodycomp", "recovery"] as Tab[]).map((t) => (
+          {(["bodycomp", "recovery", "activity"] as Tab[]).map((t) => (
             <button
               key={t}
               onClick={() => setTab(t)}
@@ -110,12 +135,12 @@ export default function TrendsCard({ fitnessData, recoveryData, recentWorkout }:
                   : "text-neutral-500 hover:text-neutral-300"
               }`}
             >
-              {t === "bodycomp" ? "Body Comp" : "Recovery"}
+              {TAB_LABELS[t]}
             </button>
           ))}
         </div>
         <div className="flex gap-1">
-          {(["7d", "30d", "90d"] as Window[]).map((w) => (
+          {(["7d", "30d", "90d", "1y"] as Window[]).map((w) => (
             <button
               key={w}
               onClick={() => setWindow(w)}
@@ -173,7 +198,7 @@ export default function TrendsCard({ fitnessData, recoveryData, recentWorkout }:
             />
           </ComposedChart>
         </ResponsiveContainer>
-      ) : (
+      ) : tab === "recovery" ? (
         <ResponsiveContainer width="100%" height={200}>
           <ComposedChart data={recoveryChartData} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
             <CartesianGrid {...gridProps} />
@@ -210,6 +235,57 @@ export default function TrendsCard({ fitnessData, recoveryData, recentWorkout }:
               connectNulls
               animationDuration={600}
             />
+            <Line
+              yAxisId="readiness"
+              type="monotone"
+              dataKey="spo2"
+              name="SpO2 %"
+              stroke="#06b6d4"
+              strokeWidth={1}
+              dot={false}
+              activeDot={{ r: 3, strokeWidth: 0 }}
+              connectNulls
+              animationDuration={600}
+              strokeDasharray="4 2"
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      ) : (
+        /* Activity tab: steps bars + active cal line */
+        <ResponsiveContainer width="100%" height={200}>
+          <ComposedChart data={activityChartData} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
+            <CartesianGrid {...gridProps} />
+            <XAxis dataKey="date" {...axisProps} interval="preserveStartEnd" />
+            <YAxis yAxisId="steps" orientation="left" {...axisProps} domain={[0, "auto"]} tickFormatter={(v) => v >= 1000 ? `${(v/1000).toFixed(0)}k` : v} />
+            <YAxis yAxisId="cal" orientation="right" {...axisProps} domain={[0, "auto"]} />
+            <Tooltip content={<CustomTooltip />} />
+            <Legend
+              iconType="circle"
+              iconSize={6}
+              wrapperStyle={{ fontSize: "11px", color: "#737373", paddingTop: "8px" }}
+            />
+            <Bar
+              yAxisId="steps"
+              dataKey="steps"
+              name="Steps"
+              fill="#6366f1"
+              opacity={0.7}
+              radius={[2, 2, 0, 0]}
+              isAnimationActive
+              animationDuration={600}
+            />
+            <Line
+              yAxisId="cal"
+              type="monotone"
+              dataKey="activeCal"
+              name="Active Cal"
+              stroke="#f97316"
+              strokeWidth={1.5}
+              dot={false}
+              activeDot={{ r: 3, strokeWidth: 0 }}
+              connectNulls
+              animationDuration={600}
+            />
           </ComposedChart>
         </ResponsiveContainer>
       )}
@@ -219,7 +295,7 @@ export default function TrendsCard({ fitnessData, recoveryData, recentWorkout }:
         <div className="mt-3 pt-3 border-t border-neutral-800 flex items-center justify-between">
           <div>
             <p className="text-xs text-neutral-500 mb-0.5">Last workout</p>
-            <p className="text-sm text-neutral-300 font-medium">{recentWorkout.activity}</p>
+            <p className="text-sm text-neutral-300 font-medium capitalize">{recentWorkout.activity}</p>
           </div>
           <div className="text-right">
             <p className="text-xs font-[family-name:var(--font-mono)] text-neutral-400">


### PR DESCRIPTION
## Summary

- **Oura sync fixes**: `daily_activity` end_date was exclusive — now passes `+1 day` so today's steps/calories are always included; union activity dates into `all_dates` so today's row is written before readiness/sleep finalize
- **New Oura endpoints**: `heartrate` (intraday HR → avg/min/max per day stored in metadata) and `workout` (Oura-detected workouts written to `workout_sessions` with intensity, distance, MET, zone breakdown)
- **Dashboard redesign**: RecoverySummary now shows three scores (Readiness + Sleep + Activity), a full 3-col metrics grid (HRV, RHR, SpO2, Steps, Active Cal, Temp Δ in °F, sleep stages, efficiency, latency, daytime HR), and a conditional stress row; removed duplicate HRV/Readiness chart, replaced with sleep-only 14-day bars
- **TrendsCard**: new Activity tab (steps bars + active cal overlay), 1y window option, SpO2 dashed line on Recovery tab
- **Backfilled** 254 days of historical Oura data

## Test plan

- [x] `sync-oura.py --days 2 --yes` runs clean, writes recovery rows + workout rows
- [x] Today's date appears in sync output (end_date fix confirmed)
- [x] Oura workouts written to `workout_sessions` with source=oura
- [x] TypeScript type-check passes (`tsc --noEmit` exit 0)
- [x] Dev server up at localhost:3000, dashboard loads
- [ ] Verify Activity tab in TrendsCard renders steps/active cal correctly
- [ ] Verify Temp Δ shows in °F on recovery card
- [ ] Verify stress row appears on days with stress data

🤖 Generated with [Claude Code](https://claude.com/claude-code)