### PR TITLE
fix: mobile UI layout and sync error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (mobile UI + sync — this PR)
+- **Weather layout** — date and weather are now on separate lines in the dashboard header; no more mid-line wrapping or diagonal cut-off of the H/L values on narrow screens
+- **Mobile nav safe area** — added `viewport-fit: cover` to the viewport metadata and `padding-bottom: env(safe-area-inset-bottom)` to the bottom tab bar so it no longer clips behind the iOS home indicator
+- **Bottom nav "More" tab** — replaced the hard-coded 5-item mobile nav with 4 primary tabs (Dashboard, Habits, Tasks, Chat) + a **More** button that opens a bottom sheet with the remaining pages (Fitness, Meals, Journal, Settings); More button highlights when the active page is one of those secondary routes
+- **Sync button no longer shows "Sync failed" for unconfigured sources** — Oura, Fitbit, and Google Fit sync routes now return HTTP 200 `{ skipped: true }` when the required env vars or tokens are absent, instead of throwing a 500; only genuine API/DB errors count as failures
+
 ### Added (food photo analysis — issue #84)
 - **Food photo analysis** — `/meals` page now has an "Analyze Food Photo" card; user selects or captures a photo, Claude vision identifies the dish and extracts an ingredients list with estimated quantities, estimates macros (calories, protein, carbs, fat, fiber, sodium), and presents an editable review before logging
 - **Ingredients-first editing** — review state shows dish name as a header and the ingredients list as the primary editable textarea; "Re-estimate macros" button sends the corrected ingredients back to Claude (Haiku) for a fresh macro calculation; macro numbers are shown read-only with an optional "Edit" toggle for manual overrides

