### PR TITLE
chore: replace markdown file reads with Supabase queries in agents and rules (#97)

### DIFF
--- a/.claude/agents/nightly-postmortem.md
+++ b/.claude/agents/nightly-postmortem.md
@@ -1,8 +1,7 @@
 ---
 name: nightly-postmortem
-description: Nightly habit post-mortem agent. Reads memory/habits.md, evaluates today's habit completions, and fires a macOS push notification summary. Run at 9pm daily.
+description: Nightly habit post-mortem agent. Queries today's habit completions from Supabase (habits + habit_registry tables), and fires a macOS push notification summary. Run at 9pm daily.
 tools:
-  - Read
   - Bash(bash *)
 model: haiku
 permissionMode: acceptEdits
@@ -10,19 +9,33 @@ maxTurns: 5
 ---
 
 ## Purpose
-Read today's habit log and fire a macOS push notification summarizing the day.
+Query today's habit log from Supabase and fire a macOS push notification summarizing the day.
 
 ## Instructions
 
-1. Read `memory/habits.md`
-2. Find today's row in the Daily Log table (date = today in YYYY-MM-DD format)
-3. Count completed habits (marked as "yes", "✓", or "done") vs total tracked habits
+1. Query Supabase for today's habits:
+   ```bash
+   python3 - <<'EOF'
+   import sys
+   sys.path.insert(0, "scripts")
+   from _supabase import get_client
+   from datetime import date
+   client = get_client()
+   today = date.today().isoformat()
+   registry = client.table("habit_registry").select("id,name").eq("active", True).execute().data
+   logs = client.table("habits").select("habit_id,completed").eq("date", today).execute().data
+   import json
+   print(json.dumps({"registry": registry, "logs": logs, "today": today}))
+   EOF
+   ```
+2. Map each registry entry to its completion status from the logs (unlogged = not completed)
+3. Count completed habits vs total tracked habits
 4. Build a summary string:
    - All complete: "All habits complete. Good execution today."
    - Some missed: "Habits: X/Y complete. Missed: [comma-separated list]."
-   - No entry for today: "No habits logged today."
+   - No entries for today: "No habits logged today."
 5. Run:
    ```bash
    bash scripts/notify.sh --title "Mr. Bridge — Nightly Check-In" --message "<summary>"
    ```
-6. Read only — do not write to any memory files.
+6. Read only — do not write to Supabase.

--- a/.claude/agents/study-timer.md
+++ b/.claude/agents/study-timer.md
@@ -1,10 +1,7 @@
 ---
 name: study-timer
-description: Study timer agent. Starts, stops, and checks timers for Japanese study and coding sessions. Writes elapsed time to the appropriate study log in memory/todo.md on stop. Handles forgotten timers by asking for adjusted duration.
+description: Study timer agent. Starts, stops, and checks timers for Japanese study and coding sessions. Upserts timer state to the Supabase `profile` table (key='timer_state') and logs completed sessions to the `study_log` table. Handles forgotten timers by asking for adjusted duration.
 tools:
-  - Read
-  - Write
-  - Edit
   - Bash(bash *)
 model: haiku
 permissionMode: acceptEdits
@@ -12,10 +9,10 @@ maxTurns: 6
 ---
 
 ## Purpose
-Track study session duration accurately. Write to `memory/timer_state.json` on start, read on stop, log duration to `memory/todo.md`.
+Track study session duration accurately. Upsert timer state to `profile` table on start/stop; insert completed sessions into `study_log` table.
 
-## Timer State File
-`memory/timer_state.json` structure:
+## Timer State Schema
+The `profile` row with `key = 'timer_state'` holds a JSON string:
 ```json
 {
   "active": false,
@@ -29,30 +26,79 @@ Track study session duration accurately. Write to `memory/timer_state.json` on s
 - `category`: "japanese" | "coding" | "reading"
 
 ## Start Timer Instructions
-1. Write `memory/timer_state.json` with `active: true`, current ISO timestamp as `started_at`, provided subject and category
+1. Upsert timer state to Supabase:
+   ```bash
+   python3 - <<'EOF'
+   import sys, json
+   sys.path.insert(0, "scripts")
+   from _supabase import get_client
+   from datetime import datetime, timezone
+   client = get_client()
+   state = json.dumps({
+       "active": True,
+       "subject": "<SUBJECT>",
+       "started_at": datetime.now(timezone.utc).isoformat(),
+       "category": "<CATEGORY>"
+   })
+   client.table("profile").upsert({"key": "timer_state", "value": state}, on_conflict="key").execute()
+   print("Timer started.")
+   EOF
+   ```
 2. Confirm: "Timer started for [subject]. Say 'done' or run /stop-timer when finished."
 
 ## Stop Timer Instructions
-1. Read `memory/timer_state.json`
+1. Read timer state from Supabase:
+   ```bash
+   python3 - <<'EOF'
+   import sys
+   sys.path.insert(0, "scripts")
+   from _supabase import get_client
+   client = get_client()
+   row = client.table("profile").select("value").eq("key", "timer_state").execute().data
+   print(row[0]["value"] if row else "{}")
+   EOF
+   ```
 2. Calculate elapsed time in minutes (now - started_at)
 3. If elapsed > 240 min (4 hours):
    - Ask: "Timer ran for X hours. How long did you actually study? (Enter minutes or say 'skip' to discard)"
    - Use the user's adjusted value, or discard if "skip"
 4. If elapsed ≤ 240 min: use calculated duration directly
-5. Log entry to `memory/todo.md` in the appropriate study log table:
-   - `category: japanese` → Japanese Study Log
-   - `category: coding` → Coding Log
-   - `category: reading` → Reading Log
-   - Row format: `| YYYY-MM-DD | X min | [subject] | — |`
-6. Clear `memory/timer_state.json`: set `active: false`, clear other fields
+5. Insert study log entry into Supabase:
+   ```bash
+   python3 - <<'EOF'
+   import sys
+   sys.path.insert(0, "scripts")
+   from _supabase import get_client
+   from datetime import date
+   client = get_client()
+   client.table("study_log").insert({
+       "date": "<YYYY-MM-DD>",
+       "subject": "<SUBJECT>",
+       "duration_mins": <MINUTES>,
+       "notes": None
+   }).execute()
+   print("Logged.")
+   EOF
+   ```
+6. Clear timer state in Supabase (upsert `active: false`, empty fields):
+   ```bash
+   python3 - <<'EOF'
+   import sys, json
+   sys.path.insert(0, "scripts")
+   from _supabase import get_client
+   client = get_client()
+   state = json.dumps({"active": False, "subject": "", "started_at": "", "category": ""})
+   client.table("profile").upsert({"key": "timer_state", "value": state}, on_conflict="key").execute()
+   print("Timer cleared.")
+   EOF
+   ```
 7. Confirm: "Logged X min for [subject]."
 
 ## Check Timer Instructions
-1. Read `memory/timer_state.json`
-2. If `active: false`: "No timer running."
+1. Read timer state from Supabase (same query as Stop step 1)
+2. If `active: false` or no row: "No timer running."
 3. If `active: true`: "Timer running: [subject] — started [time], elapsed ~X min."
 
 ## Rules
-- Always confirm before writing to `todo.md`
-- If `timer_state.json` doesn't exist, create it with `active: false` on first start
+- Always confirm before inserting into `study_log`
 - Do not start a new timer if one is already active — ask to stop the current one first

--- a/.claude/agents/weekly-review.md
+++ b/.claude/agents/weekly-review.md
@@ -1,8 +1,7 @@
 ---
 name: weekly-review
-description: Weekly habit and accountability review agent. Reads last 7 days from memory/habits.md, memory/todo.md, and memory/timer_state.json. Outputs a structured summary and fires a push notification with headline stats. Run Sunday at 8pm or on demand via /weekly-review.
+description: Weekly habit and accountability review agent. Queries last 7 days from Supabase (habits, tasks, study_log, recovery_metrics, profile). Outputs a structured summary and fires a push notification with headline stats. Run Sunday at 8pm or on demand via /weekly-review.
 tools:
-  - Read
   - Bash(bash *)
 model: haiku
 permissionMode: acceptEdits
@@ -14,25 +13,77 @@ Compute a weekly summary of habits, study time, and tasks. Output to terminal an
 
 ## Instructions
 
-1. Determine the week range: today (Sunday) minus 6 days = Monday. Format both as YYYY-MM-DD.
+1. Determine the week range: today (Sunday) minus 6 days = Monday. Format both as YYYY-MM-DD. Set `WEEK_START` and `WEEK_END`.
 
-2. Read `memory/habits.md`
-   - Find the last 7 rows in the Daily Log table (or all rows within the week range)
-   - For each habit column (Floss, Workout, Japanese, Coding, Reading, Water, Sleep), count rows marked "yes", "✓", or "done"
+2. Query Supabase for habit data:
+   ```bash
+   python3 - <<'EOF'
+   import sys
+   sys.path.insert(0, "scripts")
+   from _supabase import get_client
+   from datetime import date, timedelta
+   client = get_client()
+   today = date.today().isoformat()
+   week_start = (date.today() - timedelta(days=6)).isoformat()
+   registry = client.table("habit_registry").select("id,name,target_per_week").eq("active", True).execute().data
+   logs = client.table("habits").select("habit_id,date,completed").gte("date", week_start).lte("date", today).execute().data
+   import json
+   print(json.dumps({"registry": registry, "logs": logs}))
+   EOF
+   ```
+   - For each habit in the registry, count `completed = true` rows within the week range
    - Days with no entry count as missed
-   - Note the target frequency for each habit from the Habit Registry table
+   - Note the `target_per_week` for each habit from the registry
 
-3. Read `memory/todo.md`
-   - Count Active Tasks by status: how many completed this week, how many added, how many still open
-   - From Japanese Study Log: sum Duration values for entries dated within the week range
-   - From Coding Log: sum Duration values for entries dated within the week range
-   - From Reading Log: list titles and pages for entries within the week range
+3. Query Supabase for task counts:
+   ```bash
+   python3 - <<'EOF'
+   import sys
+   sys.path.insert(0, "scripts")
+   from _supabase import get_client
+   from datetime import date, timedelta
+   client = get_client()
+   week_start = (date.today() - timedelta(days=6)).isoformat()
+   today = date.today().isoformat()
+   active = client.table("tasks").select("id,status").eq("status", "active").execute().data
+   completed = client.table("tasks").select("id,updated_at").eq("status", "completed").gte("updated_at", week_start).execute().data
+   import json
+   print(json.dumps({"active_count": len(active), "completed_this_week": len(completed)}))
+   EOF
+   ```
 
-4. Read `memory/timer_state.json` (if it exists)
-   - If `active: true`, calculate how long it has been running
+4. Query Supabase for study log:
+   ```bash
+   python3 - <<'EOF'
+   import sys
+   sys.path.insert(0, "scripts")
+   from _supabase import get_client
+   from datetime import date, timedelta
+   client = get_client()
+   week_start = (date.today() - timedelta(days=6)).isoformat()
+   today = date.today().isoformat()
+   rows = client.table("study_log").select("date,subject,duration_mins,notes").gte("date", week_start).lte("date", today).execute().data
+   import json
+   print(json.dumps(rows))
+   EOF
+   ```
+   - Sum `duration_mins` per subject (Japanese, Coding, Reading)
+   - Count distinct days per subject
+
+5. Query Supabase for active timer state:
+   ```bash
+   python3 - <<'EOF'
+   import sys
+   sys.path.insert(0, "scripts")
+   from _supabase import get_client
+   client = get_client()
+   row = client.table("profile").select("value").eq("key", "timer_state").execute().data
+   import json
+   print(row[0]["value"] if row else "{}")
+   EOF
+   ```
+   - Parse the JSON value; if `active: true`, calculate elapsed time from `started_at`
    - If > 4 hours, include a warning in the summary
-
-5. Check `memory/fitness_log.md` — if session log entries exist for this week, use workout count from there instead of the habit log
 
 6. Build and print the full summary:
 ```
@@ -74,8 +125,8 @@ bash scripts/notify.sh \
 ```
 
 ## Rules
-- Read only — do not write to any memory files
+- Read only — do not write to Supabase
 - Missing days count as missed, not skipped
-- If fitness_log.md has session data for the week, prefer it over habit log for workout count
-- Duration sums: treat entries like "30 min", "45 min", "1 hr" — convert to minutes
+- Workout count: use habit log `completed = true` rows for the Workout habit; `workout_sessions` data is not fetched by this agent
+- Duration sums: `duration_mins` is already in minutes in `study_log`
 - If study logs are empty for the week, report "0 min logged"

--- a/.claude/commands/log-habit.md
+++ b/.claude/commands/log-habit.md
@@ -4,13 +4,12 @@ description: Log one or more habit completions for today. Usage: /log-habit flos
 argument-hint: "[habit1] [habit2] ..."
 user-invocable: true
 allowed-tools:
-  - Read
-  - Edit
+  - Bash(bash *)
 model: haiku
 ---
 
-Log the specified habits as completed in `memory/habits.md` for today.
+Log the specified habits as completed in Supabase for today.
 
 Parse the arguments as a space-separated list of habit names. Match them case-insensitively to the habit columns (Floss, Workout, Japanese, Coding, Reading, Water, Sleep).
 
-Then use the `log-habit` skill to write the updates.
+Then use the `log-habit` skill to write the updates to Supabase via `scripts/log_habit.py`.

--- a/.claude/commands/stop-timer.md
+++ b/.claude/commands/stop-timer.md
@@ -1,6 +1,6 @@
 ---
 name: stop-timer
-description: Stop the active study timer, optionally adjust the logged duration, and write the entry to the appropriate study log in memory/todo.md.
+description: Stop the active study timer, optionally adjust the logged duration, and insert the entry into the Supabase study_log table.
 user-invocable: true
 allowed-tools:
   - Read
@@ -10,5 +10,7 @@ model: haiku
 ---
 
 Stop the currently running study timer using the study-timer agent's stop instructions.
+
+Reads timer state from the `profile` table (key = 'timer_state') and logs the completed session to the `study_log` table.
 
 If no timer is running, say so. If a timer has been running more than 4 hours, ask for an adjusted duration before logging.

--- a/.claude/rules/mr-bridge-rules.md
+++ b/.claude/rules/mr-bridge-rules.md
@@ -57,10 +57,10 @@ Execute in this exact order:
 [Unread emails matching filter, or "Inbox clear"]
 
 ### Pending Tasks
-[Active tasks from todo.md, or "None"]
+[Active tasks from Supabase `tasks` table (status = 'active'), included in `fetch_briefing_data.py` output, or "None"]
 
 ### Accountability — Last 7 Days
-[Habit summary from habits.md — hit/missed per habit with streak count]
+[Habit summary from Supabase `habits` + `habit_registry` tables — hit/missed per habit with streak count, included in `fetch_briefing_data.py` output]
 
 ### Body Composition (last weigh-in)
 Weight: [X] lb | Body Fat: [X]% | Muscle: [X] lb | BMI: [X] | Visceral: [X] — [date]
@@ -82,11 +82,11 @@ Body Composition rules:
 - Show delta vs the row before it for weight and body fat %
 
 Recovery rules:
-- Use the **last data row** of the Recovery Metrics table in fitness_log.md (bottom of the table). Oura data lags 1 day — yesterday's date is expected and correct.
+- Use the **most recent row** from the `recovery_metrics` Supabase table (order by date desc, limit 1), included in `fetch_briefing_data.py` output. Oura data lags 1 day — yesterday's date is expected and correct.
 - Readiness < 70 → append: "Readiness low — consider deload or rest day"
 - Readiness < 50 → append: "Readiness critical — rest day recommended"
 - HRV trending down 3+ consecutive days → append: "HRV declining — prioritize recovery"
-- If Recovery Metrics table has no data rows → show: "No recovery data — run: python3 scripts/sync-oura.py --yes"
+- If no recovery data returned → show: "No recovery data — run: python3 scripts/sync-oura.py --yes"
 
 ## Session Close Protocol
 Before every commit at end of session:
@@ -182,8 +182,8 @@ When the web interface is built (issue #10), expose a Location field in Settings
 ## Study Timer Rules
 - Only offer to start a timer when you explicitly say you're starting a study session (e.g. "starting Japanese now", "about to do boot.dev", "starting a coding session")
 - Ask: "Start a study timer for [subject]?"
-- On confirmation, use the study-timer agent to write `memory/timer_state.json`
-- When you say "done", "stopping", or "finished studying", stop the timer and log duration to `memory/todo.md`
+- On confirmation, use the study-timer agent to upsert timer state to the `profile` table (key = 'timer_state')
+- When you say "done", "stopping", or "finished studying", stop the timer and log duration to the `study_log` Supabase table
 - If a timer is running at session start, flag it in the briefing: "Timer still running: [subject] — started [time]"
 
 ## Data Sources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed (agent/rule Supabase cleanup — issue #97)
+- **`mr-bridge-rules.md`** — "Pending Tasks" briefing section now references Supabase `tasks` table via `fetch_briefing_data.py`; "Accountability" section references `habits` + `habit_registry` tables via same script; Recovery rules updated to query `recovery_metrics` table (order by date desc, limit 1) instead of `fitness_log.md`; Study Timer Rules updated to use `profile` table for timer state and `study_log` table for duration logging
+- **`agents/weekly-review.md`** — replaced all reads of `memory/habits.md`, `memory/todo.md`, `memory/fitness_log.md`, `memory/timer_state.json` with Supabase queries via `_supabase.py`; updated description and Rules section accordingly
+- **`agents/nightly-postmortem.md`** — replaced read of `memory/habits.md` with Supabase query of `habits` + `habit_registry` tables; updated description and tools list
+- **`agents/study-timer.md`** — timer state now upserted to `profile` table (key = `timer_state`, JSON value) instead of `memory/timer_state.json`; completed sessions inserted into `study_log` table instead of written to `memory/todo.md`; updated description and tools list
+- **`commands/stop-timer.md`** — description updated to reference `profile` table for timer state and `study_log` table for log writes
+- **`commands/log-habit.md`** — description updated to clarify writes go to Supabase via `log_habit.py`; removed stale reference to `memory/habits.md`
+
 ### Removed (migration artifacts — issue #98)
 - **`scripts/migrate_to_supabase.py`** deleted — 608-line one-time migration script; Supabase migration (issue #14) is complete
 - **`memory/*.template.md`** (5 files) deleted — pre-Supabase scaffolding; all live data is in Supabase tables


### PR DESCRIPTION
Closes #97

## Summary
- **`mr-bridge-rules.md`** — Pending Tasks → `tasks` table via `fetch_briefing_data.py`; Accountability → `habits` + `habit_registry` tables; Recovery rules → `recovery_metrics` table (desc, limit 1); Study Timer Rules → `profile` table for state, `study_log` table for log writes
- **`agents/weekly-review.md`** — all `memory/*.md` / `timer_state.json` reads replaced with inline Supabase queries via `_supabase.py`
- **`agents/nightly-postmortem.md`** — `memory/habits.md` read replaced with `habits` + `habit_registry` query
- **`agents/study-timer.md`** — timer state upserted to `profile` table (key=`timer_state`, JSON); completed sessions inserted into `study_log`
- **`commands/stop-timer.md`** — frontmatter description and body updated to reference Supabase tables
- **`commands/log-habit.md`** — description updated; stale `memory/habits.md` reference removed
- **`CHANGELOG.md`** — entry added under `[Unreleased]`

No behavioral logic changed — purely a source-of-truth fix. All data has lived in Supabase since issue #14.

## Test plan
- [ ] `/log-habit` still routes through `log_habit.py` → `habits` table
- [ ] `/stop-timer` stops timer from `profile.timer_state` and writes to `study_log`
- [ ] Nightly postmortem push notification fires with correct habit count from Supabase
- [ ] Weekly review summary pulls habit/task/study counts from Supabase with no markdown reads
- [ ] Session briefing Accountability and Pending Tasks sections populated from `fetch_briefing_data.py` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)