### PR TITLE
feat: tiered model routing — Haiku for simple ops, Sonnet for reasoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Added
+- `web/src/app/api/chat/route.ts` — `selectModel()`: tiered model routing; simple CRUD commands (add task, log habit, log meal, create event, get recipes, list tasks, check habits) route to `claude-haiku-4-5-20251001`; complex reasoning requests (analysis, planning, recommendations, fitness goals, meal planning, email synthesis) stay on `claude-sonnet-4-6`; zero-latency heuristic classifier — no extra LLM call; logs selected tier to server console per request; closes #81
+
+### Added
 - `web/src/components/chat/tool-status-bar.tsx` — inline tool status chips rendered below the last message while Mr. Bridge is working; spinner while tool is executing, ✓ when result arrives, chips disappear when response finishes streaming; reads from `message.parts` (AI SDK v4) with `toolInvocations` fallback; covers all 13 chat tools; closes #64
 - `web/src/app/api/chat/route.ts` — `list_calendar_events` tool: queries all Google Calendars for a given date range (defaults to today); events tagged with `calendarType` (primary / birthday / holiday / other) so the model filters noise; declined invitations excluded server-side; closes gap where the model had no way to read the calendar
 - `web/src/app/(protected)/chat/page.tsx` — "New chat" link in header; navigating to `/chat?new=1` forces a fresh session with no prior context

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -28,6 +28,45 @@ const retryOnOverload: LanguageModelV1Middleware = {
   },
 };
 
+function selectModel(messages: { role: string; content: unknown }[]): "haiku" | "sonnet" {
+  const lastUser = [...messages].reverse().find((m) => m.role === "user");
+  if (!lastUser || typeof lastUser.content !== "string") return "sonnet";
+  const msg = lastUser.content.toLowerCase().trim();
+  if (!msg) return "sonnet";
+
+  // Gate 1: length
+  if (msg.length > 280) return "sonnet";
+
+  // Gate 2: sentence count
+  const sentences = msg.split(/[.!?]+/).filter((s) => s.trim().length > 0);
+  if (sentences.length >= 3) return "sonnet";
+
+  // Gate 3: complex keywords
+  const complexPatterns = [
+    "analyze", "analysis", "recommend", "should i", "what should",
+    "plan", "strategy", "help me", "best way", "optimize", "review",
+    "compare", "versus", " vs ", "summarize", "summary", "trend",
+    "progress", "what do you think", "advice", "suggest", "improve",
+    "breakdown", "fitness goal", "meal plan", "workout plan",
+    "schedule strategy", "is it worth", "explain why",
+  ];
+  if (complexPatterns.some((p) => msg.includes(p))) return "sonnet";
+
+  // Gate 4: simple command patterns
+  const simplePatterns = [
+    /add task/, /create task/, /new task/, /complete task/,
+    /mark.{0,20}done/, /mark.{0,20}complete/, /finish task/,
+    /log habit/, /log.{0,10}meal/, /had.{0,30}for (breakfast|lunch|dinner|snack)/,
+    /create event/, /add event/, /schedule.{0,20}at \d/, /book.{0,20}at \d/,
+    /show.{0,10}tasks/, /list.{0,10}tasks/, /get.{0,10}tasks/, /what.{0,10}tasks/,
+    /check habits/, /show habits/, /get recipes/, /find recipes/, /what.{0,20}recipes/,
+    /my habits today/,
+  ];
+  if (simplePatterns.some((p) => p.test(msg))) return "haiku";
+
+  return "sonnet";
+}
+
 export const maxDuration = 60;
 
 export async function POST(req: Request) {
@@ -674,8 +713,15 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
     }),
   };
 
+  const modelTier = selectModel(messages);
+  console.log(`[chat] model=${modelTier} session=${sessionId} msg="${messages[messages.length - 1]?.content?.toString().slice(0, 80)}"`);
+  const selectedModel = wrapLanguageModel({
+    model: anthropic(modelTier === "haiku" ? "claude-haiku-4-5-20251001" : "claude-sonnet-4-6"),
+    middleware: retryOnOverload,
+  });
+
   const result = streamText({
-    model: wrapLanguageModel({ model: anthropic("claude-sonnet-4-6"), middleware: retryOnOverload }),
+    model: selectedModel,
     system: systemPrompt,
     providerOptions: {
       anthropic: { cacheControl: { type: "ephemeral" } },


### PR DESCRIPTION
## Summary
- Adds `selectModel()` to `web/src/app/api/chat/route.ts` — a zero-latency heuristic classifier that runs before every `streamText` call
- Simple CRUD commands (add task, log habit, log meal, create event, get/list recipes/tasks/habits) route to `claude-haiku-4-5-20251001`
- Complex reasoning requests (analysis, planning, recommendations, meal planning, fitness goals, email synthesis) stay on `claude-sonnet-4-6`
- Ambiguous requests default to Sonnet — safe fallback, no degraded experience
- Logs `[chat] model=haiku|sonnet` to server console per request for cost auditing

## How the classifier works (priority order)
1. Message > 280 chars → Sonnet
2. 3+ sentences → Sonnet
3. Complex keyword match (`analyze`, `recommend`, `should i`, `plan`, `strategy`, `help me`, `fitness goal`, `meal plan`, etc.) → Sonnet
4. Simple command pattern match (`add task`, `log habit`, `create event`, `show recipes`, etc.) → Haiku
5. Default → Sonnet

## No new dependencies, no latency impact
Pure JS string matching — runs in <1ms in-process. No extra LLM call, no new files, no API changes.

## Test plan
- [ ] Start dev server, watch terminal for `[chat] model=` lines
- [ ] "Add task buy groceries" → `model=haiku`
- [ ] "Log my meditation habit" → `model=haiku`
- [ ] "Create event dentist Tuesday at 2pm" → `model=haiku`
- [ ] "Show me my habits today" → `model=haiku`
- [ ] "Analyze my fitness progress" → `model=sonnet`
- [ ] "What should I eat given my workout load?" → `model=sonnet`
- [ ] "Add task review my fitness goals and optimize my meal plan" → `model=sonnet` (complex keyword overrides simple prefix)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)