--- a/web/src/app/(protected)/layout.tsx
+++ b/web/src/app/(protected)/layout.tsx
@@ -24,7 +24,8 @@ export default async function ProtectedLayout({
       <Nav />
       {/* ml-0 on mobile (nav is bottom bar), ml-60 on desktop (240px sidebar) */}
       {/* pb-16 on mobile to clear the 56px bottom tab bar */}
-      <main className="flex-1 ml-0 lg:ml-60 px-5 lg:px-8 pt-8 pb-20 lg:pb-8 min-w-0">
+      {/* pb accounts for 56px tab bar + safe-area-inset-bottom on iOS */}
+      <main className="flex-1 ml-0 lg:ml-60 px-5 lg:px-8 pt-8 pb-[calc(56px+env(safe-area-inset-bottom)+16px)] lg:pb-8 min-w-0">
         <div className="max-w-6xl mx-auto">{children}</div>
       </main>
     </div>

--- a/web/src/app/api/sync/fitbit/route.ts
+++ b/web/src/app/api/sync/fitbit/route.ts
@@ -10,15 +10,21 @@ export async function POST() {
   } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
+  if (!process.env.FITBIT_CLIENT_ID || !process.env.FITBIT_CLIENT_SECRET) {
+    return NextResponse.json({ skipped: true, reason: "Fitbit not configured" });
+  }
+
   try {
     const db = createServiceClient();
     const result = await syncFitbit(db);
     return NextResponse.json({ success: true, ...result });
   } catch (err) {
+    const msg = err instanceof Error ? err.message : "Sync failed";
+    // Refresh token missing from profile table → treat as not configured, not an error
+    if (msg.includes("not found in profile table")) {
+      return NextResponse.json({ skipped: true, reason: "Fitbit refresh token not stored yet" });
+    }
     console.error("[/api/sync/fitbit]", err);
-    return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Sync failed" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: msg }, { status: 500 });
   }
 }

--- a/web/src/app/api/sync/googlefit/route.ts
+++ b/web/src/app/api/sync/googlefit/route.ts
@@ -10,6 +10,15 @@ export async function POST() {
   } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
+  const hasGoogleFitConfig =
+    !!(process.env.GOOGLE_FIT_CLIENT_ID ?? process.env.GOOGLE_CLIENT_ID) &&
+    !!(process.env.GOOGLE_FIT_CLIENT_SECRET ?? process.env.GOOGLE_CLIENT_SECRET) &&
+    !!(process.env.GOOGLE_FIT_REFRESH_TOKEN ?? process.env.GOOGLE_REFRESH_TOKEN);
+
+  if (!hasGoogleFitConfig) {
+    return NextResponse.json({ skipped: true, reason: "Google Fit not configured" });
+  }
+
   try {
     const db = createServiceClient();
     const result = await syncGoogleFit(db);

--- a/web/src/app/api/sync/oura/route.ts
+++ b/web/src/app/api/sync/oura/route.ts
@@ -10,6 +10,10 @@ export async function POST() {
   } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
+  if (!process.env.OURA_ACCESS_TOKEN) {
+    return NextResponse.json({ skipped: true, reason: "OURA_ACCESS_TOKEN not configured" });
+  }
+
   try {
     const db = createServiceClient();
     const result = await syncOura(db);

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,9 +1,13 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
   title: "Mr. Bridge",
   description: "Personal assistant dashboard",
+};
+
+export const viewport: Viewport = {
+  viewportFit: "cover",
 };
 
 export default function RootLayout({

--- a/web/src/components/dashboard/dashboard-header.tsx
+++ b/web/src/components/dashboard/dashboard-header.tsx
@@ -41,26 +41,23 @@ export default function DashboardHeader({ greeting, dateStr, windowKey }: Props)
         <h1 className="font-heading font-semibold" style={{ fontSize: 24, color: "var(--color-text)" }}>
           {greeting}
         </h1>
-        <p className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5" style={{ fontSize: 13, color: "var(--color-text-muted)" }}>
-          <span>{dateStr}</span>
-          {weather && (
-            <>
-              <span style={{ color: "var(--color-text-faint)" }}>·</span>
-              <span className="flex items-center gap-1.5">
-                {emoji && <span style={{ fontSize: 14, lineHeight: 1 }}>{emoji}</span>}
-                <span style={{ color: "var(--color-text)" }}>
-                  {weather.temp != null ? `${Math.round(weather.temp)}°` : ""}
-                </span>
-                <span>{weather.condition}</span>
-                {(weather.high != null || weather.low != null) && (
-                  <span style={{ color: "var(--color-text-faint)" }}>
-                    H {weather.high != null ? `${Math.round(weather.high)}°` : "—"} · L {weather.low != null ? `${Math.round(weather.low)}°` : "—"}
-                  </span>
-                )}
-              </span>
-            </>
-          )}
+        <p className="mt-0.5" style={{ fontSize: 13, color: "var(--color-text-muted)" }}>
+          {dateStr}
         </p>
+        {weather && (
+          <p className="mt-0.5 flex items-center gap-1.5" style={{ fontSize: 13, color: "var(--color-text-muted)" }}>
+            {emoji && <span style={{ fontSize: 14, lineHeight: 1 }}>{emoji}</span>}
+            {weather.temp != null && (
+              <span style={{ color: "var(--color-text)" }}>{Math.round(weather.temp)}°</span>
+            )}
+            <span>{weather.condition}</span>
+            {(weather.high != null || weather.low != null) && (
+              <span style={{ color: "var(--color-text-faint)" }}>
+                · H {weather.high != null ? `${Math.round(weather.high)}°` : "—"} L {weather.low != null ? `${Math.round(weather.low)}°` : "—"}
+              </span>
+            )}
+          </p>
+        )}
       </div>
 
       {/* Right: sync + window */}

--- a/web/src/components/nav.tsx
+++ b/web/src/components/nav.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useState } from "react";
 import {
   LayoutDashboard,
   Activity,
@@ -11,6 +12,8 @@ import {
   Settings,
   ListTodo,
   BookOpen,
+  MoreHorizontal,
+  X,
 } from "lucide-react";
 import Logo from "@/components/ui/logo";
 
@@ -25,10 +28,10 @@ const NAV_ITEMS = [
   { href: "/settings",  label: "Settings",   icon: Settings },
 ];
 
-// Mobile shows only the 5 highest-frequency actions (≤5 is the tab bar guideline)
-const MOBILE_NAV_ITEMS = NAV_ITEMS.filter((item) =>
-  ["/dashboard", "/habits", "/tasks", "/chat", "/journal"].includes(item.href)
-);
+// 4 primary tabs always visible; the rest live in the More sheet
+const PRIMARY_HREFS = ["/dashboard", "/habits", "/tasks", "/chat"];
+const MOBILE_PRIMARY = NAV_ITEMS.filter((item) => PRIMARY_HREFS.includes(item.href));
+const MOBILE_MORE    = NAV_ITEMS.filter((item) => !PRIMARY_HREFS.includes(item.href));
 
 function isActive(pathname: string, href: string) {
   if (href === "/dashboard") return pathname === "/dashboard" || pathname === "/";
@@ -37,6 +40,10 @@ function isActive(pathname: string, href: string) {
 
 export default function Nav() {
   const pathname = usePathname();
+  const [showMore, setShowMore] = useState(false);
+
+  // Is the current page one of the "More" pages? If so, highlight the More button.
+  const moreIsActive = MOBILE_MORE.some((item) => isActive(pathname, item.href));
 
   return (
     <>
@@ -85,33 +92,108 @@ export default function Nav() {
         </div>
       </nav>
 
-      {/* ── Mobile bottom tab bar (< lg) — 5 items max ─────────────── */}
+      {/* ── Mobile bottom tab bar (< lg) ────────────────────────────── */}
       <nav
         className="flex lg:hidden fixed bottom-0 left-0 right-0 z-50"
         style={{
-          height: 56,
           background: "var(--color-bg)",
           borderTop: "1px solid var(--color-border)",
+          paddingBottom: "env(safe-area-inset-bottom)",
         }}
       >
-        {MOBILE_NAV_ITEMS.map(({ href, label, icon: Icon }) => {
-          const active = isActive(pathname, href);
-          return (
-            <Link
-              key={href}
-              href={href}
-              className="flex-1 flex flex-col items-center justify-center gap-0.5 cursor-pointer transition-colors duration-150"
-              style={{
-                minHeight: 44,
-                color: active ? "var(--color-primary)" : "var(--color-text-muted)",
-              }}
-            >
-              <Icon size={18} strokeWidth={active ? 2 : 1.5} />
-              <span style={{ fontSize: 10, fontWeight: active ? 600 : 400, lineHeight: 1 }}>{label}</span>
-            </Link>
-          );
-        })}
+        <div className="flex w-full" style={{ height: 56 }}>
+          {MOBILE_PRIMARY.map(({ href, label, icon: Icon }) => {
+            const active = isActive(pathname, href);
+            return (
+              <Link
+                key={href}
+                href={href}
+                className="flex-1 flex flex-col items-center justify-center gap-0.5 cursor-pointer transition-colors duration-150"
+                style={{
+                  color: active ? "var(--color-primary)" : "var(--color-text-muted)",
+                }}
+              >
+                <Icon size={18} strokeWidth={active ? 2 : 1.5} />
+                <span style={{ fontSize: 10, fontWeight: active ? 600 : 400, lineHeight: 1 }}>{label}</span>
+              </Link>
+            );
+          })}
+
+          {/* More button */}
+          <button
+            onClick={() => setShowMore(true)}
+            className="flex-1 flex flex-col items-center justify-center gap-0.5 cursor-pointer transition-colors duration-150"
+            style={{
+              color: moreIsActive ? "var(--color-primary)" : "var(--color-text-muted)",
+              background: "transparent",
+              border: "none",
+            }}
+          >
+            <MoreHorizontal size={18} strokeWidth={moreIsActive ? 2 : 1.5} />
+            <span style={{ fontSize: 10, fontWeight: moreIsActive ? 600 : 400, lineHeight: 1 }}>More</span>
+          </button>
+        </div>
       </nav>
+
+      {/* ── More bottom sheet ────────────────────────────────────────── */}
+      {showMore && (
+        <>
+          {/* Backdrop */}
+          <div
+            className="lg:hidden fixed inset-0 z-[60]"
+            style={{ background: "rgba(0,0,0,0.6)" }}
+            onClick={() => setShowMore(false)}
+          />
+
+          {/* Sheet */}
+          <div
+            className="lg:hidden fixed left-0 right-0 bottom-0 z-[70] rounded-t-2xl"
+            style={{
+              background: "var(--color-surface)",
+              borderTop: "1px solid var(--color-border)",
+              paddingBottom: "env(safe-area-inset-bottom)",
+            }}
+          >
+            {/* Handle + header */}
+            <div className="flex items-center justify-between px-5 pt-4 pb-3">
+              <span className="text-sm font-semibold" style={{ color: "var(--color-text)" }}>
+                More
+              </span>
+              <button
+                onClick={() => setShowMore(false)}
+                style={{ color: "var(--color-text-muted)", background: "transparent", border: "none", cursor: "pointer" }}
+              >
+                <X size={18} />
+              </button>
+            </div>
+
+            <div className="px-3 pb-4 grid grid-cols-2 gap-1">
+              {MOBILE_MORE.map(({ href, label, icon: Icon }) => {
+                const active = isActive(pathname, href);
+                return (
+                  <Link
+                    key={href}
+                    href={href}
+                    onClick={() => setShowMore(false)}
+                    className="flex items-center gap-3 px-4 py-3 rounded-xl transition-colors duration-150"
+                    style={{
+                      background: active ? "var(--color-primary-dim)" : "var(--color-surface-raised)",
+                      color: active ? "var(--color-primary)" : "var(--color-text-muted)",
+                    }}
+                  >
+                    <Icon
+                      size={18}
+                      strokeWidth={active ? 2 : 1.5}
+                      style={{ color: active ? "var(--color-primary)" : "var(--color-text-muted)", flexShrink: 0 }}
+                    />
+                    <span className="text-sm font-medium">{label}</span>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        </>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary

- **Weather layout** — date and weather are now on separate lines in the dashboard header; no more diagonal cut-off or H/L values wrapping mid-line on narrow screens
- **Mobile nav safe area** — `viewport-fit: cover` + `env(safe-area-inset-bottom)` on the tab bar so it no longer clips behind the iOS home indicator
- **Bottom nav "More" tab** — 4 primary tabs (Dashboard, Habits, Tasks, Chat) + More button that opens a bottom sheet with Fitness, Meals, Journal, Settings; More highlights when active page is one of those routes
- **Sync "Sync failed" fix** — Oura, Fitbit, and Google Fit routes return HTTP 200 `{ skipped: true }` when env vars / tokens are absent; only genuine API or DB errors return 500 and trigger the error state

## Test plan

- [ ] Open `/dashboard` on mobile — verify date on one line, weather on the next, no wrapping cut-off
- [ ] On iPhone: check bottom tab bar isn't clipped by home indicator bar
- [ ] Tap "More" in the bottom nav — sheet opens with Fitness, Meals, Journal, Settings; tapping a link navigates and closes the sheet; More tab highlights when on those pages
- [ ] Press Sync with no Google Fit / Fitbit configured — should show "Synced HH:MM" not "Sync failed"
- [ ] Press Sync with Oura configured — should sync and refresh dashboard data

🤖 Generated with [Claude Code](https://claude.com/claude-code)