### PR TITLE
fix: mobile dashboard overflow at 360-414px viewports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+- `web/src/components/dashboard/recovery-summary.tsx` — scores row changed to `flex flex-wrap` with `gap-x-6 gap-y-3`; status block uses `w-full sm:w-auto sm:ml-auto` to stack below scores on mobile instead of overflowing; stress row changed to `flex flex-wrap` with `gap-x-4 gap-y-1` so Resilience label wraps rather than overflows at 360–414px; closes #83
+- `web/src/components/dashboard/trends-card.tsx` — tab/window button header changed to `flex flex-col sm:flex-row sm:items-center sm:justify-between` to prevent overflow at 360–414px; closes #83
+- `web/src/components/dashboard/tasks-summary.tsx` — added `min-w-0` to task row flex container so `truncate` on task title clips correctly
+- `web/src/components/dashboard/important-emails.tsx` — added `min-w-0` to per-email container so `truncate` on sender/subject lines clips correctly
+
 ### Added
 - `web/src/app/api/sync/oura/route.ts` — POST endpoint; syncs last 3 days of Oura data (sleep, readiness, activity, spo2, stress, resilience, vo2) into `recovery_metrics`; requires authenticated session; closes #82
 - `web/src/app/api/sync/fitbit/route.ts` — POST endpoint; syncs last 7 days of Fitbit body composition and workouts into `fitness_log` and `workout_sessions`; reads rotating refresh token from Supabase `profile` table; writes back new token after each refresh

--- a/web/src/components/dashboard/important-emails.tsx
+++ b/web/src/components/dashboard/important-emails.tsx
@@ -41,7 +41,7 @@ export default function ImportantEmails() {
       ) : emails.length > 0 ? (
         <div className="divide-y divide-neutral-800/50">
           {emails.map((email, i) => (
-            <div key={i} className="py-2 first:pt-0 last:pb-0">
+            <div key={i} className="py-2 first:pt-0 last:pb-0 min-w-0">
               <p className="text-xs text-neutral-400 truncate">
                 {email.from}
                 {email.account === "professional" && (

--- a/web/src/components/dashboard/recovery-summary.tsx
+++ b/web/src/components/dashboard/recovery-summary.tsx
@@ -103,7 +103,7 @@ export default function RecoverySummary({ recovery, trends }: Props) {
         {recovery ? (
           <div className="space-y-4">
             {/* Three scores */}
-            <div className={`flex items-end gap-8 rounded-xl p-4 ${scoreBg(recovery.readiness)}`}>
+            <div className={`flex flex-wrap items-end gap-x-6 gap-y-3 rounded-xl p-4 ${scoreBg(recovery.readiness)}`}>
               <div>
                 <p className="text-xs text-neutral-500 uppercase tracking-wide mb-1">Readiness</p>
                 <span className={`text-[3.25rem] font-bold font-[family-name:var(--font-mono)] leading-none ${scoreColor(recovery.readiness)}`}>
@@ -124,7 +124,7 @@ export default function RecoverySummary({ recovery, trends }: Props) {
                   </span>
                 </div>
               )}
-              <div className="ml-auto text-right pb-1">
+              <div className="w-full sm:w-auto sm:ml-auto text-left sm:text-right pb-1">
                 <p className={`text-xs font-medium ${statusColor(recovery.readiness).split(" ")[0]}`}>
                   {statusLabel(recovery.readiness)}
                 </p>
@@ -191,7 +191,7 @@ export default function RecoverySummary({ recovery, trends }: Props) {
 
             {/* Stress row — only if data present */}
             {(meta(recovery, "stress_high_mins") != null || meta(recovery, "stress_day_summary") != null) && (
-              <div className="flex items-center gap-4 text-xs text-neutral-500 pt-1 border-t border-neutral-800/60">
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-neutral-500 pt-1 border-t border-neutral-800/60">
                 <span className="uppercase tracking-wide">Stress</span>
                 {meta(recovery, "stress_high_mins") != null && (
                   <span className="font-[family-name:var(--font-mono)] text-neutral-300">

--- a/web/src/components/dashboard/tasks-summary.tsx
+++ b/web/src/components/dashboard/tasks-summary.tsx
@@ -53,7 +53,7 @@ export default function TasksSummary({ tasks }: Props) {
           {topTasks.map((t) => (
             <div
               key={t.id}
-              className={`flex items-center gap-2 border-l-2 pl-2 ${priorityBorder(t.priority)}`}
+              className={`flex items-center gap-2 border-l-2 pl-2 min-w-0 ${priorityBorder(t.priority)}`}
             >
               <p className="text-xs text-neutral-300 truncate flex-1">{t.title}</p>
               {t.due_date && (

--- a/web/src/components/dashboard/trends-card.tsx
+++ b/web/src/components/dashboard/trends-card.tsx
@@ -123,7 +123,7 @@ export default function TrendsCard({ fitnessData, recoveryData, recentWorkout }:
   return (
     <div className="bg-neutral-900 rounded-xl border border-neutral-800 p-4 h-full">
       {/* Header row */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-4">
         <div className="flex gap-1">
           {(["bodycomp", "recovery", "activity"] as Tab[]).map((t) => (
             <button


### PR DESCRIPTION
## Summary

- **Recovery & Sleep card** (`recovery-summary.tsx`): scores row changed from `flex gap-8` (unwrapped) to `flex flex-wrap gap-x-6 gap-y-3`; status text block gains `w-full sm:w-auto sm:ml-auto` so it stacks below the scores on narrow viewports instead of extending the row past the edge; stress row gains `flex-wrap` so the Resilience label wraps to a new line instead of overflowing
- **Trends card** (`trends-card.tsx`): tab + window button header row changed to `flex-col sm:flex-row` so the two button groups stack vertically at 360–414px and return to side-by-side on `sm+`
- **Tasks + Emails cards**: added `min-w-0` to the direct flex-item parent of each `truncate` child — without this, CSS truncation silently breaks in a flex context

## Test plan

- [ ] Open the dashboard in Chrome DevTools → Responsive → 360px: Recovery & Sleep card scores visible without horizontal scroll; status text ("Recovery good — normal training") appears below the scores
- [ ] At 414px: same — no horizontal scrollbar anywhere on the page
- [ ] At 640px+: layout reverts to the original inline design — status text right-aligned beside the scores
- [ ] Trends card at 360px: "Body Comp / Recovery / Activity" buttons on one line, "7d / 30d / 90d / 1y" on the next; at 640px+ both groups are on one row
- [ ] Long task titles and email subjects are clipped (not overflowing their containers)

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)