### PR TITLE
fix: cap latestRecovery query to date < today

### DIFF
--- a/web/src/app/(protected)/dashboard/page.tsx
+++ b/web/src/app/(protected)/dashboard/page.tsx
@@ -54,10 +54,12 @@ export default async function DashboardPage() {
       .select("date,weight_lb,body_fat_pct")
       .gte("date", daysAgoString(days - 1))
       .order("date", { ascending: true }),
-    // Latest full recovery row (yesterday's complete data)
+    // Latest full recovery row — capped to before today so a partial same-day
+    // sync row does not replace yesterday's complete data in Health Breakdown
     supabase
       .from("recovery_metrics")
       .select("*")
+      .lt("date", today)
       .order("date", { ascending: false })
       .limit(1),
     // Today's scores only (for the strip above Health Breakdown)


### PR DESCRIPTION
## Problem

After PR #93 merged, a partial Oura sync running early in the morning creates today's `recovery_metrics` row with only `readiness` and `sleep_score` — HRV, RHR, Total Sleep, Deep, REM, and Steps are all `null`. Because the `latestRecovery` query had no date filter, it fetched this incomplete Apr 13 row. Health Breakdown then showed today's date with all detail metrics as `—`, and the `TodayScoresStrip` was suppressed (since `today === latestRecovery.date`). Apr 12's complete data was invisible.

## Fix

Add `.lt("date", today)` to the `recoveryLatestRes` query so Health Breakdown always shows the last **complete** day (Apr 12). The today-specific query for `TodayScoresStrip` already captures today's partial row separately.

## Result

- Health Breakdown → shows Apr 12 with full HRV, RHR, sleep stages, steps
- TodayScoresStrip → shows Apr 13 readiness + sleep above the card (dates now differ, so strip renders)
- No behavior change when today's row doesn't exist yet

## Test plan
- [ ] Morning (partial sync): Health Breakdown shows yesterday's complete row; strip shows today's readiness + sleep
- [ ] Late-night (full sync completes today): today's row gets all fields; Health Breakdown advances to today naturally since `today < today` is false — wait, no. With `.lt("date", today)`, Health Breakdown will always show yesterday even after today's sync completes.

> **Note:** This fix intentionally keeps Health Breakdown on yesterday's data all day. Today's readiness/sleep are surfaced via TodayScoresStrip until midnight. If you want Health Breakdown to advance to today once the full sync lands, a follow-up can check completeness (e.g. `hrv IS NOT NULL`) instead of date < today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)