### PR TITLE
feat: web-native data sync — Vercel cron + manual Sync button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - `web/src/app/api/cron/sync/route.ts` — GET endpoint; verifies Vercel `CRON_SECRET`; runs all three syncs in parallel with 30-minute skip window (mirrors `run-syncs.py` logic); each source reports independently so a single failure doesn't block others
 - `web/src/lib/sync/oura.ts`, `fitbit.ts`, `googlefit.ts`, `log.ts` — shared sync library; extracted from route files so cron and user-triggered routes share identical logic; `logSync` + `lastSyncAgeSecs` helpers read/write `sync_log` table
 - `web/src/components/dashboard/sync-button.tsx` — "Sync" button in the Recovery & Sleep card header; calls all three sync routes in parallel; spinner animation while running; shows "Synced HH:MM" on success; triggers `router.refresh()` to reload server component data without a full page reload
-- `web/vercel.json` — Vercel cron schedule (`*/30 * * * *`); calls `/api/cron/sync` every 30 minutes so the web app stays current without requiring a CLI session
+- `web/vercel.json` — Vercel cron schedule (`0 14 * * *`, 6am PST / 7am PDT); calls `/api/cron/sync` daily so overnight Oura/Fitbit/Google Fit data is ready when the dashboard opens; manual Sync button handles on-demand refreshes throughout the day
 - `web/src/app/api/chat/route.ts` — `selectModel()`: tiered model routing; simple CRUD commands (add task, log habit, log meal, create event, get recipes, list tasks, check habits) route to `claude-haiku-4-5-20251001`; complex reasoning requests (analysis, planning, recommendations, fitness goals, meal planning, email synthesis) stay on `claude-sonnet-4-6`; zero-latency heuristic classifier — no extra LLM call; logs selected tier to server console per request; closes #81
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Added
+- `web/src/app/api/sync/oura/route.ts` — POST endpoint; syncs last 3 days of Oura data (sleep, readiness, activity, spo2, stress, resilience, vo2) into `recovery_metrics`; requires authenticated session; closes #82
+- `web/src/app/api/sync/fitbit/route.ts` — POST endpoint; syncs last 7 days of Fitbit body composition and workouts into `fitness_log` and `workout_sessions`; reads rotating refresh token from Supabase `profile` table; writes back new token after each refresh
+- `web/src/app/api/sync/googlefit/route.ts` — POST endpoint; discovers datasources then aggregates last 7 days of body composition into `fitness_log`; skips dates already covered by a richer source
+- `web/src/app/api/cron/sync/route.ts` — GET endpoint; verifies Vercel `CRON_SECRET`; runs all three syncs in parallel with 30-minute skip window (mirrors `run-syncs.py` logic); each source reports independently so a single failure doesn't block others
+- `web/src/lib/sync/oura.ts`, `fitbit.ts`, `googlefit.ts`, `log.ts` — shared sync library; extracted from route files so cron and user-triggered routes share identical logic; `logSync` + `lastSyncAgeSecs` helpers read/write `sync_log` table
+- `web/src/components/dashboard/sync-button.tsx` — "Sync" button in the Recovery & Sleep card header; calls all three sync routes in parallel; spinner animation while running; shows "Synced HH:MM" on success; triggers `router.refresh()` to reload server component data without a full page reload
+- `web/vercel.json` — Vercel cron schedule (`*/30 * * * *`); calls `/api/cron/sync` every 30 minutes so the web app stays current without requiring a CLI session
 - `web/src/app/api/chat/route.ts` — `selectModel()`: tiered model routing; simple CRUD commands (add task, log habit, log meal, create event, get recipes, list tasks, check habits) route to `claude-haiku-4-5-20251001`; complex reasoning requests (analysis, planning, recommendations, fitness goals, meal planning, email synthesis) stay on `claude-sonnet-4-6`; zero-latency heuristic classifier — no extra LLM call; logs selected tier to server console per request; closes #81
 
-### Added
+### Fixed
+- `web/src/app/(protected)/page.tsx` — removed `avg_hrv IS NOT NULL` filter from the recovery query; previously, if Oura hadn't finalized HRV when the sync ran in the morning, the card fell back to two-day-old data instead of showing the most recent (partial) row
+- `web/src/middleware.ts` — `/api/cron/` routes now bypass session redirect; previously Vercel cron requests were redirected to `/login` before reaching the route handler
 - `web/src/components/chat/tool-status-bar.tsx` — inline tool status chips rendered below the last message while Mr. Bridge is working; spinner while tool is executing, ✓ when result arrives, chips disappear when response finishes streaming; reads from `message.parts` (AI SDK v4) with `toolInvocations` fallback; covers all 13 chat tools; closes #64
 - `web/src/app/api/chat/route.ts` — `list_calendar_events` tool: queries all Google Calendars for a given date range (defaults to today); events tagged with `calendarType` (primary / birthday / holiday / other) so the model filters noise; declined invitations excluded server-side; closes gap where the model had no way to read the calendar
 - `web/src/app/(protected)/chat/page.tsx` — "New chat" link in header; navigating to `/chat?new=1` forces a fresh session with no prior context

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ flowchart LR
         renpho["Renpho"]
     end
 
-    subgraph scripts["Sync Scripts"]
+    subgraph scripts["CLI Sync Scripts\n(session start)"]
         so["sync-oura"]
         sf["sync-fitbit"]
         sg["sync-googlefit"]
@@ -22,7 +22,9 @@ flowchart LR
 
     db[("Supabase\n14 tables")]
 
-    subgraph web["Next.js Web App"]
+    subgraph web["Next.js Web App (Vercel)"]
+        cron["api/cron/sync\n(every 30 min)"]
+        rs["api/sync/oura\napi/sync/fitbit\napi/sync/googlefit"]
         rc["api/chat"]
         rf["api/fun-fact"]
         rq["api/daily-quote"]
@@ -43,6 +45,9 @@ flowchart LR
     fitbit --> sf --> db
     gfit --> sg --> db
     renpho --> sr --> db
+
+    oura & fitbit & gfit --> rs --> db
+    cron --> rs
 
     db --> pg
     db --> rc
