### PR TITLE
feat: streaming tool status chips + calendar read tool (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+- `web/src/components/chat/tool-status-bar.tsx` — inline tool status chips rendered below the last message while Mr. Bridge is working; spinner while tool is executing, ✓ when result arrives, chips disappear when response finishes streaming; reads from `message.parts` (AI SDK v4) with `toolInvocations` fallback; covers all 13 chat tools; closes #64
+- `web/src/app/api/chat/route.ts` — `list_calendar_events` tool: queries all Google Calendars for a given date range (defaults to today); events tagged with `calendarType` (primary / birthday / holiday / other) so the model filters noise; declined invitations excluded server-side; closes gap where the model had no way to read the calendar
+- `web/src/app/(protected)/chat/page.tsx` — "New chat" link in header; navigating to `/chat?new=1` forces a fresh session with no prior context
+
+### Fixed
+- `web/src/app/api/chat/route.ts` — system prompt now includes today's date via `todayString()`; previously the model had no date awareness and passed 2025 dates to calendar tools, returning stale events
+- `web/src/app/api/chat/route.ts` — model no longer narrates before tool calls ("Let me grab that now", etc.); pre-tool text and post-tool response were concatenating without a separator in the streamed content
+- `web/src/lib/timezone.ts` — added `startOfDayRFC3339(date)`, `endOfDayRFC3339(date)`, `addDays(date, n)` helpers; previous calendar implementation used `toLocaleString → new Date()` for RFC 3339 conversion which produced unreliable timezone offsets
+
+### Changed
+- `web/src/app/(protected)/chat/page.tsx` — `initialMessages` now scoped to the current session only; previously loaded across all web sessions, causing stale context to bleed into new chats
+- `web/src/app/api/chat/route.ts` — calendar events include `calendarType` field (primary / birthday / holiday / other); model instructed to surface birthdays as reminders and omit holiday calendars by default
+- `web/src/components/chat/chat-interface.tsx` — imports and renders `ToolStatusBar`
+
 ### Fixed
 - `scripts/sync-oura.py` — `daily_activity` end_date is exclusive; changed `end_str` to `now + 1 day` so today's steps/calories are included in the sync
 - `scripts/sync-oura.py` — `all_dates` union now includes `activity` dates so today's activity row is written even when readiness/sleep haven't finalized yet

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ mr-bridge-assistant/
 │   │   │   │   ├── chat/page.tsx          # Mr. Bridge chat
 │   │   │   │   └── journal/page.tsx       # Daily journal — guided 5-prompt flow
 │   │   │   ├── api/
-│   │   │   │   ├── chat/route.ts          # Claude API tool use (12 tools: tasks, habits, fitness, profile, Gmail, Calendar, recipes, meals)
+│   │   │   │   ├── chat/route.ts          # Claude API tool use (13 tools: tasks, habits, fitness, profile, Gmail, Calendar read+write, recipes, meals)
 │   │   │   │   ├── fun-fact/route.ts      # Claude Haiku daily fact + Supabase cache
 │   │   │   │   ├── daily-quote/route.ts   # Claude Haiku motivational quote, cached daily in Supabase
 │   │   │   │   ├── weather/route.ts       # Open-Meteo forecast (no API key); resolves location from profile
@@ -290,7 +290,7 @@ Feature backlog is tracked via GitHub Issues in your fork.
 A Next.js web app deployed on Vercel providing a full daily briefing UI:
 
 - **Dashboard** — Bento grid (3-col lg): personalized greeting (name from Supabase profile) with live weather inline (temp, condition, high/low, wind, precip, location — via Open-Meteo, no API key); combined Fun Fact + Daily Quote card (Claude Haiku, quote cached daily in Supabase); Schedule Today with multi-calendar support and past-event dimming; Important Emails with `work` badge for professional account; Upcoming Birthday card; Recovery & Sleep full-width card with HRV sparkline + 14-day trend charts; Body Comp / Recovery unified trends card (tabbed, 7d/30d/90d); Habit pills; Task list with priority colors
-- **Chat** — streams responses from Claude Sonnet with markdown rendering
+- **Chat** — streams responses from Claude Sonnet with markdown rendering; inline tool status chips show which tools are running (spinner → ✓) while Mr. Bridge works; "New chat" button starts a clean session; 13 tools: tasks, habits, fitness, profile, Gmail, Calendar (read + write), recipes, meals
 - **Tasks** — add, complete, and archive tasks
 - **Habits** — daily check-in with blue toggle states, 7-day history grid
 - **Fitness** — body composition chart (Recharts) + workout log

--- a/web/src/app/(protected)/chat/page.tsx
+++ b/web/src/app/(protected)/chat/page.tsx
@@ -6,25 +6,30 @@ import type { ChatMessage, ChatSession } from "@/lib/types";
 import { todayString } from "@/lib/timezone";
 import type { Message } from "ai";
 
-export default async function ChatPage() {
+export default async function ChatPage({ searchParams }: { searchParams: Promise<{ new?: string }> }) {
   const supabase = await createClient();
   const today = todayString();
+  const { new: forceNew } = await searchParams;
 
   // Find or create today's web session (used as the write target for new messages)
   let session: ChatSession | null = null;
 
-  const { data: existing } = await supabase
-    .from("chat_sessions")
-    .select("*")
-    .eq("device", "web")
-    .gte("started_at", `${today}T00:00:00`)
-    .order("started_at", { ascending: false })
-    .limit(1)
-    .maybeSingle();
+  if (!forceNew) {
+    const { data: existing } = await supabase
+      .from("chat_sessions")
+      .select("*")
+      .eq("device", "web")
+      .gte("started_at", `${today}T00:00:00`)
+      .order("started_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
 
-  if (existing) {
-    session = existing as ChatSession;
-  } else {
+    if (existing) {
+      session = existing as ChatSession;
+    }
+  }
+
+  if (!session) {
     const { data: created } = await supabase
       .from("chat_sessions")
       .insert({ device: "web" })
@@ -33,19 +38,13 @@ export default async function ChatPage() {
     session = created as ChatSession;
   }
 
-  // Load last 20 messages across all web sessions so history is never lost
+  // Load last 20 messages from the current session only
   let initialMessages: Message[] = [];
-  const { data: sessionIds } = await supabase
-    .from("chat_sessions")
-    .select("id")
-    .eq("device", "web");
-
-  if (sessionIds && sessionIds.length > 0) {
-    const ids = sessionIds.map((s: { id: string }) => s.id);
+  if (session?.id) {
     const { data: msgs } = await supabase
       .from("chat_messages")
       .select("id, role, content, created_at")
-      .in("session_id", ids)
+      .eq("session_id", session.id)
       .in("role", ["user", "assistant"])
       .order("created_at", { ascending: false })
       .limit(20);
@@ -64,8 +63,17 @@ export default async function ChatPage() {
 
   return (
     <div className="pt-6">
-      <h1 className="text-xl font-semibold text-neutral-100 mb-4">Chat</h1>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-xl font-semibold text-neutral-100">Chat</h1>
+        <a
+          href="/chat?new=1"
+          className="text-xs text-neutral-500 hover:text-neutral-300 transition-colors"
+        >
+          New chat
+        </a>
+      </div>
       <ChatInterface
+        key={session?.id}
         sessionId={session?.id ?? ""}
         initialMessages={initialMessages}
       />

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -1,5 +1,5 @@
 import { anthropic } from "@ai-sdk/anthropic";
-import { todayString, daysAgoString } from "@/lib/timezone";
+import { todayString, daysAgoString, startOfDayRFC3339, endOfDayRFC3339, addDays } from "@/lib/timezone";
 import { streamText, tool, jsonSchema, wrapLanguageModel } from "ai";
 import type { LanguageModelV1Middleware } from "ai";
 import { createServiceClient } from "@/lib/supabase/service";
@@ -65,10 +65,12 @@ export async function POST(req: Request) {
 
   const userLabel = userName ?? "the user";
   const systemPrompt = `You are Mr. Bridge, ${userLabel}'s personal AI assistant.
+Today's date is ${todayString()}.
 ${userName ? `Address the user as "${userName}" — use their name naturally in conversation, not robotically after every sentence.` : 'If you learn the user\'s name during the conversation, use it naturally going forward.'}
 
 Style: Direct, structured, high-density. No filler, no emojis, no motivational language.
 Quantify wherever possible. Conservative estimates. Lead with the answer, then reasoning.
+Do not narrate before calling tools — never say things like "Let me check that", "Let me grab that now", "One moment", etc. Call the tool directly and respond after.
 When making sequential tool calls, always start each status update on a new line — never run status messages together without a line break.
 When creating multiple calendar events, work one week at a time. After completing each week, stop and report what was created, then wait for the user to confirm before continuing to the next week. Never attempt to create more than 7 events in a single response.
 
@@ -84,6 +86,7 @@ Tools available:
 - get_profile: profile key/value store
 - search_gmail: search Gmail with any query string, returns message IDs + metadata
 - get_email_body: fetch and decode the full plain-text body of an email by message ID
+- list_calendar_events: list events across all calendars for a date range (defaults to today); each event includes a calendarType field: "primary" (user's own events), "birthday" (auto-generated from contacts), "holiday" (subscription holiday calendars), "other" (shared/secondary). By default show only primary+other events; mention birthdays as reminders separately; omit holiday events unless the user asks. IMPORTANT: only report events that appear in the tool result — never infer or carry over events from conversation history
 - create_calendar_event: create a Google Calendar event on the primary calendar
 - get_recipes: search saved recipes by ingredient, name, or tag; omit query to return all
 - log_meal: log a meal by type (breakfast/lunch/dinner/snack) with optional recipe link or notes
@@ -444,6 +447,84 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
           };
         } catch (err) {
           return { error: err instanceof Error ? err.message : "Failed to fetch email body" };
+        }
+      },
+    }),
+
+    list_calendar_events: tool({
+      description:
+        "List events across all Google Calendars for a given date range. Defaults to today only. Use this whenever the user asks what's on their calendar, schedule, or agenda.",
+      parameters: jsonSchema<{ date?: string; days?: number }>({
+        type: "object",
+        properties: {
+          date: {
+            type: "string",
+            description: "Start date in YYYY-MM-DD format. Defaults to today.",
+          },
+          days: {
+            type: "number",
+            description: "Number of days to include (1 = just the start date). Defaults to 1.",
+          },
+        },
+      }),
+      execute: async ({ date, days = 1 }) => {
+        try {
+          const startDate = date ?? todayString();
+          const endDate = addDays(startDate, Math.max(1, days) - 1);
+
+          const auth = getGoogleAuthClient();
+          const calendar = google.calendar({ version: "v3", auth });
+
+          const calListRes = await calendar.calendarList.list({ minAccessRole: "reader" });
+          const calendars = calListRes.data.items ?? [];
+
+          const allEventArrays = await Promise.all(
+            calendars.map(async (cal) => {
+              const res = await calendar.events.list({
+                calendarId: cal.id!,
+                timeMin: startOfDayRFC3339(startDate),
+                timeMax: endOfDayRFC3339(endDate),
+                singleEvents: true,
+                orderBy: "startTime",
+                maxResults: 25,
+              });
+              const calName = cal.summaryOverride ?? cal.summary ?? cal.id ?? "Unknown";
+              const calNameLower = calName.toLowerCase();
+              const calendarType = cal.primary
+                ? "primary"
+                : calNameLower.includes("birthday") || calNameLower.includes("contact")
+                ? "birthday"
+                : calNameLower.includes("holiday")
+                ? "holiday"
+                : "other";
+
+              return (res.data.items ?? [])
+                .filter((e) => {
+                  if (e.status === "cancelled") return false;
+                  // Filter out events the user has declined
+                  const selfAttendee = e.attendees?.find((a) => a.self);
+                  if (selfAttendee?.responseStatus === "declined") return false;
+                  return true;
+                })
+                .map((e) => ({
+                  title: e.summary ?? "(No title)",
+                  start: e.start?.dateTime ?? e.start?.date ?? "",
+                  end: e.end?.dateTime ?? e.end?.date ?? "",
+                  allDay: !e.start?.dateTime,
+                  calendar: calName,
+                  calendarType,
+                  location: e.location ?? null,
+                }));
+            })
+          );
+
+          const events = allEventArrays
+            .flat()
+            .sort((a, b) => a.start.localeCompare(b.start));
+
+          return { events, count: events.length };
+        } catch (err) {
+          return { error: err instanceof Error ? err.message : "Failed to list calendar events" };
         }
       },
     }),

--- a/web/src/components/chat/chat-interface.tsx
+++ b/web/src/components/chat/chat-interface.tsx
@@ -4,6 +4,7 @@ import { useChat } from "ai/react";
 import { useEffect, useRef } from "react";
 import { Send } from "lucide-react";
 import MessageBubble from "./message-bubble";
+import ToolStatusBar from "./tool-status-bar";
 import type { Message } from "ai";
 
 interface Props {
@@ -35,6 +36,7 @@ export default function ChatInterface({ sessionId, initialMessages }: Props) {
         {messages.map((m) => (
           <MessageBubble key={m.id} message={m} />
         ))}
+        <ToolStatusBar messages={messages} isLoading={isLoading} />
         {isLoading && messages[messages.length - 1]?.role === "user" && (
           <div className="flex justify-start">
             <div className="bg-neutral-900 border border-neutral-800 rounded-2xl rounded-bl-sm px-4 py-2.5">

--- a/web/src/components/chat/tool-status-bar.tsx
+++ b/web/src/components/chat/tool-status-bar.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import type { Message } from "ai";
+
+const TOOL_LABELS: Record<string, string> = {
+  get_tasks: "Fetching tasks",
+  add_task: "Adding task",
+  complete_task: "Completing task",
+  get_habits_today: "Fetching habits",
+  log_habit: "Logging habit",
+  get_fitness_summary: "Fetching fitness data",
+  get_profile: "Loading profile",
+  search_gmail: "Searching email",
+  get_email_body: "Reading email",
+  list_calendar_events: "Checking calendar",
+  create_calendar_event: "Creating calendar event",
+  get_recipes: "Searching recipes",
+  log_meal: "Logging meal",
+};
+
+function toolLabel(toolName: string): string {
+  return TOOL_LABELS[toolName] ?? toolName.replace(/_/g, " ");
+}
+
+interface ToolInvocation {
+  toolCallId: string;
+  toolName: string;
+  state: "partial-call" | "call" | "result";
+}
+
+// AI SDK v4 message.parts shape (subset we care about)
+type MessagePart =
+  | { type: "text"; text: string }
+  | { type: "tool-invocation"; toolInvocation: ToolInvocation }
+  | { type: string };
+
+interface Props {
+  messages: Message[];
+  isLoading: boolean;
+}
+
+/** Extract tool invocations from a message, checking parts first then toolInvocations. */
+function getInvocations(msg: Message): ToolInvocation[] {
+  const parts = (msg as unknown as { parts?: MessagePart[] }).parts;
+  if (parts?.length) {
+    return parts
+      .filter((p): p is { type: "tool-invocation"; toolInvocation: ToolInvocation } =>
+        p.type === "tool-invocation"
+      )
+      .map((p) => p.toolInvocation);
+  }
+  return (msg.toolInvocations as ToolInvocation[] | undefined) ?? [];
+}
+
+export default function ToolStatusBar({ messages, isLoading }: Props) {
+  if (!isLoading) return null;
+
+  // Only look at messages since the last user turn
+  const lastUserIdx = messages.reduce((acc, m, i) => (m.role === "user" ? i : acc), -1);
+  if (lastUserIdx === -1) return null;
+
+  const assistantMessages = messages.slice(lastUserIdx + 1).filter((m) => m.role === "assistant");
+  if (assistantMessages.length === 0) return null;
+
+  // Collect all tool invocations across multi-step responses, last state wins per call ID
+  const seen = new Map<string, ToolInvocation>();
+  for (const msg of assistantMessages) {
+    for (const inv of getInvocations(msg)) {
+      seen.set(inv.toolCallId, inv);
+    }
+  }
+
+  if (seen.size === 0) return null;
+
+  const chips = Array.from(seen.values());
+
+  return (
+    <div className="flex justify-start">
+      <div className="flex flex-wrap gap-1.5 px-1 py-1">
+        {chips.map((inv) => {
+          const isDone = inv.state === "result";
+          return (
+            <span
+              key={inv.toolCallId}
+              className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs bg-neutral-800 border border-neutral-700 ${
+                isDone ? "text-neutral-500" : "text-neutral-400"
+              }`}
+            >
+              {isDone ? (
+                <span className="text-emerald-600 text-[10px] leading-none">✓</span>
+              ) : (
+                <span className="inline-block w-2.5 h-2.5 border border-neutral-400 border-t-transparent rounded-full animate-spin shrink-0" />
+              )}
+              {toolLabel(inv.toolName)}{isDone ? "" : "..."}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/timezone.ts
+++ b/web/src/lib/timezone.ts
@@ -60,3 +60,30 @@ export function startOfTodayRFC3339(tz = USER_TZ): string {
 export function endOfTodayRFC3339(tz = USER_TZ): string {
   return `${todayString(tz)}T23:59:59${tzOffsetString(tz)}`;
 }
+
+/**
+ * Returns an RFC 3339 string for midnight of an arbitrary date in the user's timezone.
+ * date must be a YYYY-MM-DD string.
+ * e.g. startOfDayRFC3339("2026-04-14") → "2026-04-14T00:00:00-07:00"
+ */
+export function startOfDayRFC3339(date: string, tz = USER_TZ): string {
+  return `${date}T00:00:00${tzOffsetString(tz)}`;
+}
+
+/**
+ * Returns an RFC 3339 string for end-of-day of an arbitrary date in the user's timezone.
+ * date must be a YYYY-MM-DD string.
+ */
+export function endOfDayRFC3339(date: string, tz = USER_TZ): string {
+  return `${date}T23:59:59${tzOffsetString(tz)}`;
+}
+
+/**
+ * Adds N days to a YYYY-MM-DD string, returns a new YYYY-MM-DD string.
+ * Uses UTC arithmetic to avoid DST shifts changing the date.
+ */
+export function addDays(date: string, days: number): string {
+  const d = new Date(`${date}T12:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}


### PR DESCRIPTION
## Summary

- **ToolStatusBar** (`web/src/components/chat/tool-status-bar.tsx`) — inline chips below the last message while tools execute; spinner per tool while running, ✓ when result arrives, chips disappear when the response finishes streaming. Reads `message.parts` (AI SDK v4) with `toolInvocations` as fallback.
- **`list_calendar_events` tool** — Mr. Bridge can now read the calendar, not just write to it. Queries all Google Calendars for a date range; events tagged `calendarType` (primary / birthday / holiday / other) so the model filters noise by default; declined invitations excluded server-side.
- **"New chat" button** — `/chat?new=1` creates a fresh session; `initialMessages` now scoped to the current session only so stale context no longer bleeds in.

### Bug fixes found during implementation
- Model was using 2025 dates for calendar queries (no date awareness) — fixed by injecting `todayString()` into the system prompt
- Pre-tool narration ("Let me grab that now.") was concatenating directly into the response text without a separator — suppressed via system prompt instruction
- Calendar RFC 3339 timestamp generation used unreliable `toLocaleString → new Date()` pattern — replaced with `startOfDayRFC3339` / `endOfDayRFC3339` / `addDays` helpers in `timezone.ts`

## Test plan

- [ ] Send a message that uses a tool (e.g. "what are my tasks?" or "check my calendar") — chips should appear below the last bubble while loading, disappear when response finishes
- [ ] Ask "check my calendar for this week" — should return 2026 events only, no 2025 bleed-through
- [ ] Click "New chat" — history clears, fresh session starts
- [ ] Multi-tool response (e.g. "check my calendar and tasks") — multiple chips shown simultaneously

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)