### PR TITLE
feat: grouped task due notifications with per-task 24h dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (task due push notifications — issue #59)
+- **`scripts/check_task_due_alerts.py`** — replaces `check_daily_alerts.py` task alerting; queries active tasks with `due_date <= today`; sends one grouped ntfy.sh notification for overdue tasks and one for due-today tasks; per-task 24-hour deduplication via profile key `task_notif_cache` (JSON dict `{task_id: iso_timestamp}`); only fires when new tasks need notification
+- **`scripts/run-syncs.py`** — ALERTS list updated to invoke `check_task_due_alerts.py` instead of `check_daily_alerts.py`
+
 ### Changed (agent/rule Supabase cleanup — issue #97)
 - **`mr-bridge-rules.md`** — "Pending Tasks" briefing section now references Supabase `tasks` table via `fetch_briefing_data.py`; "Accountability" section references `habits` + `habit_registry` tables via same script; Recovery rules updated to query `recovery_metrics` table (order by date desc, limit 1) instead of `fitness_log.md`; Study Timer Rules updated to use `profile` table for timer state and `study_log` table for duration logging
 - **`agents/weekly-review.md`** — replaced all reads of `memory/habits.md`, `memory/todo.md`, `memory/fitness_log.md`, `memory/timer_state.json` with Supabase queries via `_supabase.py`; updated description and Rules section accordingly

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ mr-bridge-assistant/
 │   ├── sync-renpho.py                     # Renpho CSV → Supabase fitness_log (deprecated)
 │   ├── check_birthday_notif.py            # Birthday push alerts from Google Calendar
 │   ├── check_hrv_alert.py                 # HRV drop push alert (vs 7-day baseline)
-│   ├── check_daily_alerts.py              # Task due-date push alerts
+│   ├── check_task_due_alerts.py           # Task due-date push alerts (grouped, per-task 24h dedup)
 │   ├── check_weather_alert.py             # Severe weather push alerts (precip/thunder/heat/freeze/wind)
 │   ├── notify.sh                          # Push notifications: macOS (osascript) + Android/Windows (ntfy.sh)
 │   └── update-references.sh              # Pull latest best practices submodule

--- a/scripts/check_task_due_alerts.py
+++ b/scripts/check_task_due_alerts.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Task due-date push notifications with per-task deduplication.
+
+Queries tasks table for active tasks with due_date <= today. Sends one grouped
+ntfy.sh notification for overdue tasks and one for due-today tasks. Skips tasks
+notified within the last 24 hours — tracked per task ID in profile key
+'task_notif_cache' (JSON dict: {task_id: ISO timestamp}).
+
+Requires: supabase, python-dotenv
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+from _supabase import get_client
+
+NOTIFY_SCRIPT = ROOT / "scripts" / "notify.sh"
+CACHE_KEY = "task_notif_cache"
+DEDUP_HOURS = 24
+
+
+def get_profile_value(client, key: str) -> str | None:
+    rows = (
+        client.table("profile")
+        .select("value")
+        .eq("key", key)
+        .limit(1)
+        .execute()
+        .data
+    )
+    return rows[0]["value"] if rows else None
+
+
+def set_profile_value(client, key: str, value: str) -> None:
+    client.table("profile").upsert({"key": key, "value": value}, on_conflict="key").execute()
+
+
+def load_notif_cache(client) -> dict[str, str]:
+    """Return {task_id: iso_timestamp_last_notified} from profile."""
+    raw = get_profile_value(client, CACHE_KEY)
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+
+
+def save_notif_cache(client, cache: dict[str, str]) -> None:
+    set_profile_value(client, CACHE_KEY, json.dumps(cache))
+
+
+def needs_notification(task_id: str, cache: dict[str, str]) -> bool:
+    """Return True if the task hasn't been notified within the last 24 hours."""
+    last_str = cache.get(str(task_id))
+    if not last_str:
+        return True
+    try:
+        last = datetime.fromisoformat(last_str)
+        if last.tzinfo is None:
+            last = last.replace(tzinfo=timezone.utc)
+        age_hours = (datetime.now(timezone.utc) - last).total_seconds() / 3600
+        return age_hours >= DEDUP_HOURS
+    except ValueError:
+        return True
+
+
+def send_notify(title: str, message: str) -> None:
+    subprocess.run(
+        ["bash", str(NOTIFY_SCRIPT), "--title", title, "--message", message],
+        check=True,
+    )
+
+
+def main() -> None:
+    try:
+        client = get_client()
+    except Exception as e:
+        print(f"[check_task_due_alerts] Supabase connection error: {e}", file=sys.stderr)
+        return
+
+    today_str = date.today().isoformat()
+
+    # Query active tasks with a due date on or before today
+    try:
+        rows = (
+            client.table("tasks")
+            .select("id, title, due_date")
+            .eq("status", "active")
+            .not_("due_date", "is", None)
+            .lte("due_date", today_str)
+            .order("due_date", desc=False)
+            .execute()
+            .data
+        )
+    except Exception as e:
+        print(f"[check_task_due_alerts] tasks query error: {e}", file=sys.stderr)
+        return
+
+    if not rows:
+        return
+
+    cache = load_notif_cache(client)
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    # Partition tasks that need notification into overdue vs due-today buckets.
+    # Track task_ids so we can update the cache only for successfully-fired groups.
+    overdue_labels: list[str] = []
+    overdue_ids: list[str] = []
+    due_today_labels: list[str] = []
+    due_today_ids: list[str] = []
+
+    for task in rows:
+        task_id = str(task.get("id", ""))
+        title = task.get("title", "(unnamed)")
+        due = task.get("due_date", "")
+
+        if not needs_notification(task_id, cache):
+            continue
+
+        if due == today_str:
+            due_today_labels.append(title)
+            due_today_ids.append(task_id)
+        else:
+            overdue_labels.append(f"{title} (due {due})")
+            overdue_ids.append(task_id)
+
+    if not overdue_ids and not due_today_ids:
+        return
+
+    fired = 0
+
+    if overdue_labels:
+        try:
+            send_notify(
+                f"Overdue Tasks ({len(overdue_labels)})",
+                "\n".join(overdue_labels),
+            )
+            for tid in overdue_ids:
+                cache[tid] = now_iso
+            fired += 1
+        except Exception as e:
+            print(f"[check_task_due_alerts] notify error (overdue): {e}", file=sys.stderr)
+
+    if due_today_labels:
+        try:
+            send_notify(
+                f"Due Today ({len(due_today_labels)})",
+                "\n".join(due_today_labels),
+            )
+            for tid in due_today_ids:
+                cache[tid] = now_iso
+            fired += 1
+        except Exception as e:
+            print(f"[check_task_due_alerts] notify error (due today): {e}", file=sys.stderr)
+
+    if fired:
+        save_notif_cache(client, cache)
+        print(
+            f"[check_task_due_alerts] Fired {fired} notification(s) "
+            f"({len(overdue_labels)} overdue, {len(due_today_labels)} due today)."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run-syncs.py
+++ b/scripts/run-syncs.py
@@ -30,7 +30,7 @@ SYNCS: list[tuple[str, list[str]]] = [
 # Alert scripts run after syncs — order matters (HRV needs fresh Oura data)
 ALERTS: list[list[str]] = [
     ["scripts/check_hrv_alert.py"],
-    ["scripts/check_daily_alerts.py"],
+    ["scripts/check_task_due_alerts.py"],
     ["scripts/check_weather_alert.py"],
 ]
 


### PR DESCRIPTION
## Summary

- Adds `scripts/check_task_due_alerts.py` — replaces the per-task one-notification-per-task approach in `check_daily_alerts.py` with two grouped notifications (one for overdue, one for due today)
- Per-task 24-hour deduplication via `profile` key `task_notif_cache` (JSON dict `{task_id: iso_timestamp}`); tasks are only re-notified after 24 hours, regardless of how many times the script runs
- `run-syncs.py` ALERTS list updated to call `check_task_due_alerts.py` instead of `check_daily_alerts.py`

## Behavior

- Query: `tasks` where `status = 'active'` and `due_date <= today`
- Overdue tasks (due_date < today): one notification listing all titles + due dates
- Due-today tasks: one notification listing all titles
- No notification fired if no matching tasks pass the dedup filter
- Cache stored as JSON in `profile` table under key `task_notif_cache`; only updated for successfully-sent notification groups

## Test plan

- [ ] Run `python3 scripts/check_task_due_alerts.py` with active tasks due today and overdue — confirm two ntfy.sh notifications fire
- [ ] Run again immediately — confirm no notifications fire (dedup cache hit)
- [ ] Manually set a cache entry's timestamp to >24 hours ago in Supabase — confirm notification re-fires on next run
- [ ] Run with no due/overdue tasks — confirm no notification and no cache write

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)