@@ -94,6 +99,12 @@ mr-bridge-assistant/
 │   │   │   │   └── journal/page.tsx       # Daily journal — guided 5-prompt flow
 │   │   │   ├── api/
 │   │   │   │   ├── chat/route.ts          # Claude API tool use (13 tools: tasks, habits, fitness, profile, Gmail, Calendar read+write, recipes, meals)
+│   │   │   │   ├── sync/
+│   │   │   │   │   ├── oura/route.ts      # POST — sync last 3d Oura data → recovery_metrics (session auth)
+│   │   │   │   │   ├── fitbit/route.ts    # POST — sync last 7d Fitbit body + workouts (session auth; refresh token from profile table)
+│   │   │   │   │   └── googlefit/route.ts # POST — sync last 7d Google Fit body comp (session auth)
+│   │   │   │   ├── cron/
+│   │   │   │   │   └── sync/route.ts      # GET — Vercel cron handler; CRON_SECRET auth; 30-min skip window; all 3 sources in parallel
 │   │   │   │   ├── fun-fact/route.ts      # Claude Haiku daily fact + Supabase cache
 │   │   │   │   ├── daily-quote/route.ts   # Claude Haiku motivational quote, cached daily in Supabase
 │   │   │   │   ├── weather/route.ts       # Open-Meteo forecast (no API key); resolves location from profile
@@ -117,7 +128,8 @@ mr-bridge-assistant/
 │   │   │       ├── weather-card.tsx       # Weather inline with greeting header (Open-Meteo)
 │   │   │       ├── schedule-today.tsx     # Google Calendar card
 │   │   │       ├── important-emails.tsx   # Gmail card
-│   │   │       ├── recovery-summary.tsx   # Oura: 3 scores (readiness/sleep/activity), metrics grid (HRV, RHR, SpO2, steps, temp Δ, sleep stages, daytime HR), stress row, 14-day sleep chart
+│   │   │       ├── recovery-summary.tsx   # Oura: 3 scores (readiness/sleep/activity), metrics grid (HRV, RHR, SpO2, steps, temp Δ, sleep stages, daytime HR), stress row, 14-day sleep chart; Sync button in header
+│   │   │       ├── sync-button.tsx        # Client component; calls all 3 sync routes in parallel; spinner + router.refresh() on completion
 │   │   │       ├── recovery-trends.tsx    # 14-day stacked sleep breakdown chart (light/deep/REM)
 │   │   │       ├── fitness-summary.tsx    # Body comp + last workout card
 │   │   │       ├── inline-sparkline.tsx   # Mini trend sparkline (used in summary cards)
@@ -127,7 +139,13 @@ mr-bridge-assistant/
 │   │   └── lib/
 │   │       ├── timezone.ts                # Timezone-aware date helpers (USER_TIMEZONE)
 │   │       ├── supabase/                  # Client, server, service clients
-│   │       └── types.ts                   # TypeScript interfaces for all DB tables
+│   │       ├── types.ts                   # TypeScript interfaces for all DB tables
+│   │       └── sync/
+│   │           ├── oura.ts                # syncOura() — all Oura endpoints, upserts recovery_metrics
+│   │           ├── fitbit.ts              # syncFitbit() — body comp + workouts; manages rotating refresh token
+│   │           ├── googlefit.ts           # syncGoogleFit() — datasource discovery + aggregate API
+│   │           └── log.ts                 # logSync() + lastSyncAgeSecs() helpers for sync_log table
+│   ├── vercel.json                        # Cron: /api/cron/sync every 30 minutes
 │   └── package.json
 │
 ├── .claude/
@@ -289,7 +307,7 @@ Feature backlog is tracked via GitHub Issues in your fork.
 
 A Next.js web app deployed on Vercel providing a full daily briefing UI:
 
-- **Dashboard** — Bento grid (3-col lg): personalized greeting (name from Supabase profile) with live weather inline (temp, condition, high/low, wind, precip, location — via Open-Meteo, no API key); combined Fun Fact + Daily Quote card (Claude Haiku, quote cached daily in Supabase); Schedule Today with multi-calendar support and past-event dimming; Important Emails with `work` badge for professional account; Upcoming Birthday card; Recovery & Sleep full-width card with HRV sparkline + 14-day trend charts; Body Comp / Recovery unified trends card (tabbed, 7d/30d/90d); Habit pills; Task list with priority colors
+- **Dashboard** — Bento grid (3-col lg): personalized greeting (name from Supabase profile) with live weather inline (temp, condition, high/low, wind, precip, location — via Open-Meteo, no API key); combined Fun Fact + Daily Quote card (Claude Haiku, quote cached daily in Supabase); Schedule Today with multi-calendar support and past-event dimming; Important Emails with `work` badge for professional account; Upcoming Birthday card; Recovery & Sleep full-width card with HRV sparkline + 14-day trend charts + **Sync button** (triggers Oura, Fitbit, and Google Fit refresh on demand); Body Comp / Recovery unified trends card (tabbed, 7d/30d/90d); Habit pills; Task list with priority colors
 - **Chat** — streams responses from Claude Sonnet with markdown rendering; inline tool status chips show which tools are running (spinner → ✓) while Mr. Bridge works; "New chat" button starts a clean session; 13 tools: tasks, habits, fitness, profile, Gmail, Calendar (read + write), recipes, meals
 - **Tasks** — add, complete, and archive tasks
 - **Habits** — daily check-in with blue toggle states, 7-day history grid
@@ -312,8 +330,26 @@ ANTHROPIC_API_KEY=...
 GOOGLE_CLIENT_ID=...
 GOOGLE_CLIENT_SECRET=...
 GOOGLE_REFRESH_TOKEN=...
