### PR TITLE
feat: food photo analysis for macro estimation (#84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (food photo analysis — issue #84)
+- **Food photo analysis** — `/meals` page now has an "Analyze Food Photo" card; user selects or captures a photo, Claude vision identifies the dish and extracts an ingredients list with estimated quantities, estimates macros (calories, protein, carbs, fat, fiber, sodium), and presents an editable review before logging
+- **Ingredients-first editing** — review state shows dish name as a header and the ingredients list as the primary editable textarea; "Re-estimate macros" button sends the corrected ingredients back to Claude (Haiku) for a fresh macro calculation; macro numbers are shown read-only with an optional "Edit" toggle for manual overrides
+- **`/api/meals/analyze-photo`** — POST route; accepts `multipart/form-data` image, sends to `claude-sonnet-4-6` via `generateObject`, returns structured food/macro JSON; image is never written to disk or Supabase Storage
+- **`/api/meals/estimate-macros`** — POST route; accepts `{ ingredients }` string, re-estimates macros via `claude-haiku-4-5-20251001`; used by the Re-estimate button in the review flow
+- **`/api/meals/log`** — POST route; inserts a full nutrition row into `meal_log` from the client component (bypasses chat)
+- **`FoodPhotoAnalyzer`** client component — idle → loading (thumbnail preview) → review → saving → done/error state machine; mobile-optimised: no `capture=` attribute (iOS shows native Take Photo / Photo Library sheet), `font-size: 16px` on all inputs to prevent iOS auto-zoom, `minHeight: 48px` touch targets, 2-column macro grid on mobile, full-width Log Meal button
+- **Nutrition columns on `meal_log`** — migration `20260412000000_add_nutrition_to_meal_log.sql` adds `calories`, `protein_g`, `carbs_g`, `fat_g`, `fiber_g`, `sodium_mg`, `source` (all nullable)
+- **Macro display in meal log** — meals page shows inline macro summary (`620 cal · P 42g · C 58g · F 14g`) on any entry that has nutrition data
+- **`log_meal` chat tool extended** — now accepts optional `calories`, `protein_g`, `carbs_g`, `fat_g` so chat-logged meals can carry macros when the user mentions them or Claude can estimate from the description
+
 ### Added (web UI redesign — PR #89)
 - **Design system** — `globals.css` now defines all CSS custom properties (`--color-bg`, `--color-surface`, `--color-surface-raised`, `--color-border`, `--color-primary`, `--color-positive`, `--color-warning`, `--color-danger`, `--color-info`, `--color-text`, `--color-text-muted`, `--color-text-faint`); skeleton shimmer keyframe; `prefers-reduced-motion` block disables all transitions and chart animations
 - **Typography** — replaced Geist with DM Sans (headings, `font-heading`) + Inter (body); loaded via Google Fonts `<link>` in layout

--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ mr-bridge-assistant/
 │       ├── 20260410164609_add_unique_constraints.sql
 │       ├── 20260410170000_study_log_unique_constraint.sql
 │       ├── 20260411000000_add_journal_entries.sql
-│       └── 20260411000001_recovery_metrics_extended.sql
+│       ├── 20260411000001_recovery_metrics_extended.sql
+│       ├── 20260411100000_fitness_log_unique_date_source.sql
+│       └── 20260412000000_add_nutrition_to_meal_log.sql
 │
 ├── web/                                   # Next.js web interface (deployed on Vercel)
 │   ├── .env.local.example                 # Web app env var template (Supabase, Anthropic, Google, timezone)
@@ -109,9 +111,11 @@ mr-bridge-assistant/
 │   │   │   │   ├── habits/page.tsx        # Habit tracking — add/archive + 7/30/90d history
 │   │   │   │   ├── fitness/page.tsx       # Body composition + workouts
 │   │   │   │   ├── chat/page.tsx          # Mr. Bridge chat
+│   │   │   │   ├── meals/page.tsx         # Meal log + FoodPhotoAnalyzer (photo → Claude vision → macros → log)
+│   │   │   │   ├── meals/FoodPhotoAnalyzer.tsx  # Client component: photo upload, ingredient editing, macro review
 │   │   │   │   └── journal/page.tsx       # Daily journal — guided 5-prompt flow
 │   │   │   ├── api/
-│   │   │   │   ├── chat/route.ts          # Claude API tool use (13 tools: tasks, habits, fitness, profile, Gmail, Calendar read+write, recipes, meals)
+│   │   │   │   ├── chat/route.ts          # Claude API tool use (13 tools: tasks, habits, fitness, profile, Gmail, Calendar read+write, recipes, meals with macros)
 │   │   │   │   ├── sync/
 │   │   │   │   │   ├── oura/route.ts      # POST — sync last 3d Oura data → recovery_metrics (session auth)
 │   │   │   │   │   ├── fitbit/route.ts    # POST — sync last 7d Fitbit body + workouts (session auth; refresh token from profile table)
@@ -121,6 +125,10 @@ mr-bridge-assistant/
 │   │   │   │   ├── fun-fact/route.ts      # Claude Haiku daily fact + Supabase cache
 │   │   │   │   ├── daily-quote/route.ts   # Claude Haiku motivational quote, cached daily in Supabase
 │   │   │   │   ├── weather/route.ts       # Open-Meteo forecast (no API key); resolves location from profile
+│   │   │   │   ├── meals/
+│   │   │   │   │   ├── analyze-photo/route.ts  # POST — Claude vision macro estimation from image; image never stored
+│   │   │   │   │   ├── estimate-macros/route.ts # POST — re-estimate macros from edited ingredients string (Haiku)
+│   │   │   │   │   └── log/route.ts            # POST — insert meal_log row with full nutrition fields
 │   │   │   │   └── google/
 │   │   │   │       ├── calendar/route.ts  # Today's Google Calendar events
 │   │   │   │       └── gmail/route.ts     # Important unread emails

--- a/supabase/migrations/20260412000000_add_nutrition_to_meal_log.sql
+++ b/supabase/migrations/20260412000000_add_nutrition_to_meal_log.sql
@@ -1,0 +1,11 @@
+-- Add nutrition columns to meal_log for photo-based macro/micro estimation (issue #84)
+-- All columns are nullable — existing rows are unaffected.
+
+alter table meal_log
+  add column if not exists calories   integer,
+  add column if not exists protein_g  numeric(6,1),
+  add column if not exists carbs_g    numeric(6,1),
+  add column if not exists fat_g      numeric(6,1),
+  add column if not exists fiber_g    numeric(6,1),
+  add column if not exists sodium_mg  integer,
+  add column if not exists source     text; -- 'vision' | 'chat' | 'manual'

--- a/web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx
+++ b/web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx
@@ -1,0 +1,452 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Camera, Loader2, X, CheckCircle, AlertCircle, RefreshCw, ChevronDown, ChevronUp } from "lucide-react";
+import type { FoodAnalysis } from "@/app/api/meals/analyze-photo/route";
+
+type MealType = "breakfast" | "lunch" | "dinner" | "snack";
+type Phase = "idle" | "loading" | "review" | "saving" | "done" | "error";
+
+interface ReviewState extends FoodAnalysis {
+  meal_type_guess: MealType;
+}
+
+const CONFIDENCE_COLORS: Record<string, string> = {
+  high: "var(--color-success, #22c55e)",
+  medium: "var(--color-warning, #f59e0b)",
+  low: "var(--color-danger, #ef4444)",
+};
+
+const inputStyle = {
+  background: "var(--color-bg)",
+  border: "1px solid var(--color-border)",
+  color: "var(--color-text)",
+  outline: "none",
+  fontSize: 16, // Prevents iOS auto-zoom on focus
+  borderRadius: 8,
+  padding: "10px 12px",
+  width: "100%",
+  WebkitAppearance: "none" as const,
+} as const;
+
+export default function FoodPhotoAnalyzer() {
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string>("");
+  const [review, setReview] = useState<ReviewState | null>(null);
+  const [reestimating, setReestimating] = useState(false);
+  const [macrosExpanded, setMacrosExpanded] = useState(false);
+
+  function reset() {
+    setPhase("idle");
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+      setPreviewUrl(null);
+    }
+    setReview(null);
+    setErrorMsg("");
+    setReestimating(false);
+    setMacrosExpanded(false);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const url = URL.createObjectURL(file);
+    setPreviewUrl(url);
+    setPhase("loading");
+
+    const formData = new FormData();
+    formData.append("image", file);
+
+    try {
+      const res = await fetch("/api/meals/analyze-photo", {
+        method: "POST",
+        body: formData,
+      });
+      const data = await res.json();
+      if (!res.ok || data.error) throw new Error(data.error ?? "Analysis failed");
+      setReview(data as ReviewState);
+      setPhase("review");
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "Analysis failed");
+      setPhase("error");
+    }
+  }
+
+  async function handleReestimate() {
+    if (!review) return;
+    setReestimating(true);
+    try {
+      const res = await fetch("/api/meals/estimate-macros", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ingredients: review.ingredients }),
+      });
+      const data = await res.json();
+      if (!res.ok || data.error) throw new Error(data.error ?? "Re-estimation failed");
+      // Merge updated macros back, keep meal_type_guess from user's current selection
+      setReview((prev) =>
+        prev ? { ...data, meal_type_guess: prev.meal_type_guess } : data
+      );
+    } catch (err) {
+      // Surface re-estimation errors inline without blowing away the review state
+      setErrorMsg(err instanceof Error ? err.message : "Re-estimation failed");
+    } finally {
+      setReestimating(false);
+    }
+  }
+
+  async function handleLog() {
+    if (!review) return;
+    setPhase("saving");
+
+    try {
+      const res = await fetch("/api/meals/log", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          meal_type: review.meal_type_guess,
+          notes: `${review.food_name} — ${review.ingredients}`,
+          calories: review.calories,
+          protein_g: review.protein_g,
+          carbs_g: review.carbs_g,
+          fat_g: review.fat_g,
+          fiber_g: review.fiber_g,
+          sodium_mg: review.sodium_mg,
+          source: "vision",
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok || data.error) throw new Error(data.error ?? "Failed to log meal");
+      setPhase("done");
+      router.refresh();
+      setTimeout(reset, 2000);
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "Failed to log meal");
+      setPhase("error");
+    }
+  }
+
+  function updateMacro(field: keyof ReviewState, value: string, isInt: boolean) {
+    const parsed = isInt ? parseInt(value, 10) : parseFloat(value);
+    if (!isNaN(parsed)) setReview((prev) => (prev ? { ...prev, [field]: parsed } : prev));
+    else if (value === "") setReview((prev) => (prev ? { ...prev, [field]: 0 } : prev));
+  }
+
+  return (
+    <div
+      className="rounded-xl p-5"
+      style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+    >
+      <p
+        className="text-xs uppercase tracking-widest mb-4"
+        style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}
+      >
+        Analyze Food Photo
+      </p>
+
+      {/* IDLE */}
+      {phase === "idle" && (
+        <div className="flex flex-col gap-3">
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            className="flex items-center justify-center gap-2 rounded-xl font-medium transition-opacity active:opacity-70"
+            style={{
+              background: "var(--color-primary)",
+              color: "#fff",
+              fontSize: 16,
+              padding: "13px 20px",
+              width: "100%",
+              minHeight: 48,
+            }}
+          >
+            <Camera size={18} />
+            Upload or take photo
+          </button>
+          <p style={{ fontSize: 12, color: "var(--color-text-faint)" }}>
+            Claude identifies the food and estimates macros. Images are never stored.
+          </p>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleFileChange}
+          />
+        </div>
+      )}
+
+      {/* LOADING */}
+      {phase === "loading" && (
+        <div className="flex items-center gap-4">
+          {previewUrl && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={previewUrl}
+              alt="Food preview"
+              className="rounded-lg object-cover flex-shrink-0"
+              style={{ width: 64, height: 64 }}
+            />
+          )}
+          <div className="flex items-center gap-2" style={{ color: "var(--color-text-muted)" }}>
+            <Loader2 size={16} className="animate-spin" style={{ color: "var(--color-primary)" }} />
+            <span style={{ fontSize: 15 }}>Analyzing…</span>
+          </div>
+        </div>
+      )}
+
+      {/* REVIEW */}
+      {phase === "review" && review && (
+        <div className="space-y-5">
+          {/* Thumbnail row */}
+          {previewUrl && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={previewUrl}
+              alt="Food preview"
+              className="rounded-lg object-cover w-full"
+              style={{ maxHeight: 180, objectFit: "cover" }}
+            />
+          )}
+
+          {/* ── Food name (display label) ── */}
+          <div>
+            <p style={{ fontSize: 16, fontWeight: 600, color: "var(--color-text)" }}>
+              {review.food_name}
+            </p>
+          </div>
+
+          {/* ── Ingredients (primary edit target) ── */}
+          <div>
+            <label style={{ fontSize: 12, color: "var(--color-text-muted)", display: "block", marginBottom: 6 }}>
+              Ingredients
+            </label>
+            <textarea
+              value={review.ingredients}
+              onChange={(e) => setReview((prev) => prev ? { ...prev, ingredients: e.target.value } : prev)}
+              rows={3}
+              placeholder="e.g. chicken breast ~150g, white rice ~1 cup, broccoli ~½ cup"
+              autoComplete="off"
+              autoCorrect="off"
+              style={{
+                ...inputStyle,
+                resize: "none",
+                lineHeight: 1.6,
+              }}
+            />
+            <div className="flex items-center gap-3 mt-2">
+              <button
+                onClick={handleReestimate}
+                disabled={reestimating}
+                className="flex items-center gap-1.5 rounded-lg transition-opacity active:opacity-70 disabled:opacity-40"
+                style={{
+                  fontSize: 13,
+                  color: "var(--color-primary)",
+                  padding: "6px 0",
+                  background: "none",
+                  border: "none",
+                  cursor: reestimating ? "default" : "pointer",
+                }}
+              >
+                {reestimating
+                  ? <Loader2 size={13} className="animate-spin" />
+                  : <RefreshCw size={13} />
+                }
+                Re-estimate macros
+              </button>
+              {review.confidence && (
+                <span
+                  className="rounded-full px-2 py-0.5 text-xs font-medium ml-auto"
+                  style={{
+                    background: CONFIDENCE_COLORS[review.confidence] + "22",
+                    color: CONFIDENCE_COLORS[review.confidence],
+                  }}
+                >
+                  {review.confidence} confidence
+                </span>
+              )}
+            </div>
+            {review.notes && (
+              <p style={{ fontSize: 12, color: "var(--color-text-faint)", marginTop: 6, fontStyle: "italic" }}>
+                {review.notes}
+              </p>
+            )}
+          </div>
+
+          {/* Meal type */}
+          <div>
+            <label style={{ fontSize: 12, color: "var(--color-text-muted)", display: "block", marginBottom: 6 }}>
+              Meal type
+            </label>
+            <select
+              value={review.meal_type_guess}
+              onChange={(e) =>
+                setReview((prev) => prev ? { ...prev, meal_type_guess: e.target.value as MealType } : prev)
+              }
+              style={inputStyle}
+            >
+              <option value="breakfast">Breakfast</option>
+              <option value="lunch">Lunch</option>
+              <option value="dinner">Dinner</option>
+              <option value="snack">Snack</option>
+            </select>
+          </div>
+
+          {/* ── Macro summary (read-only) with optional manual edit toggle ── */}
+          <div
+            className="rounded-lg p-3"
+            style={{ background: "var(--color-bg)", border: "1px solid var(--color-border)" }}
+          >
+            {/* Read-only summary row */}
+            <div className="flex items-center justify-between">
+              <div className="flex flex-wrap gap-x-4 gap-y-1">
+                {[
+                  { label: "cal", value: review.calories },
+                  { label: "P", value: review.protein_g != null ? `${review.protein_g}g` : null },
+                  { label: "C", value: review.carbs_g != null ? `${review.carbs_g}g` : null },
+                  { label: "F", value: review.fat_g != null ? `${review.fat_g}g` : null },
+                ].map(({ label, value }) =>
+                  value != null ? (
+                    <span key={label} style={{ fontSize: 14, color: "var(--color-text)" }}>
+                      <span style={{ color: "var(--color-text-muted)", fontSize: 12 }}>{label} </span>
+                      {value}
+                    </span>
+                  ) : null
+                )}
+              </div>
+              <button
+                onClick={() => setMacrosExpanded((v) => !v)}
+                className="flex items-center gap-1 rounded transition-opacity active:opacity-70 ml-3 flex-shrink-0"
+                style={{ fontSize: 12, color: "var(--color-text-muted)", background: "none", border: "none" }}
+              >
+                Edit
+                {macrosExpanded ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+              </button>
+            </div>
+
+            {/* Expandable manual edit grid */}
+            {macrosExpanded && (
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mt-4">
+                {(
+                  [
+                    { label: "Calories", field: "calories", unit: "kcal", isInt: true },
+                    { label: "Protein", field: "protein_g", unit: "g" },
+                    { label: "Carbs", field: "carbs_g", unit: "g" },
+                    { label: "Fat", field: "fat_g", unit: "g" },
+                    { label: "Fiber", field: "fiber_g", unit: "g" },
+                    { label: "Sodium", field: "sodium_mg", unit: "mg", isInt: true },
+                  ] as { label: string; field: keyof ReviewState; unit: string; isInt?: boolean }[]
+                ).map(({ label, field, unit, isInt }) => (
+                  <div key={field}>
+                    <label style={{ fontSize: 11, color: "var(--color-text-muted)", display: "block", marginBottom: 4 }}>
+                      {label} <span style={{ color: "var(--color-text-faint)" }}>({unit})</span>
+                    </label>
+                    <input
+                      type="text"
+                      inputMode={isInt ? "numeric" : "decimal"}
+                      value={review[field] as number ?? ""}
+                      onChange={(e) => updateMacro(field, e.target.value, isInt ?? false)}
+                      style={inputStyle}
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Inline re-estimation error */}
+          {errorMsg && phase === "review" && (
+            <div className="flex items-center gap-2" style={{ color: "var(--color-danger, #ef4444)", fontSize: 13 }}>
+              <AlertCircle size={14} />
+              {errorMsg}
+              <button
+                onClick={() => setErrorMsg("")}
+                style={{ marginLeft: "auto", background: "none", border: "none", cursor: "pointer", color: "inherit" }}
+              >
+                <X size={13} />
+              </button>
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="flex flex-col sm:flex-row gap-2 pt-1">
+            <button
+              onClick={handleLog}
+              className="flex items-center justify-center gap-2 rounded-xl font-medium transition-opacity active:opacity-70"
+              style={{
+                background: "var(--color-primary)",
+                color: "#fff",
+                fontSize: 16,
+                padding: "13px 20px",
+                minHeight: 48,
+                flex: 1,
+              }}
+            >
+              Log Meal
+            </button>
+            <button
+              onClick={reset}
+              className="flex items-center justify-center gap-2 rounded-xl transition-opacity active:opacity-70"
+              style={{
+                border: "1px solid var(--color-border)",
+                color: "var(--color-text-muted)",
+                fontSize: 15,
+                padding: "13px 20px",
+                minHeight: 48,
+              }}
+            >
+              <X size={15} />
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* SAVING */}
+      {phase === "saving" && (
+        <div className="flex items-center gap-3" style={{ color: "var(--color-text-muted)" }}>
+          <Loader2 size={16} className="animate-spin" style={{ color: "var(--color-primary)" }} />
+          <span style={{ fontSize: 15 }}>Logging meal…</span>
+        </div>
+      )}
+
+      {/* DONE */}
+      {phase === "done" && (
+        <div className="flex items-center gap-2" style={{ color: "var(--color-success, #22c55e)" }}>
+          <CheckCircle size={18} />
+          <span style={{ fontSize: 15 }}>Meal logged.</span>
+        </div>
+      )}
+
+      {/* ERROR (fatal — photo upload failed) */}
+      {phase === "error" && (
+        <div className="space-y-4">
+          <div className="flex items-start gap-2" style={{ color: "var(--color-danger, #ef4444)" }}>
+            <AlertCircle size={16} style={{ flexShrink: 0, marginTop: 2 }} />
+            <span style={{ fontSize: 14 }}>{errorMsg}</span>
+          </div>
+          <button
+            onClick={reset}
+            className="flex items-center justify-center rounded-xl transition-opacity active:opacity-70"
+            style={{
+              border: "1px solid var(--color-border)",
+              color: "var(--color-text-muted)",
+              fontSize: 15,
+              padding: "13px 20px",
+              minHeight: 48,
+              width: "100%",
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/(protected)/meals/page.tsx
+++ b/web/src/app/(protected)/meals/page.tsx
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import Link from "next/link";
 import { MessageSquare } from "lucide-react";
 import { daysAgoString } from "@/lib/timezone";
+import FoodPhotoAnalyzer from "./FoodPhotoAnalyzer";
 
 interface MealRow {
   id: string;
@@ -11,6 +12,10 @@ interface MealRow {
   meal_type: string;
   notes: string | null;
   recipes: { name: string } | null;
+  calories: number | null;
+  protein_g: number | null;
+  carbs_g: number | null;
+  fat_g: number | null;
 }
 
 function fmtDate(d: string) {
@@ -30,7 +35,7 @@ export default async function MealsPage() {
 
   const { data } = await supabase
     .from("meal_log")
-    .select("id, date, meal_type, notes, recipes(name)")
+    .select("id, date, meal_type, notes, calories, protein_g, carbs_g, fat_g, recipes(name)")
     .gte("date", daysAgoString(6))
     .order("date", { ascending: false })
     .order("meal_type", { ascending: true });
@@ -56,6 +61,9 @@ export default async function MealsPage() {
         </p>
       </div>
 
+      {/* Photo analyzer */}
+      <FoodPhotoAnalyzer />
+
       {/* Log via chat nudge */}
       <div
         className="flex items-center gap-3 rounded-xl px-4 py-3"
@@ -63,7 +71,7 @@ export default async function MealsPage() {
       >
         <MessageSquare size={16} style={{ color: "var(--color-primary)", flexShrink: 0 }} />
         <p style={{ fontSize: 14, color: "var(--color-text-muted)" }}>
-          Log meals by telling{" "}
+          Or log meals by telling{" "}
           <Link
             href="/chat"
             style={{ color: "var(--color-primary)", textDecoration: "underline", textUnderlineOffset: 2 }}
@@ -101,7 +109,19 @@ export default async function MealsPage() {
                   {fmtDate(date)}
                 </p>
                 <div className="space-y-2">
-                  {dayMeals.map((m) => (
+                  {dayMeals.map((m) => {
+                    const hasMacros = m.calories != null || m.protein_g != null;
+                    const macroStr = hasMacros
+                      ? [
+                          m.calories != null && `${m.calories} cal`,
+                          m.protein_g != null && `P ${m.protein_g}g`,
+                          m.carbs_g != null && `C ${m.carbs_g}g`,
+                          m.fat_g != null && `F ${m.fat_g}g`,
+                        ]
+                          .filter(Boolean)
+                          .join(" · ")
+                      : null;
+                    return (
                     <div key={m.id} className="flex items-baseline gap-3">
                       <span
                         style={{
@@ -114,11 +134,19 @@ export default async function MealsPage() {
                       >
                         {m.meal_type}
                       </span>
-                      <span style={{ fontSize: 14, color: "var(--color-text)" }}>
-                        {m.recipes?.name ?? m.notes ?? "—"}
-                      </span>
+                      <div>
+                        <span style={{ fontSize: 14, color: "var(--color-text)" }}>
+                          {m.recipes?.name ?? m.notes ?? "—"}
+                        </span>
+                        {macroStr && (
+                          <span style={{ fontSize: 11, color: "var(--color-text-faint)", marginLeft: 8 }}>
+                            {macroStr}
+                          </span>
+                        )}
+                      </div>
                     </div>
-                  ))}
+                    );
+                  })}
                 </div>
               </div>
             );

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -128,7 +128,7 @@ Tools available:
 - list_calendar_events: list events across all calendars for a date range (defaults to today); each event includes a calendarType field: "primary" (user's own events), "birthday" (auto-generated from contacts), "holiday" (subscription holiday calendars), "other" (shared/secondary). By default show only primary+other events; mention birthdays as reminders separately; omit holiday events unless the user asks. IMPORTANT: only report events that appear in the tool result — never infer or carry over events from conversation history
 - create_calendar_event: create a Google Calendar event on the primary calendar
 - get_recipes: search saved recipes by ingredient, name, or tag; omit query to return all
-- log_meal: log a meal by type (breakfast/lunch/dinner/snack) with optional recipe link or notes
+- log_meal: log a meal by type (breakfast/lunch/dinner/snack) with optional recipe link, notes, and estimated macros (calories, protein_g, carbs_g, fat_g) — include macros whenever the user mentions them or you can estimate from the food description
 
 Recipes and meal planning are in scope. When asked what to cook given ingredients on hand:
 1. Call get_recipes to check for saved recipes that match.
@@ -680,12 +680,16 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
     }),
 
     log_meal: tool({
-      description: "Log a meal to the meal_log table.",
+      description: "Log a meal to the meal_log table. Include estimated macros (calories, protein_g, carbs_g, fat_g) whenever the user mentions them or you can estimate them from the food description.",
       parameters: jsonSchema<{
         meal_type: "breakfast" | "lunch" | "dinner" | "snack";
         notes?: string;
         recipe_id?: string;
         date?: string;
+        calories?: number;
+        protein_g?: number;
+        carbs_g?: number;
+        fat_g?: number;
       }>({
         type: "object",
         required: ["meal_type"],
@@ -694,9 +698,13 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
           notes: { type: "string", description: "Free-text meal description." },
           recipe_id: { type: "string", description: "UUID of a saved recipe." },
           date: { type: "string", description: "Date in YYYY-MM-DD format. Defaults to today." },
+          calories: { type: "number", description: "Estimated calories." },
+          protein_g: { type: "number", description: "Estimated protein in grams." },
+          carbs_g: { type: "number", description: "Estimated carbohydrates in grams." },
+          fat_g: { type: "number", description: "Estimated fat in grams." },
         },
       }),
-      execute: async ({ meal_type, notes, recipe_id, date }) => {
+      execute: async ({ meal_type, notes, recipe_id, date, calories, protein_g, carbs_g, fat_g }) => {
         const { data, error } = await supabase
           .from("meal_log")
           .insert({
@@ -704,6 +712,11 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
             notes: notes ?? null,
             recipe_id: recipe_id ?? null,
             date: date ?? todayString(),
+            calories: calories ?? null,
+            protein_g: protein_g ?? null,
+            carbs_g: carbs_g ?? null,
+            fat_g: fat_g ?? null,
+            source: "chat",
           })
           .select()
           .single();

--- a/web/src/app/api/meals/analyze-photo/route.ts
+++ b/web/src/app/api/meals/analyze-photo/route.ts
@@ -1,0 +1,100 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import { generateObject } from "ai";
+import { z } from "zod";
+
+export const maxDuration = 30;
+
+const FoodAnalysisSchema = z.object({
+  food_name: z.string().describe("Name of the dish or food item"),
+  ingredients: z
+    .string()
+    .describe(
+      "Comma-separated list of visible ingredients and their estimated quantities, e.g. 'chicken breast ~150g, white rice ~1 cup, broccoli ~½ cup, olive oil ~1 tbsp'"
+    ),
+  meal_type_guess: z
+    .enum(["breakfast", "lunch", "dinner", "snack"])
+    .describe("Best guess for meal type based on the food"),
+  calories: z.number().int().describe("Estimated total calories for the visible portion"),
+  protein_g: z.number().describe("Estimated protein in grams"),
+  carbs_g: z.number().describe("Estimated carbohydrates in grams"),
+  fat_g: z.number().describe("Estimated fat in grams"),
+  fiber_g: z.number().describe("Estimated dietary fiber in grams"),
+  sodium_mg: z.number().int().describe("Estimated sodium in milligrams"),
+  confidence: z.enum(["high", "medium", "low"]).describe("Confidence level of the analysis"),
+  notes: z
+    .string()
+    .describe("Brief caveats or assumptions, e.g. 'portion size estimated from plate context'"),
+});
+
+export type FoodAnalysis = z.infer<typeof FoodAnalysisSchema>;
+
+export async function POST(req: Request) {
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch {
+    return Response.json({ error: "Invalid form data" }, { status: 400 });
+  }
+
+  const imageFile = formData.get("image");
+  if (!imageFile || !(imageFile instanceof File)) {
+    return Response.json({ error: "No image file provided" }, { status: 400 });
+  }
+
+  // Validate file type
+  if (!imageFile.type.startsWith("image/")) {
+    return Response.json({ error: "File must be an image" }, { status: 400 });
+  }
+
+  // Limit to 10 MB to avoid excessive token costs
+  const MAX_SIZE = 10 * 1024 * 1024;
+  if (imageFile.size > MAX_SIZE) {
+    return Response.json({ error: "Image must be under 10 MB" }, { status: 400 });
+  }
+
+  // Read into memory — never stored, analyzed in-transit only
+  const arrayBuffer = await imageFile.arrayBuffer();
+  const base64 = Buffer.from(arrayBuffer).toString("base64");
+  const mimeType = imageFile.type as "image/jpeg" | "image/png" | "image/gif" | "image/webp";
+
+  try {
+    const { object } = await generateObject({
+      model: anthropic("claude-sonnet-4-6"),
+      schema: FoodAnalysisSchema,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              image: base64,
+              mimeType,
+            },
+            {
+              type: "text",
+              text: `Analyze this food photo and estimate its nutritional content.
+
+Instructions:
+- Identify the dish name and list all visible ingredients with estimated quantities
+- Estimate macros and micros for the total visible portion (what would be eaten)
+- Use conservative estimates — do not inflate
+- If multiple items are present, sum the totals
+- Set confidence to "high" only if the food is clearly identifiable and portion is estimable
+- Set confidence to "low" if the image is unclear, the food is ambiguous, or portion size is very uncertain
+- Include any key assumptions in notes (e.g. "sauce not included", "estimated half-plate portion")
+- If this is not a food image, set food_name to "Unknown", ingredients to "unknown", and all numeric values to 0`,
+            },
+          ],
+        },
+      ],
+    });
+
+    return Response.json(object);
+  } catch (err) {
+    console.error("[analyze-photo] Claude error:", err);
+    return Response.json(
+      { error: err instanceof Error ? err.message : "Analysis failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/web/src/app/api/meals/estimate-macros/route.ts
+++ b/web/src/app/api/meals/estimate-macros/route.ts
@@ -1,0 +1,66 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import { generateObject } from "ai";
+import { z } from "zod";
+
+export const maxDuration = 20;
+
+const MacroEstimateSchema = z.object({
+  food_name: z.string().describe("Cleaned-up name of the dish or food item"),
+  meal_type_guess: z
+    .enum(["breakfast", "lunch", "dinner", "snack"])
+    .describe("Best guess for meal type based on the food"),
+  calories: z.number().int().describe("Estimated total calories for the described portion"),
+  protein_g: z.number().describe("Estimated protein in grams"),
+  carbs_g: z.number().describe("Estimated carbohydrates in grams"),
+  fat_g: z.number().describe("Estimated fat in grams"),
+  fiber_g: z.number().describe("Estimated dietary fiber in grams"),
+  sodium_mg: z.number().int().describe("Estimated sodium in milligrams"),
+  confidence: z.enum(["high", "medium", "low"]).describe("Confidence level of the estimate"),
+  notes: z.string().describe("Brief caveats, e.g. 'portion size assumed standard serving'"),
+});
+
+export type MacroEstimate = z.infer<typeof MacroEstimateSchema>;
+
+export async function POST(req: Request) {
+  let body: { ingredients: string };
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.ingredients?.trim()) {
+    return Response.json({ error: "ingredients is required" }, { status: 400 });
+  }
+
+  try {
+    const { object } = await generateObject({
+      model: anthropic("claude-haiku-4-5-20251001"),
+      schema: MacroEstimateSchema,
+      messages: [
+        {
+          role: "user",
+          content: `Estimate the nutritional content of a meal with these ingredients:
+
+"${body.ingredients.trim()}"
+
+Instructions:
+- Use the listed ingredients and quantities to estimate macros
+- If quantities are missing, assume a standard single serving
+- Use conservative estimates — do not inflate
+- Set confidence to "high" if ingredients and quantities are clearly specified
+- Set confidence to "low" if ingredients are vague or quantities are absent
+- Include any key assumptions in notes`,
+        },
+      ],
+    });
+
+    return Response.json(object);
+  } catch (err) {
+    console.error("[estimate-macros] Claude error:", err);
+    return Response.json(
+      { error: err instanceof Error ? err.message : "Estimation failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/web/src/app/api/meals/log/route.ts
+++ b/web/src/app/api/meals/log/route.ts
@@ -1,0 +1,55 @@
+import { createServiceClient } from "@/lib/supabase/service";
+import { todayString } from "@/lib/timezone";
+
+interface MealLogBody {
+  meal_type: "breakfast" | "lunch" | "dinner" | "snack";
+  notes?: string;
+  date?: string;
+  calories?: number;
+  protein_g?: number;
+  carbs_g?: number;
+  fat_g?: number;
+  fiber_g?: number;
+  sodium_mg?: number;
+  source?: string;
+}
+
+export async function POST(req: Request) {
+  let body: MealLogBody;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const validTypes = ["breakfast", "lunch", "dinner", "snack"];
+  if (!body.meal_type || !validTypes.includes(body.meal_type)) {
+    return Response.json({ error: "meal_type must be breakfast, lunch, dinner, or snack" }, { status: 400 });
+  }
+
+  const supabase = createServiceClient();
+
+  const { data, error } = await supabase
+    .from("meal_log")
+    .insert({
+      meal_type: body.meal_type,
+      notes: body.notes ?? null,
+      date: body.date ?? todayString(),
+      calories: body.calories ?? null,
+      protein_g: body.protein_g ?? null,
+      carbs_g: body.carbs_g ?? null,
+      fat_g: body.fat_g ?? null,
+      fiber_g: body.fiber_g ?? null,
+      sodium_mg: body.sodium_mg ?? null,
+      source: body.source ?? "manual",
+    })
+    .select()
+    .single();
+
+  if (error) {
+    console.error("[meals/log] Supabase error:", error);
+    return Response.json({ error: error.message }, { status: 500 });
+  }
+
+  return Response.json(data, { status: 201 });
+}


### PR DESCRIPTION
## Summary

- User can upload or capture a food photo from the `/meals` page; Claude vision identifies the dish, extracts an ingredients list with estimated quantities, and estimates macros (calories, protein, carbs, fat, fiber, sodium)
- Ingredients textarea is the primary edit target — more intuitive than editing raw numbers; "Re-estimate macros" button sends the corrected list back to Claude (Haiku) for a fresh calculation
- Macros shown read-only with an optional manual "Edit" toggle for overrides
- Image is analyzed in-memory and never written to disk or Supabase Storage
- Mobile-optimised: iOS native photo/camera sheet, `font-size: 16px` prevents auto-zoom, 48px touch targets, full-width Log Meal button
- `log_meal` chat tool extended with optional macro fields so chat-logged meals can carry nutrition data too

## Changes

| File | Change |
|------|--------|
| `supabase/migrations/20260412000000_add_nutrition_to_meal_log.sql` | Adds `calories`, `protein_g`, `carbs_g`, `fat_g`, `fiber_g`, `sodium_mg`, `source` to `meal_log` (all nullable) |
| `web/src/app/api/meals/analyze-photo/route.ts` | POST — Claude vision analysis; returns food name, ingredients, macros |
| `web/src/app/api/meals/estimate-macros/route.ts` | POST — re-estimate macros from ingredients string (Haiku) |
| `web/src/app/api/meals/log/route.ts` | POST — insert `meal_log` row with full nutrition fields |
| `web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx` | New client component — full upload/review/log flow |
| `web/src/app/(protected)/meals/page.tsx` | Adds analyzer card; shows inline macros on logged entries |
| `web/src/app/api/chat/route.ts` | Extends `log_meal` tool with macro params |
| `CHANGELOG.md` / `README.md` | Documented |

## Test plan

- [ ] Run migration: `npx supabase db push` — confirm new columns in `meal_log`
- [ ] Open `/meals` on desktop — analyzer card appears above chat nudge
- [ ] Upload a food photo — loading state shows thumbnail, review state pre-fills dish name, ingredients, and macros
- [ ] Edit ingredients → tap "Re-estimate macros" → numbers update
- [ ] Expand "Edit" toggle → manually override a macro value → Log Meal → entry appears in today's log with macro summary
- [ ] Open `/meals` on mobile (LAN: `http://192.168.68.63:3001/meals`) — tap "Upload or take photo" → iOS shows native Take Photo / Photo Library sheet
- [ ] Verify no image data in Supabase `meal_log` table — only nutrition columns populated
- [ ] In chat: "I had grilled salmon with rice for dinner" → Claude logs with estimated macros
- [ ] Upload a non-food image → graceful error state

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)