### PR TITLE
feat: daily macro summary + nutrition goals + photo context prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (daily macro summary — issue #61)
+- **`MacroSummaryCard`** (`web/src/components/meals/MacroSummaryCard.tsx`) — server component rendered at the top of `/meals`; queries today's `meal_log` rows (only those with a non-null `calories` value) and profile goal keys; shows per-macro progress bars (calories, protein, carbs, fat) with green/amber/red color coding (green < 85% consumed, amber 85–100%, red > 100%); displays "X left" or "+X over" beside each bar
+- **Nutrition Goals section in Settings** — four new fields added to `ProfileForm` in a dedicated "Nutrition Goals" card: `calorie_goal` (kcal/day), `protein_goal`, `carbs_goal`, `fat_goal` (g/day); stored as profile key-value pairs; inline save/delete matches existing field pattern
+- **No-goals prompt** — when no goal keys exist in profile, the summary card shows a link to Settings rather than an empty state
+
+### Added (photo context prompt — issue #61)
+- **Context field in FoodPhotoAnalyzer** — optional free-text textarea shown before the upload button; content is sent as `prompt` in the FormData and injected into Claude's analysis prompt as "User context"; helps improve macro accuracy when portion size or ingredients are known (e.g. "homemade bowl, ~200g chicken")
+
 ### Added (weekly review page — issue #58)
 - **`/weekly` page** — server-rendered weekly review at `web/src/app/(protected)/weekly/page.tsx`; fetches the last 7 days from Supabase in a single `Promise.all`
 - **Habit completion** — per-habit score (e.g. `5/7`) with current streak and a 7-pill strip showing hit/miss for each day; color-coded green ≥ 6, yellow ≥ 4, red < 4

--- a/README.md
+++ b/README.md
@@ -314,8 +314,8 @@ A Next.js web app deployed on Vercel. Built against a full design system (DM San
 - **Fitness** — Dual-axis body comp chart (weight + BF%); weekly workout frequency bar chart; active cal area chart; sortable/paginated workout history table
 - **Journal** — Two-tab editor: *Reflect* (all 5 prompts visible, progress dots, 1.5s auto-save) and *Free Write* (open textarea with word count); collapsible history accordion
 - **Weekly Review** — Last 7 days at a glance: habit score + 7-day pill strip per habit with streak; tasks completed this week, still-active tasks with overdue callout; workout count/duration/calories; average readiness/sleep/HRV with per-day readiness column; body composition delta vs 7 days ago; journal entry count
-- **Meals** — Recent meal log from Supabase (stub; full logging via Chat)
-- **Settings** — Profile key-values from Supabase `profile` table
+- **Meals** — Daily macro summary card (calories/protein/carbs/fat vs goals, progress bars with color coding); food photo analyzer with optional context prompt (Claude vision → macro estimation → log); 7-day meal history from Supabase
+- **Settings** — Profile key-values from Supabase `profile` table; Nutrition Goals section (calorie, protein, carbs, fat daily targets)
 
 **Local development:**
 ```bash

--- a/web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx
+++ b/web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx
@@ -39,6 +39,7 @@ export default function FoodPhotoAnalyzer() {
   const [review, setReview] = useState<ReviewState | null>(null);
   const [reestimating, setReestimating] = useState(false);
   const [macrosExpanded, setMacrosExpanded] = useState(false);
+  const [userPrompt, setUserPrompt] = useState<string>("");
 
   function reset() {
     setPhase("idle");
@@ -50,6 +51,7 @@ export default function FoodPhotoAnalyzer() {
     setErrorMsg("");
     setReestimating(false);
     setMacrosExpanded(false);
+    setUserPrompt("");
     if (fileInputRef.current) fileInputRef.current.value = "";
   }
 
@@ -63,6 +65,7 @@ export default function FoodPhotoAnalyzer() {
 
     const formData = new FormData();
     formData.append("image", file);
+    if (userPrompt.trim()) formData.append("prompt", userPrompt.trim());
 
     try {
       const res = await fetch("/api/meals/analyze-photo", {
@@ -154,6 +157,24 @@ export default function FoodPhotoAnalyzer() {
       {/* IDLE */}
       {phase === "idle" && (
         <div className="flex flex-col gap-3">
+          <div>
+            <label style={{ fontSize: 12, color: "var(--color-text-muted)", display: "block", marginBottom: 6 }}>
+              Context <span style={{ color: "var(--color-text-faint)" }}>(optional)</span>
+            </label>
+            <textarea
+              value={userPrompt}
+              onChange={(e) => setUserPrompt(e.target.value)}
+              rows={2}
+              placeholder="e.g. This is a homemade bowl with ~200g chicken breast and half-cup rice"
+              autoComplete="off"
+              autoCorrect="off"
+              style={{
+                ...inputStyle,
+                resize: "none",
+                lineHeight: 1.6,
+              }}
+            />
+          </div>
           <button
             onClick={() => fileInputRef.current?.click()}
             className="flex items-center justify-center gap-2 rounded-xl font-medium transition-opacity active:opacity-70"

--- a/web/src/app/(protected)/meals/page.tsx
+++ b/web/src/app/(protected)/meals/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { MessageSquare } from "lucide-react";
 import { daysAgoString } from "@/lib/timezone";
 import FoodPhotoAnalyzer from "./FoodPhotoAnalyzer";
+import MacroSummaryCard from "@/components/meals/MacroSummaryCard";
 
 interface MealRow {
   id: string;
@@ -60,6 +61,9 @@ export default async function MealsPage() {
           Last 7 days
         </p>
       </div>
+
+      {/* Macro summary */}
+      <MacroSummaryCard />
 
       {/* Photo analyzer */}
       <FoodPhotoAnalyzer />

--- a/web/src/app/api/meals/analyze-photo/route.ts
+++ b/web/src/app/api/meals/analyze-photo/route.ts
@@ -41,6 +41,9 @@ export async function POST(req: Request) {
     return Response.json({ error: "No image file provided" }, { status: 400 });
   }
 
+  const userPromptRaw = formData.get("prompt");
+  const userPrompt = typeof userPromptRaw === "string" ? userPromptRaw.trim() : "";
+
   // Validate file type
   if (!imageFile.type.startsWith("image/")) {
     return Response.json({ error: "File must be an image" }, { status: 400 });
@@ -73,12 +76,13 @@ export async function POST(req: Request) {
             {
               type: "text",
               text: `Analyze this food photo and estimate its nutritional content.
-
+${userPrompt ? `\nUser context: ${userPrompt}\n` : ""}
 Instructions:
 - Identify the dish name and list all visible ingredients with estimated quantities
 - Estimate macros and micros for the total visible portion (what would be eaten)
 - Use conservative estimates — do not inflate
 - If multiple items are present, sum the totals
+- If the user provided context above, use it to improve accuracy (e.g. specific ingredients, portion size, cooking method)
 - Set confidence to "high" only if the food is clearly identifiable and portion is estimable
 - Set confidence to "low" if the image is unclear, the food is ambiguous, or portion size is very uncertain
 - Include any key assumptions in notes (e.g. "sauce not included", "estimated half-plate portion")

--- a/web/src/components/meals/MacroSummaryCard.tsx
+++ b/web/src/components/meals/MacroSummaryCard.tsx
@@ -113,7 +113,7 @@ export default async function MacroSummaryCard() {
   const hasData = rows.length > 0;
 
   const totals = rows.reduce(
-    (acc, row) => ({
+    (acc: { calories: number; protein_g: number; carbs_g: number; fat_g: number }, row) => ({
       calories: acc.calories + (row.calories ?? 0),
       protein_g: acc.protein_g + (row.protein_g ?? 0),
       carbs_g: acc.carbs_g + (row.carbs_g ?? 0),

--- a/web/src/components/meals/MacroSummaryCard.tsx
+++ b/web/src/components/meals/MacroSummaryCard.tsx
@@ -1,0 +1,168 @@
+import { createClient } from "@/lib/supabase/server";
+import { todayString } from "@/lib/timezone";
+import Link from "next/link";
+
+interface MacroRow {
+  calories: number | null;
+  protein_g: number | null;
+  carbs_g: number | null;
+  fat_g: number | null;
+}
+
+interface Macro {
+  key: string;
+  label: string;
+  unit: string;
+  consumed: number;
+  goal: number | null;
+}
+
+function progressColor(pct: number): string {
+  if (pct > 100) return "var(--color-danger)";
+  if (pct >= 85) return "var(--color-warning)";
+  return "var(--color-positive)";
+}
+
+function ProgressBar({ pct, color }: { pct: number; color: string }) {
+  const clamped = Math.min(pct, 100);
+  return (
+    <div
+      className="rounded-full overflow-hidden"
+      style={{ height: 4, background: "var(--color-border)" }}
+    >
+      <div
+        className="h-full rounded-full transition-all duration-300"
+        style={{ width: `${clamped}%`, background: color }}
+      />
+    </div>
+  );
+}
+
+function MacroRow({ macro }: { macro: Macro }) {
+  if (macro.goal === null) return null;
+  const pct = macro.goal > 0 ? (macro.consumed / macro.goal) * 100 : 0;
+  const color = progressColor(pct);
+  const remaining = macro.goal - macro.consumed;
+  const isOver = remaining < 0;
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-baseline justify-between">
+        <span style={{ fontSize: 13, fontWeight: 500, color: "var(--color-text)" }}>
+          {macro.label}
+        </span>
+        <div className="flex items-baseline gap-1.5">
+          <span style={{ fontSize: 13, color: "var(--color-text)" }}>
+            {macro.consumed}
+            <span style={{ color: "var(--color-text-muted)", fontSize: 11 }}>
+              {macro.unit}
+            </span>
+          </span>
+          <span style={{ fontSize: 11, color: "var(--color-text-faint)" }}>/</span>
+          <span style={{ fontSize: 11, color: "var(--color-text-muted)" }}>
+            {macro.goal}
+            {macro.unit}
+          </span>
+          <span
+            style={{
+              fontSize: 11,
+              fontWeight: 500,
+              color,
+              minWidth: 52,
+              textAlign: "right",
+            }}
+          >
+            {isOver
+              ? `+${Math.abs(remaining)}${macro.unit} over`
+              : `${remaining}${macro.unit} left`}
+          </span>
+        </div>
+      </div>
+      <ProgressBar pct={pct} color={color} />
+    </div>
+  );
+}
+
+export default async function MacroSummaryCard() {
+  const supabase = await createClient();
+  const today = todayString();
+
+  const [{ data: meals }, { data: profile }] = await Promise.all([
+    supabase
+      .from("meal_log")
+      .select("calories, protein_g, carbs_g, fat_g")
+      .eq("date", today)
+      .not("calories", "is", null),
+    supabase.from("profile").select("key, value"),
+  ]);
+
+  const profileMap: Record<string, string> = {};
+  for (const row of profile ?? []) {
+    profileMap[row.key] = row.value;
+  }
+
+  const calorieGoal = profileMap["calorie_goal"] ? parseInt(profileMap["calorie_goal"], 10) : null;
+  const proteinGoal = profileMap["protein_goal"] ? parseInt(profileMap["protein_goal"], 10) : null;
+  const carbsGoal = profileMap["carbs_goal"] ? parseInt(profileMap["carbs_goal"], 10) : null;
+  const fatGoal = profileMap["fat_goal"] ? parseInt(profileMap["fat_goal"], 10) : null;
+
+  const hasAnyGoal =
+    calorieGoal !== null || proteinGoal !== null || carbsGoal !== null || fatGoal !== null;
+
+  const rows = (meals ?? []) as MacroRow[];
+  const hasData = rows.length > 0;
+
+  const totals = rows.reduce(
+    (acc, row) => ({
+      calories: acc.calories + (row.calories ?? 0),
+      protein_g: acc.protein_g + (row.protein_g ?? 0),
+      carbs_g: acc.carbs_g + (row.carbs_g ?? 0),
+      fat_g: acc.fat_g + (row.fat_g ?? 0),
+    }),
+    { calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0 }
+  );
+
+  const macros: Macro[] = [
+    { key: "calories", label: "Calories", unit: " kcal", consumed: totals.calories, goal: calorieGoal },
+    { key: "protein", label: "Protein", unit: "g", consumed: Math.round(totals.protein_g), goal: proteinGoal },
+    { key: "carbs", label: "Carbs", unit: "g", consumed: Math.round(totals.carbs_g), goal: carbsGoal },
+    { key: "fat", label: "Fat", unit: "g", consumed: Math.round(totals.fat_g), goal: fatGoal },
+  ];
+
+  return (
+    <div
+      className="rounded-xl p-5"
+      style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+    >
+      <p
+        className="text-xs uppercase tracking-widest mb-4"
+        style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}
+      >
+        Today&apos;s Macros
+      </p>
+
+      {!hasAnyGoal ? (
+        <p style={{ fontSize: 14, color: "var(--color-text-muted)" }}>
+          No nutrition goals set.{" "}
+          <Link
+            href="/settings"
+            style={{ color: "var(--color-primary)", textDecoration: "underline", textUnderlineOffset: 2 }}
+          >
+            Configure goals in Settings
+          </Link>{" "}
+          to track progress here.
+        </p>
+      ) : !hasData ? (
+        <p style={{ fontSize: 14, color: "var(--color-text-faint)" }}>
+          No macro data yet today
+        </p>
+      ) : (
+        <div className="space-y-4">
+          {macros.map((m) =>
+            m.goal !== null ? <MacroRow key={m.key} macro={m} /> : null
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/settings/profile-form.tsx
+++ b/web/src/components/settings/profile-form.tsx
@@ -43,6 +43,33 @@ const EDITABLE_FIELDS: Field[] = [
   },
 ];
 
+const NUTRITION_GOAL_FIELDS: Field[] = [
+  {
+    key: "calorie_goal",
+    label: "Daily Calorie Goal",
+    placeholder: "e.g. 2000",
+    hint: "kcal per day",
+  },
+  {
+    key: "protein_goal",
+    label: "Protein Goal",
+    placeholder: "e.g. 150",
+    hint: "grams per day",
+  },
+  {
+    key: "carbs_goal",
+    label: "Carbs Goal",
+    placeholder: "e.g. 200",
+    hint: "grams per day",
+  },
+  {
+    key: "fat_goal",
+    label: "Fat Goal",
+    placeholder: "e.g. 65",
+    hint: "grams per day",
+  },
+];
+
 function FieldRow({
   field,
   initialValue,
@@ -129,24 +156,46 @@ function FieldRow({
 
 export function ProfileForm({ values, updateAction, deleteAction }: Props) {
   return (
-    <div
-      className="rounded-xl overflow-hidden"
-      style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
-    >
-      <div className="px-5 py-4" style={{ borderBottom: "1px solid var(--color-border)" }}>
-        <p className="text-xs uppercase tracking-widest" style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}>
-          Profile
-        </p>
+    <div className="space-y-6">
+      <div
+        className="rounded-xl overflow-hidden"
+        style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+      >
+        <div className="px-5 py-4" style={{ borderBottom: "1px solid var(--color-border)" }}>
+          <p className="text-xs uppercase tracking-widest" style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}>
+            Profile
+          </p>
+        </div>
+        {EDITABLE_FIELDS.map((field) => (
+          <FieldRow
+            key={field.key}
+            field={field}
+            initialValue={values[field.key] ?? ""}
+            updateAction={updateAction}
+            deleteAction={deleteAction}
+          />
+        ))}
       </div>
-      {EDITABLE_FIELDS.map((field) => (
-        <FieldRow
-          key={field.key}
-          field={field}
-          initialValue={values[field.key] ?? ""}
-          updateAction={updateAction}
-          deleteAction={deleteAction}
-        />
-      ))}
+
+      <div
+        className="rounded-xl overflow-hidden"
+        style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+      >
+        <div className="px-5 py-4" style={{ borderBottom: "1px solid var(--color-border)" }}>
+          <p className="text-xs uppercase tracking-widest" style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}>
+            Nutrition Goals
+          </p>
+        </div>
+        {NUTRITION_GOAL_FIELDS.map((field) => (
+          <FieldRow
+            key={field.key}
+            field={field}
+            initialValue={values[field.key] ?? ""}
+            updateAction={updateAction}
+            deleteAction={deleteAction}
+          />
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #61.

- **`MacroSummaryCard`** — new server component at the top of `/meals`; sums today's `meal_log` rows (where `calories` is not null) and renders per-macro progress bars for calories, protein, carbs, and fat against profile goal targets. Color coding: green < 85% consumed, amber 85–100%, red > 100%. Shows "X left" or "+X over" inline. Falls back to a Settings link when no goals are set, or "No macro data yet today" when meals have no nutrition columns filled.
- **Nutrition Goals in Settings** — new "Nutrition Goals" card in `ProfileForm` with four inline-save fields: `calorie_goal`, `protein_goal`, `carbs_goal`, `fat_goal` stored as profile key-value pairs. Same save/delete pattern as the existing Profile fields.
- **Photo context prompt** — optional free-text textarea added to `FoodPhotoAnalyzer` (idle state, above the upload button). Content is sent as `prompt` in FormData and injected into the Claude analysis prompt as user context to improve macro accuracy when the user knows portion sizes or specific ingredients.

## Test plan

- [ ] Set nutrition goals in Settings → verify values persist and appear on next load
- [ ] Log a meal via photo or chat with macro data → verify MacroSummaryCard totals update on page refresh
- [ ] Verify progress bar color changes at 85% (amber) and >100% (red)
- [ ] Leave goals unset → confirm Settings link prompt renders
- [ ] Log meals with no `calories` value → confirm "No macro data yet today" state
- [ ] Upload photo with context prompt → verify Claude references the hint in its analysis notes/confidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)