+GOOGLE_FIT_REFRESH_TOKEN=...
+OURA_ACCESS_TOKEN=...
+FITBIT_CLIENT_ID=...
+FITBIT_CLIENT_SECRET=...
+FITBIT_WEIGHT_UNIT=lbs
 USER_TIMEZONE=America/Los_Angeles
 ```
+
+> **Note:** `FITBIT_REFRESH_TOKEN` is stored in the Supabase `profile` table (key: `fitbit_refresh_token`) rather than as an env var, because Fitbit rotates it on every use. Write it once with:
+> ```bash
+> python3 -c "
+> import sys, os; sys.path.insert(0, 'scripts')
+> from dotenv import load_dotenv; load_dotenv(dotenv_path='.env')
+> from _supabase import get_client
+> get_client().table('profile').upsert({'key': 'fitbit_refresh_token', 'value': os.environ['FITBIT_REFRESH_TOKEN']}, on_conflict='key').execute()
+> print('Done.')
+> "
+> ```
+>
+> The Vercel cron (`*/30 * * * *`) requires `CRON_SECRET` to be set in Vercel environment variables — Vercel generates and manages this automatically when you deploy with `vercel.json` crons enabled.
 
 ## Voice Interface (Jarvis Mode)
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ mr-bridge-assistant/
 │   │           ├── fitbit.ts              # syncFitbit() — body comp + workouts; manages rotating refresh token
 │   │           ├── googlefit.ts           # syncGoogleFit() — datasource discovery + aggregate API
 │   │           └── log.ts                 # logSync() + lastSyncAgeSecs() helpers for sync_log table
-│   ├── vercel.json                        # Cron: /api/cron/sync every 30 minutes
+│   ├── vercel.json                        # Cron: /api/cron/sync daily at 6am PST (0 14 * * *)
 │   └── package.json
 │
 ├── .claude/

--- a/web/src/app/(protected)/page.tsx
+++ b/web/src/app/(protected)/page.tsx
@@ -55,7 +55,6 @@ export default async function DashboardPage() {
     supabase
       .from("recovery_metrics")
       .select("*")
-      .not("avg_hrv", "is", null)
       .order("date", { ascending: false })
       .limit(1)
       .maybeSingle(),

--- a/web/src/app/api/cron/sync/route.ts
+++ b/web/src/app/api/cron/sync/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { syncOura } from "@/lib/sync/oura";
+import { syncFitbit } from "@/lib/sync/fitbit";
+import { syncGoogleFit } from "@/lib/sync/googlefit";
+import { lastSyncAgeSecs } from "@/lib/sync/log";
+
+const SKIP_WINDOW_SECS = 30 * 60; // 30 minutes — same as run-syncs.py
+
+export async function GET(request: NextRequest) {
+  // Verify Vercel cron secret
+  const auth = request.headers.get("authorization");
+  if (!process.env.CRON_SECRET || auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const db = createServiceClient();
+  const results: Record<string, unknown> = {};
+
+  // Run all three syncs in parallel, skipping any synced within the last 30 minutes
+  const [ouraAge, fitbitAge, googleFitAge] = await Promise.all([
+    lastSyncAgeSecs(db, "oura"),
+    lastSyncAgeSecs(db, "fitbit"),
+    lastSyncAgeSecs(db, "google_fit"),
+  ]);
+
+  const tasks: Promise<void>[] = [];
+
+  if (ouraAge === null || ouraAge >= SKIP_WINDOW_SECS) {
+    tasks.push(
+      syncOura(db)
+        .then((r) => { results.oura = r; })
+        .catch((e) => { results.oura = { error: (e as Error).message }; }),
+    );
+  } else {
+    results.oura = { skipped: true, ageSecs: Math.round(ouraAge) };
+  }
+
+  if (fitbitAge === null || fitbitAge >= SKIP_WINDOW_SECS) {
+    tasks.push(
+      syncFitbit(db)
+        .then((r) => { results.fitbit = r; })
+        .catch((e) => { results.fitbit = { error: (e as Error).message }; }),
+    );
+  } else {
+    results.fitbit = { skipped: true, ageSecs: Math.round(fitbitAge) };
+  }
+
+  if (googleFitAge === null || googleFitAge >= SKIP_WINDOW_SECS) {
+    tasks.push(
+      syncGoogleFit(db)
+        .then((r) => { results.googleFit = r; })
+        .catch((e) => { results.googleFit = { error: (e as Error).message }; }),
+    );
+  } else {
+    results.googleFit = { skipped: true, ageSecs: Math.round(googleFitAge) };
+  }
+
+  await Promise.all(tasks);
+
+  return NextResponse.json({ success: true, results });
+}

--- a/web/src/app/api/sync/fitbit/route.ts
+++ b/web/src/app/api/sync/fitbit/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { syncFitbit } from "@/lib/sync/fitbit";
+
+export async function POST() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    const db = createServiceClient();
+    const result = await syncFitbit(db);
+    return NextResponse.json({ success: true, ...result });
+  } catch (err) {
+    console.error("[/api/sync/fitbit]", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Sync failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/sync/googlefit/route.ts
+++ b/web/src/app/api/sync/googlefit/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { syncGoogleFit } from "@/lib/sync/googlefit";
+
+export async function POST() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    const db = createServiceClient();
+    const result = await syncGoogleFit(db);
+    return NextResponse.json({ success: true, ...result });
+  } catch (err) {
+    console.error("[/api/sync/googlefit]", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Sync failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/sync/oura/route.ts
+++ b/web/src/app/api/sync/oura/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { syncOura } from "@/lib/sync/oura";
+
+export async function POST() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    const db = createServiceClient();
+    const result = await syncOura(db);
+    return NextResponse.json({ success: true, ...result });
+  } catch (err) {
+    console.error("[/api/sync/oura]", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Sync failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/components/dashboard/recovery-summary.tsx
+++ b/web/src/components/dashboard/recovery-summary.tsx
@@ -1,6 +1,7 @@
 import type { RecoveryMetrics } from "@/lib/types";
 import RecoveryTrends from "./recovery-trends";
 import InlineSparkline from "./inline-sparkline";
+import SyncButton from "./sync-button";
 
 interface Props {
   recovery: RecoveryMetrics | null;
@@ -94,7 +95,10 @@ export default function RecoverySummary({ recovery, trends }: Props) {
       <div className={`h-0.5 w-full ${accentBar(recovery?.readiness ?? null)}`} />
 
       <div className="p-5">
-        <p className="text-xs text-neutral-500 uppercase tracking-wide mb-4">Recovery &amp; Sleep</p>
+        <div className="flex items-center justify-between mb-4">
+          <p className="text-xs text-neutral-500 uppercase tracking-wide">Recovery &amp; Sleep</p>
+          <SyncButton />
+        </div>
 
         {recovery ? (
           <div className="space-y-4">

--- a/web/src/components/dashboard/sync-button.tsx
+++ b/web/src/components/dashboard/sync-button.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+type SyncState = "idle" | "syncing" | "done" | "error";
+
+export default function SyncButton() {
+  const router = useRouter();
+  const [state, setState] = useState<SyncState>("idle");
+  const [syncedAt, setSyncedAt] = useState<string | null>(null);
+
+  async function handleSync() {
+    setState("syncing");
+    try {
+      // All three sources in parallel
+      const results = await Promise.allSettled([
+        fetch("/api/sync/oura", { method: "POST" }),
+        fetch("/api/sync/fitbit", { method: "POST" }),
+        fetch("/api/sync/googlefit", { method: "POST" }),
+      ]);
+
+      const anyFailed = results.some((r) => r.status === "rejected" || (r.status === "fulfilled" && !r.value.ok));
+      setState(anyFailed ? "error" : "done");
+      if (!anyFailed) {
+        setSyncedAt(
+          new Date().toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit" }),
+        );
+      }
+      router.refresh();
+    } catch {
+      setState("error");
+    }
+  }
+
+  return (
+    <button
+      onClick={handleSync}
+      disabled={state === "syncing"}
+      title={syncedAt ? `Last synced ${syncedAt}` : "Sync all data sources"}
+      className="flex items-center gap-1.5 text-xs text-neutral-500 hover:text-neutral-300 disabled:opacity-40 transition-colors"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={state === "syncing" ? "animate-spin" : ""}
+      >
+        <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+        <path d="M21 3v5h-5" />
+        <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+        <path d="M8 16H3v5" />
+      </svg>
+      {state === "error" ? (
+        <span className="text-red-500">Sync failed</span>
+      ) : state === "syncing" ? (
+        "Syncing…"
+      ) : syncedAt ? (
+        `Synced ${syncedAt}`
+      ) : (
+        "Sync"
+      )}
+    </button>
+  );
+}

--- a/web/src/lib/sync/fitbit.ts
+++ b/web/src/lib/sync/fitbit.ts
@@ -1,0 +1,219 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { logSync } from "./log";
+
+const FITBIT_TOKEN_URL = "https://api.fitbit.com/oauth2/token";
+const FITBIT_API_BASE = "https://api.fitbit.com";
+const SYNC_DAYS = 7;
+
+// ---------------------------------------------------------------------------
+// OAuth token refresh — saves new token back to profile table (it rotates)
+// ---------------------------------------------------------------------------
+
+async function refreshFitbitToken(
+  db: SupabaseClient,
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+): Promise<string> {
+  const credentials = btoa(`${clientId}:${clientSecret}`);
+  const res = await fetch(FITBIT_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${credentials}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({ grant_type: "refresh_token", refresh_token: refreshToken }),
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Fitbit token refresh failed ${res.status}: ${body}`);
+  }
+
+  const data = await res.json();
+
+  // Save rotated refresh token back to profile table
+  if (data.refresh_token && data.refresh_token !== refreshToken) {
+    await db
+      .from("profile")
+      .upsert({ key: "fitbit_refresh_token", value: data.refresh_token }, { onConflict: "key" });
+  }
+
+  return data.access_token as string;
+}
+
+// ---------------------------------------------------------------------------
+// Fitbit API fetch
+// ---------------------------------------------------------------------------
+
+async function fitbitGet(
+  accessToken: string,
+  path: string,
+): Promise<Record<string, unknown>> {
+  const res = await fetch(`${FITBIT_API_BASE}${path}`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Fitbit ${path} returned ${res.status}: ${body}`);
+  }
+  return res.json();
+}
+
+function fmtHrZones(zones: Record<string, unknown>[]): string | null {
+  if (!zones?.length) return null;
+  const order = ["Peak", "Cardio", "Fat Burn"];
+  const zoneMap: Record<string, number> = {};
+  for (const z of zones) zoneMap[z.name as string] = (z.minutes as number) ?? 0;
+  const parts = order.filter((n) => (zoneMap[n] ?? 0) > 0).map((n) => `${n}: ${zoneMap[n]}m`);
+  return parts.length ? parts.join(" | ") : null;
+}
+
+// ---------------------------------------------------------------------------
+// Main sync function
+// ---------------------------------------------------------------------------
+
+export interface FitbitSyncResult {
+  bodyWritten: number;
+  workoutsWritten: number;
+}
+
+export async function syncFitbit(db: SupabaseClient): Promise<FitbitSyncResult> {
+  const clientId = process.env.FITBIT_CLIENT_ID;
+  const clientSecret = process.env.FITBIT_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    throw new Error("FITBIT_CLIENT_ID or FITBIT_CLIENT_SECRET not configured");
+  }
+
+  // Read refresh token from profile table (it rotates, so env var won't work long-term)
+  const { data: tokenRow } = await db
+    .from("profile")
+    .select("value")
+    .eq("key", "fitbit_refresh_token")
+    .maybeSingle();
+
+  const refreshToken = tokenRow?.value as string | undefined;
+  if (!refreshToken) throw new Error("fitbit_refresh_token not found in profile table");
+
+  const accessToken = await refreshFitbitToken(db, clientId, clientSecret, refreshToken);
+
+  const now = new Date();
+  const past = new Date(now);
+  past.setDate(past.getDate() - SYNC_DAYS);
+  const startStr = past.toISOString().slice(0, 10);
+  const endStr = now.toISOString().slice(0, 10);
+
+  // Fetch body comp and workouts in parallel
+  const weightUnit = (process.env.FITBIT_WEIGHT_UNIT ?? "lbs").toLowerCase();
+  const isLbs = weightUnit === "lbs";
+
+  const [weightData, workoutData] = await Promise.all([
+    fitbitGet(accessToken, `/1/user/-/body/log/weight/date/${startStr}/${endStr}.json`),
+    fitbitGet(
+      accessToken,
+      `/1/user/-/activities/list.json?afterDate=${startStr}&sort=asc&limit=100&offset=0`,
+    ),
+  ]);
+
+  // ── Body composition ──────────────────────────────────────────────────────
+
+  const bodyRows: Record<string, unknown>[] = [];
+  for (const entry of (weightData.weight as Record<string, unknown>[] | undefined) ?? []) {
+    const dt = entry.date as string | undefined;
+    const weightVal = entry.weight as number | undefined;
+    if (!dt || weightVal == null) continue;
+
+    const row: Record<string, unknown> = {
+      date: dt,
+      weight_lb: Math.round((isLbs ? weightVal : weightVal * 2.20462) * 10) / 10,
+      source: "fitbit_body",
+    };
+    if (entry.fat != null) row.body_fat_pct = Math.round((entry.fat as number) * 10) / 10;
+    if (entry.bmi != null) row.bmi = Math.round((entry.bmi as number) * 10) / 10;
+    bodyRows.push(row);
+  }
+
+  // Skip dates that already have body fat % from any source
+  let bodyWritten = 0;
+  if (bodyRows.length) {
+    const { data: existingRich } = await db
+      .from("fitness_log")
+      .select("date")
+      .not("body_fat_pct", "is", null);
+    const { data: existingFitbit } = await db
+      .from("fitness_log")
+      .select("date")
+      .eq("source", "fitbit_body");
+
+    const skip = new Set([
+      ...((existingRich ?? []) as { date: string }[]).map((r) => r.date),
+      ...((existingFitbit ?? []) as { date: string }[]).map((r) => r.date),
+    ]);
+
+    const newRows = bodyRows.filter((r) => !skip.has(r.date as string));
+    if (newRows.length) {
+      const { error } = await db.from("fitness_log").insert(newRows);
+      if (error) throw new Error(`fitness_log insert: ${error.message}`);
+      bodyWritten = newRows.length;
+    }
+  }
+
+  // ── Workouts ──────────────────────────────────────────────────────────────
+
+  const workoutRows: Record<string, unknown>[] = [];
+  for (const a of (workoutData.activities as Record<string, unknown>[] | undefined) ?? []) {
+    const rawStart = (a.startTime ?? a.originalStartTime ?? "") as string;
+    const dateStr = rawStart.slice(0, 10);
+    if (!dateStr || dateStr < startStr || dateStr > endStr) continue;
+
+    const durationMin = Math.round(((a.duration as number) ?? 0) / 60000);
+    if (durationMin < 5) continue;
+
+    const timeStr = rawStart.length >= 19 ? rawStart.slice(11, 19) : null;
+    const avgHr = a.averageHeartRate as number | undefined;
+    const calories = a.calories as number | undefined;
+    const zones = (a.heartRateZones as Record<string, unknown>[] | undefined) ?? [];
+
+    workoutRows.push({
+      date: dateStr,
+      start_time: timeStr,
+      activity: (a.activityName as string) ?? "Unknown",
+      duration_mins: durationMin,
+      calories: calories != null ? Math.round(calories) : null,
+      avg_hr: avgHr != null ? Math.round(avgHr) : null,
+      source: "fitbit",
+      metadata: { hr_zones: fmtHrZones(zones) },
+      _key: `${dateStr}|${timeStr}|${(a.activityName as string) ?? ""}`,
+    });
+  }
+
+  let workoutsWritten = 0;
+  if (workoutRows.length) {
+    const { data: existingWorkouts } = await db
+      .from("workout_sessions")
+      .select("date,start_time,activity")
+      .eq("source", "fitbit");
+
+    const existingKeys = new Set(
+      ((existingWorkouts ?? []) as { date: string; start_time: string; activity: string }[]).map(
+        (r) => `${r.date}|${r.start_time}|${r.activity}`,
+      ),
+    );
+
+    const newWorkouts = workoutRows
+      .filter((r) => !existingKeys.has(r._key as string))
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      .map(({ _key, ...rest }) => rest);
+
+    if (newWorkouts.length) {
+      const { error } = await db.from("workout_sessions").insert(newWorkouts);
+      if (error) throw new Error(`workout_sessions insert: ${error.message}`);
+      workoutsWritten = newWorkouts.length;
+    }
+  }
+
+  await logSync(db, "fitbit", "ok", bodyWritten + workoutsWritten);
+  return { bodyWritten, workoutsWritten };
+}

--- a/web/src/lib/sync/googlefit.ts
+++ b/web/src/lib/sync/googlefit.ts
@@ -1,0 +1,212 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { logSync } from "./log";
+
+const SYNC_DAYS = 7;
+
+const BODY_DATA_TYPES = [
+  "com.google.weight",
+  "com.google.body_fat_percentage",
+  "com.google.bmi",
+  "com.google.lean_body_mass",
+  "com.google.hydration",
+  "com.google.basal_metabolic_rate",
+  "com.google.height",
+];
+
+// ---------------------------------------------------------------------------
+// OAuth token exchange (refresh token → access token)
+// Google refresh tokens don't rotate, so env var is safe.
+// ---------------------------------------------------------------------------
+
+async function getGoogleAccessToken(): Promise<string> {
+  const clientId = process.env.GOOGLE_FIT_CLIENT_ID ?? process.env.GOOGLE_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_FIT_CLIENT_SECRET ?? process.env.GOOGLE_CLIENT_SECRET;
+  const refreshToken =
+    process.env.GOOGLE_FIT_REFRESH_TOKEN ?? process.env.GOOGLE_REFRESH_TOKEN;
+
+  if (!clientId || !clientSecret || !refreshToken) {
+    throw new Error(
+      "GOOGLE_FIT_CLIENT_ID, GOOGLE_FIT_CLIENT_SECRET, and GOOGLE_FIT_REFRESH_TOKEN must be set",
+    );
+  }
+
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: refreshToken,
+      grant_type: "refresh_token",
+    }),
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Google token exchange failed ${res.status}: ${body}`);
+  }
+
+  const data = await res.json();
+  return data.access_token as string;
+}
+
+// ---------------------------------------------------------------------------
+// Google Fit API helpers
+// ---------------------------------------------------------------------------
+
+async function fitGet(
+  accessToken: string,
+  endpoint: string,
+): Promise<Record<string, unknown>> {
+  const res = await fetch(`https://www.googleapis.com/fitness/v1/users/me/${endpoint}`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Google Fit GET ${endpoint} returned ${res.status}: ${body}`);
+  }
+  return res.json();
+}
+
+async function fitPost(
+  accessToken: string,
+  endpoint: string,
+  body: unknown,
+): Promise<Record<string, unknown>> {
+  const res = await fetch(`https://www.googleapis.com/fitness/v1/users/me/${endpoint}`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Google Fit POST ${endpoint} returned ${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Main sync function
+// ---------------------------------------------------------------------------
+
+export interface GoogleFitSyncResult {
+  written: number;
+}
+
+export async function syncGoogleFit(db: SupabaseClient): Promise<GoogleFitSyncResult> {
+  const accessToken = await getGoogleAccessToken();
+
+  // Discover available body datasources
+  const sourcesResult = await fitGet(accessToken, "dataSources");
+  const typeToSources: Record<string, string[]> = {};
+  for (const ds of (sourcesResult.dataSource as Record<string, unknown>[] | undefined) ?? []) {
+    const dtName = (ds.dataType as Record<string, string> | undefined)?.name ?? "";
+    if (!BODY_DATA_TYPES.includes(dtName)) continue;
+    const dsId = ds.dataStreamId as string | undefined;
+    if (dsId) {
+      if (!typeToSources[dtName]) typeToSources[dtName] = [];
+      typeToSources[dtName].push(dsId);
+    }
+  }
+
+  if (!Object.keys(typeToSources).length) return { written: 0 };
+
+  // Aggregate body data for last SYNC_DAYS days
+  const now = Date.now();
+  const startMs = now - SYNC_DAYS * 24 * 60 * 60 * 1000;
+
+  const aggregateBy = Object.values(typeToSources)
+    .flat()
+    .map((dsId) => ({ dataSourceId: dsId }));
+
+  const aggResult = await fitPost(accessToken, "dataset:aggregate", {
+    aggregateBy,
+    bucketByTime: { durationMillis: 86400000 },
+    startTimeMillis: startMs,
+    endTimeMillis: now,
+  });
+
+  const rows: Record<string, unknown>[] = [];
+  for (const bucket of (aggResult.bucket as Record<string, unknown>[] | undefined) ?? []) {
+    const dateStr = new Date(parseInt(bucket.startTimeMillis as string))
+      .toISOString()
+      .slice(0, 10);
+
+    // Index points by data type
+    const byType: Record<string, { value: { fpVal?: number }[] }[]> = {};
+    for (const dataset of (bucket.dataset as Record<string, unknown>[] | undefined) ?? []) {
+      const dsId = dataset.dataSourceId as string;
+      for (const dtype of BODY_DATA_TYPES) {
+        if (dsId.includes(dtype)) {
+          if (!byType[dtype]) byType[dtype] = [];
+          byType[dtype].push(...(dataset.point as { value: { fpVal?: number }[] }[]));
+        }
+      }
+    }
+
+    const firstFp = (dtype: string): number | null => {
+      const points = byType[dtype] ?? [];
+      if (!points.length) return null;
+      return points[0].value?.[0]?.fpVal ?? null;
+    };
+
+    const weightKg = firstFp("com.google.weight");
+    const leanKg = firstFp("com.google.lean_body_mass");
+    const fatPct = firstFp("com.google.body_fat_percentage");
+    const bmiVal = firstFp("com.google.bmi");
+    const hydrationL = firstFp("com.google.hydration");
+    const bmr = firstFp("com.google.basal_metabolic_rate");
+    const heightM = firstFp("com.google.height");
+
+    const meta: Record<string, number> = {};
+    if (hydrationL != null) meta.body_water_l = Math.round(hydrationL * 100) / 100;
+    if (bmr != null) meta.bmr_kcal = Math.round(bmr * 10) / 10;
+    if (heightM != null) meta.height_m = Math.round(heightM * 1000) / 1000;
+
+    const row: Record<string, unknown> = {
+      date: dateStr,
+      weight_lb: weightKg != null ? Math.round(weightKg * 2.20462 * 10) / 10 : null,
+      body_fat_pct: fatPct != null ? Math.round(fatPct * 10) / 10 : null,
+      bmi: bmiVal != null ? Math.round(bmiVal * 10) / 10 : null,
+      muscle_mass_lb: leanKg != null ? Math.round(leanKg * 2.20462 * 10) / 10 : null,
+      metadata: Object.keys(meta).length ? meta : null,
+    };
+
+    // Only include rows that have at least one numeric value
+    if (Object.entries(row).some(([k, v]) => !["date", "metadata"].includes(k) && v != null)) {
+      rows.push(row);
+    }
+  }
+
+  if (!rows.length) return { written: 0 };
+
+  // Skip dates that already have body fat % (from any source) or are already from google_fit
+  const { data: existingRich } = await db
+    .from("fitness_log")
+    .select("date")
+    .not("body_fat_pct", "is", null);
+  const { data: existingGfit } = await db
+    .from("fitness_log")
+    .select("date")
+    .eq("source", "google_fit");
+
+  const skip = new Set([
+    ...((existingRich ?? []) as { date: string }[]).map((r) => r.date),
+    ...((existingGfit ?? []) as { date: string }[]).map((r) => r.date),
+  ]);
+
+  const newRows = rows
+    .filter((r) => !skip.has(r.date as string))
+    .map((r) => ({ ...r, source: "google_fit" }));
+
+  if (!newRows.length) return { written: 0 };
+
+  const { error } = await db.from("fitness_log").insert(newRows);
+  if (error) throw new Error(`fitness_log insert: ${error.message}`);
+
+  await logSync(db, "google_fit", "ok", newRows.length);
+  return { written: newRows.length };
+}

--- a/web/src/lib/sync/log.ts
+++ b/web/src/lib/sync/log.ts
@@ -1,0 +1,28 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export async function logSync(
+  db: SupabaseClient,
+  source: string,
+  status: string,
+  rowsWritten: number,
+): Promise<void> {
+  await db.from("sync_log").insert({ source, status, rows_written: rowsWritten });
+}
+
+/** Returns seconds since last successful sync, or null if never synced. */
+export async function lastSyncAgeSecs(
+  db: SupabaseClient,
+  source: string,
+): Promise<number | null> {
+  const { data } = await db
+    .from("sync_log")
+    .select("synced_at")
+    .eq("source", source)
+    .eq("status", "ok")
+    .order("synced_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (!data?.synced_at) return null;
+  return (Date.now() - new Date(data.synced_at).getTime()) / 1000;
+}

--- a/web/src/lib/sync/oura.ts
+++ b/web/src/lib/sync/oura.ts
@@ -1,0 +1,210 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { logSync } from "./log";
+
+const OURA_BASE = "https://api.ouraring.com/v2/usercollection";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function secsToHrs(s: number | null | undefined): number | null {
+  if (s == null) return null;
+  return Math.round((s / 3600) * 1000) / 1000;
+}
+
+function secsToMins(s: number | null | undefined): number | null {
+  if (s == null) return null;
+  return Math.round((s / 60) * 10) / 10;
+}
+
+function fmtTime(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  return iso.slice(11, 19);
+}
+
+async function ouraGet(
+  endpoint: string,
+  start: string,
+  end: string,
+  token: string,
+  required = true,
+): Promise<Record<string, unknown> | null> {
+  const url = `${OURA_BASE}/${endpoint}?start_date=${start}&end_date=${end}`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    if (!required && [400, 403, 404, 422].includes(res.status)) return null;
+    throw new Error(`Oura ${endpoint} returned ${res.status}`);
+  }
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Main sync function
+// ---------------------------------------------------------------------------
+
+export interface OuraSyncResult {
+  updated: number;
+}
+
+export async function syncOura(db: SupabaseClient, days = 3): Promise<OuraSyncResult> {
+  const token = process.env.OURA_ACCESS_TOKEN;
+  if (!token) throw new Error("OURA_ACCESS_TOKEN not configured");
+
+  const now = new Date();
+  const past = new Date(now);
+  past.setDate(past.getDate() - days);
+  const startStr = past.toISOString().slice(0, 10);
+  const endStr = now.toISOString().slice(0, 10);
+
+  const [
+    sleepData,
+    readinessData,
+    sleepScoreData,
+    activityData,
+    spo2Data,
+    stressData,
+    resilienceData,
+    vo2Data,
+  ] = await Promise.all([
+    ouraGet("sleep", startStr, endStr, token),
+    ouraGet("daily_readiness", startStr, endStr, token),
+    ouraGet("daily_sleep", startStr, endStr, token),
+    ouraGet("daily_activity", startStr, endStr, token),
+    ouraGet("daily_spo2", startStr, endStr, token, false),
+    ouraGet("daily_stress", startStr, endStr, token, false),
+    ouraGet("daily_resilience", startStr, endStr, token, false),
+    ouraGet("vo2_max", startStr, endStr, token, false),
+  ]);
+
+  type SleepDetail = Record<string, number | string | null>;
+  const sleepDetail: Record<string, SleepDetail> = {};
+  for (const d of (sleepData?.data as Record<string, unknown>[] | undefined) ?? []) {
+    if (d.type !== "long_sleep" || !d.day) continue;
+    const day = d.day as string;
+    sleepDetail[day] = {
+      bedtime: fmtTime(d.bedtime_start as string),
+      bedtime_end: fmtTime(d.bedtime_end as string),
+      total_sleep_hrs: secsToHrs(d.total_sleep_duration as number),
+      light_hrs: secsToHrs(d.light_sleep_duration as number),
+      deep_hrs: secsToHrs(d.deep_sleep_duration as number),
+      rem_hrs: secsToHrs(d.rem_sleep_duration as number),
+      awake_hrs: secsToHrs(d.awake_time as number),
+      avg_hrv: d.average_hrv != null ? Math.round(d.average_hrv as number) : null,
+      resting_hr: (d.lowest_heart_rate as number) ?? null,
+      avg_hr_sleep: d.average_heart_rate != null ? Math.round(d.average_heart_rate as number) : null,
+      avg_breath: d.average_breath != null ? Math.round((d.average_breath as number) * 10) / 10 : null,
+      efficiency: (d.efficiency as number) ?? null,
+      latency_mins: secsToMins(d.latency as number),
+      restless_periods: (d.restless_periods as number) ?? null,
+    };
+  }
+
+  const readiness: Record<string, number | null> = {};
+  const bodyTemp: Record<string, number | null> = {};
+  for (const d of (readinessData?.data as Record<string, unknown>[] | undefined) ?? []) {
+    if (!d.day) continue;
+    const day = d.day as string;
+    readiness[day] = (d.score as number) ?? null;
+    bodyTemp[day] = (d.temperature_deviation as number) ?? null;
+  }
+
+  const sleepScores: Record<string, number | null> = {};
+  for (const d of (sleepScoreData?.data as Record<string, unknown>[] | undefined) ?? []) {
+    if (d.day) sleepScores[d.day as string] = (d.score as number) ?? null;
+  }
+
+  type ActivityDetail = Record<string, number | null>;
+  const activity: Record<string, ActivityDetail> = {};
+  for (const d of (activityData?.data as Record<string, unknown>[] | undefined) ?? []) {
+    if (!d.day) continue;
+    const day = d.day as string;
+    activity[day] = {
+      active_cal: (d.active_calories as number) ?? null,
+      steps: (d.steps as number) ?? null,
+      total_cal: (d.total_calories as number) ?? null,
+      activity_score: (d.score as number) ?? null,
+    };
+  }
+
+  const spo2: Record<string, number | null> = {};
+  for (const d of (spo2Data?.data as Record<string, unknown>[] | undefined) ?? []) {
+    if (!d.day) continue;
+    const pct = d.spo2_percentage as Record<string, number> | null;
+    spo2[d.day as string] = pct?.average ?? null;
+  }
+
+  const stress: Record<string, Record<string, number | string | null>> = {};
+  for (const d of (stressData?.data as Record<string, unknown>[] | undefined) ?? []) {
+    if (!d.day) continue;
+    const day = d.day as string;
+    stress[day] = {
+      stress_high_mins: secsToMins(d.stress_high as number),
+      stress_recovery_mins: secsToMins(d.recovery_high as number),
+      stress_day_summary: (d.day_summary as string) ?? null,
+    };
+  }
+
+  const resilience: Record<string, string | null> = {};
+  for (const d of (resilienceData?.data as Record<string, unknown>[] | undefined) ?? []) {
+    if (d.day) resilience[d.day as string] = (d.level as string) ?? null;
+  }
+
+  const vo2: Record<string, number | null> = {};
+  for (const d of (vo2Data?.data as Record<string, unknown>[] | undefined) ?? []) {
+    if (d.day) vo2[d.day as string] = (d.vo2_max as number) ?? null;
+  }
+
+  const allDates = [
+    ...new Set([...Object.keys(sleepDetail), ...Object.keys(readiness), ...Object.keys(activity)]),
+  ].sort();
+
+  const rows = allDates.map((d) => {
+    const sd = sleepDetail[d] ?? {};
+    const act = activity[d] ?? {};
+    const st = stress[d] ?? {};
+
+    const meta: Record<string, number | string | null> = {};
+    if (sd.bedtime_end != null) meta.bedtime_end = sd.bedtime_end;
+    if (sd.awake_hrs != null) meta.awake_hrs = sd.awake_hrs;
+    if (sd.efficiency != null) meta.sleep_efficiency = sd.efficiency;
+    if (sd.latency_mins != null) meta.latency_mins = sd.latency_mins;
+    if (sd.avg_breath != null) meta.avg_breath = sd.avg_breath;
+    if (sd.avg_hr_sleep != null) meta.avg_hr_sleep = sd.avg_hr_sleep;
+    if (sd.restless_periods != null) meta.restless_periods = sd.restless_periods;
+    if (act.total_cal != null) meta.total_calories = act.total_cal;
+    if (st.stress_high_mins != null) meta.stress_high_mins = st.stress_high_mins;
+    if (st.stress_recovery_mins != null) meta.stress_recovery_mins = st.stress_recovery_mins;
+    if (st.stress_day_summary) meta.stress_day_summary = st.stress_day_summary;
+    if (resilience[d]) meta.resilience_level = resilience[d];
+    if (vo2[d] != null) meta.vo2_max = vo2[d];
+
+    return {
+      date: d,
+      bedtime: sd.bedtime ?? null,
+      total_sleep_hrs: sd.total_sleep_hrs ?? null,
+      light_hrs: sd.light_hrs ?? null,
+      deep_hrs: sd.deep_hrs ?? null,
+      rem_hrs: sd.rem_hrs ?? null,
+      avg_hrv: sd.avg_hrv ?? null,
+      resting_hr: sd.resting_hr ?? null,
+      readiness: readiness[d] ?? null,
+      sleep_score: sleepScores[d] ?? null,
+      active_cal: act.active_cal ?? null,
+      steps: act.steps ?? null,
+      activity_score: act.activity_score ?? null,
+      spo2_avg: spo2[d] ?? null,
+      body_temp_delta: bodyTemp[d] ?? null,
+      metadata: meta,
+      source: "oura",
+    };
+  });
+
+  const { error } = await db.from("recovery_metrics").upsert(rows, { onConflict: "date" });
+  if (error) throw new Error(error.message);
+
+  await logSync(db, "oura", "ok", rows.length);
+  return { updated: rows.length };
+}

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -32,7 +32,8 @@ export async function middleware(request: NextRequest) {
 
   const isAuthRoute =
     request.nextUrl.pathname.startsWith("/login") ||
-    request.nextUrl.pathname.startsWith("/auth");
+    request.nextUrl.pathname.startsWith("/auth") ||
+    request.nextUrl.pathname.startsWith("/api/cron/");
 
   if (!user && !isAuthRoute) {
     const url = request.nextUrl.clone();

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/sync",
+      "schedule": "*/30 * * * *"
+    }
+  ]
+}

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/sync",
-      "schedule": "*/30 * * * *"
+      "schedule": "0 14 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Web app was read-only — data only refreshed when a CLI session ran `run-syncs.py`. This PR makes the web app self-sufficient for all three data sources (Oura, Fitbit, Google Fit).
- Adds a **Sync button** in the Recovery & Sleep card header that calls all three sync routes in parallel and refreshes the dashboard on completion.
- Adds a **Vercel cron** (`*/30 * * * *`) that keeps data fresh automatically — no CLI session required.
- Fixes a morning data gap where the dashboard showed two-day-old recovery data because `avg_hrv IS NOT NULL` excluded rows that Oura hadn't finalized yet.

## What changed

**New API routes**
- `POST /api/sync/oura` — last 3 days; session auth
- `POST /api/sync/fitbit` — last 7 days; reads/writes rotating refresh token from Supabase `profile` table
- `POST /api/sync/googlefit` — last 7 days; datasource discovery + aggregate API; session auth
- `GET /api/cron/sync` — CRON_SECRET auth; runs all three in parallel with 30-min skip window

**New files**
- `web/src/lib/sync/` — shared sync logic (oura, fitbit, googlefit, log helpers)
- `web/src/components/dashboard/sync-button.tsx` — client component with spinner + router.refresh()
- `web/vercel.json` — cron schedule

**Fixes**
- Removed `avg_hrv IS NOT NULL` from dashboard recovery query — partial rows now show instead of falling back to stale data
- Middleware now exempts `/api/cron/` from session redirect

## Setup required before merging

1. Add to Vercel env vars: `OURA_ACCESS_TOKEN`, `FITBIT_CLIENT_ID`, `FITBIT_CLIENT_SECRET`, `FITBIT_WEIGHT_UNIT`, `GOOGLE_FIT_CLIENT_ID`, `GOOGLE_FIT_CLIENT_SECRET`, `GOOGLE_FIT_REFRESH_TOKEN`
2. `CRON_SECRET` is generated automatically by Vercel when crons are enabled
3. Fitbit refresh token must be in Supabase `profile` table (key: `fitbit_refresh_token`) — see README

## Test plan

- [x] Cron endpoint tested locally with `curl -H "Authorization: Bearer dev-cron-secret-local"` — Oura updated 4 rows, Fitbit wrote today's weigh-in, Google Fit 0 new (no data gap)
- [x] Auth guard confirmed — unauthenticated POST to sync routes returns redirect to `/login`
- [x] Middleware fix confirmed — `/api/cron/` no longer redirects to `/login`
- [ ] Verify Sync button renders correctly in dashboard
- [ ] Verify Vercel cron fires after deploy (check Vercel cron logs)

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)