### PR TITLE
feat: slash command autocomplete for chat input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (slash command autocomplete — issue #63)
+- **`SlashCommandMenu`** (`web/src/components/chat/slash-command-menu.tsx`) — floating suggestion list that renders above the chat input; shows up to 6 commands, scrollable; each row displays the command usage (monospace, primary color) and a short description; keyboard-navigable (↑/↓ arrows, Enter/Tab to select, Escape to dismiss)
+- **Autocomplete trigger** — activates when the user types `/` at the start of the input or after a space; filters the list by prefix match as more characters are typed (e.g. `/w` shows `/weekly`, `/workout`, `/weight`)
+- **Eight built-in commands** surfaced in the menu: `/weekly`, `/briefing`, `/workout [type]`, `/habit [name]`, `/task [title]`, `/weight [lbs]`, `/meal [description]`, `/journal`
+- **Selection behavior** — selecting a command replaces the current slash token with `/command ` (trailing space, no bracket placeholders) and returns focus to the input for argument entry; mouse hover updates the active row; `onMouseDown` prevents input blur so click completes correctly
+- **Mobile-safe** — menu is positioned `bottom: 100%` relative to the input wrapper, so it naturally sits above the virtual keyboard when it is open
+
 ### Added (daily macro summary — issue #61)
 - **`MacroSummaryCard`** (`web/src/components/meals/MacroSummaryCard.tsx`) — server component rendered at the top of `/meals`; queries today's `meal_log` rows (only those with a non-null `calories` value) and profile goal keys; shows per-macro progress bars (calories, protein, carbs, fat) with green/amber/red color coding (green < 85% consumed, amber 85–100%, red > 100%); displays "X left" or "+X over" beside each bar
 - **Nutrition Goals section in Settings** — four new fields added to `ProfileForm` in a dedicated "Nutrition Goals" card: `calorie_goal` (kcal/day), `protein_goal`, `carbs_goal`, `fat_goal` (g/day); stored as profile key-value pairs; inline save/delete matches existing field pattern

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ A Next.js web app deployed on Vercel. Built against a full design system (DM San
   - *Sleep* tabs: Sleep Stages · HRV · Resting HR · SpO₂
   - Window selector (7d/14d/30d/90d/1yr) and single Sync button (triggers Oura, Fitbit, Google Fit on demand) in the header
   - Habits Today + Active Tasks side-by-side below (fixed height, inner scroll); Schedule Today + Important Emails below that; Upcoming Birthday widget
-- **Chat** — Streams Claude Sonnet responses with markdown rendering; inline tool status chips (spinner → ✓); "New chat" button; 13 tools: tasks, habits, fitness, profile, Gmail, Calendar (read + write), recipes, meals
+- **Chat** — Streams Claude Sonnet responses with markdown rendering; inline tool status chips (spinner → ✓); "New chat" button; slash command autocomplete (type `/` to surface 8 built-in commands, filter by prefix, keyboard-navigable); 13 tools: tasks, habits, fitness, profile, Gmail, Calendar (read + write), recipes, meals
 - **Tasks** — Inline title editing, priority dot selector, relative due dates, completed tasks accordion
 - **Habits** — Daily check-in with indigo toggles + streak counts; 90-day heatmap; streak bar chart; weekly radial completion chart
 - **Fitness** — Dual-axis body comp chart (weight + BF%); weekly workout frequency bar chart; active cal area chart; sortable/paginated workout history table

--- a/web/src/components/chat/chat-interface.tsx
+++ b/web/src/components/chat/chat-interface.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useChat } from "ai/react";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Send } from "lucide-react";
 import MessageBubble from "./message-bubble";
 import ToolStatusBar from "./tool-status-bar";
+import SlashCommandMenu, { SLASH_COMMANDS, type SlashCommand } from "./slash-command-menu";
 import type { Message } from "ai";
 
 interface Props {
@@ -13,16 +14,104 @@ interface Props {
   onMessageSent?: () => void;
 }
 
+// Returns the slash token the cursor is currently inside, or null.
+// A valid token is "/" at position 0 or preceded by whitespace, with no
+// whitespace between the slash and the cursor.
+function getSlashToken(value: string, cursorPos: number): { start: number; query: string } | null {
+  const before = value.slice(0, cursorPos);
+  const match = before.match(/(?:^|(?<=\s))(\/\S*)$/);
+  if (!match) return null;
+  const start = before.lastIndexOf(match[1]);
+  return { start, query: match[1].slice(1).toLowerCase() };
+}
+
 export default function ChatInterface({ sessionId, initialMessages, onMessageSent }: Props) {
   const bottomRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  const { messages, input, handleInputChange, handleSubmit, isLoading, error, reload } = useChat({
+  const { messages, input, handleInputChange, handleSubmit, isLoading, error, reload, setInput } = useChat({
     api: "/api/chat",
     body: { sessionId },
     initialMessages,
     onFinish: onMessageSent,
   });
 
+  // ── Slash-command menu state ──────────────────────────────────────────
+  const [menuCommands, setMenuCommands] = useState<SlashCommand[]>([]);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const updateMenu = useCallback((value: string, cursorPos: number) => {
+    const token = getSlashToken(value, cursorPos);
+    if (!token) {
+      setMenuCommands([]);
+      return;
+    }
+    const filtered = SLASH_COMMANDS.filter((c) =>
+      c.name.startsWith(token.query)
+    );
+    setMenuCommands(filtered);
+    setActiveIndex(0);
+  }, []);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      handleInputChange(e);
+      updateMenu(e.target.value, e.target.selectionStart ?? e.target.value.length);
+    },
+    [handleInputChange, updateMenu]
+  );
+
+  const applyCommand = useCallback(
+    (cmd: SlashCommand) => {
+      const el = inputRef.current;
+      const cursorPos = el?.selectionStart ?? input.length;
+      const token = getSlashToken(input, cursorPos);
+      if (!token) return;
+      // Insert "/name " (no placeholder brackets) so user can type the arg
+      const insert = `/${cmd.name} `;
+      const newValue = input.slice(0, token.start) + insert + input.slice(cursorPos);
+      setInput(newValue);
+      setMenuCommands([]);
+      // Move cursor to end of inserted text
+      const newCursor = token.start + insert.length;
+      requestAnimationFrame(() => {
+        el?.focus();
+        el?.setSelectionRange(newCursor, newCursor);
+      });
+    },
+    [input, setInput]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (menuCommands.length === 0) return;
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setActiveIndex((i) => (i + 1) % menuCommands.length);
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setActiveIndex((i) => (i - 1 + menuCommands.length) % menuCommands.length);
+          break;
+        case "Enter":
+          e.preventDefault();
+          applyCommand(menuCommands[activeIndex]);
+          break;
+        case "Escape":
+          e.preventDefault();
+          setMenuCommands([]);
+          break;
+        case "Tab":
+          e.preventDefault();
+          applyCommand(menuCommands[activeIndex]);
+          break;
+      }
+    },
+    [menuCommands, activeIndex, applyCommand]
+  );
+
+  // ── Scroll to bottom on new messages ─────────────────────────────────
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
@@ -118,26 +207,43 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
         className="flex gap-2 py-3"
         style={{ borderTop: "1px solid var(--color-border)" }}
       >
-        <input
-          value={input}
-          onChange={handleInputChange}
-          placeholder="Ask Mr. Bridge..."
-          disabled={isLoading}
-          className="flex-1 rounded-xl px-4 py-2.5 text-sm transition-colors duration-150 focus:outline-none"
-          style={{
-            background: "var(--color-surface)",
-            border: "1px solid var(--color-border)",
-            color: "var(--color-text)",
-          }}
-          onFocus={(e) => {
-            e.currentTarget.style.borderColor = "var(--color-primary)";
-            e.currentTarget.style.boxShadow = "0 0 0 3px var(--color-primary-dim)";
-          }}
-          onBlur={(e) => {
-            e.currentTarget.style.borderColor = "var(--color-border)";
-            e.currentTarget.style.boxShadow = "none";
-          }}
-        />
+        {/* Wrapper provides anchor for the floating menu */}
+        <div className="relative flex-1">
+          {menuCommands.length > 0 && (
+            <SlashCommandMenu
+              commands={menuCommands}
+              activeIndex={activeIndex}
+              onSelect={applyCommand}
+              onHover={setActiveIndex}
+            />
+          )}
+          <input
+            ref={inputRef}
+            value={input}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask Mr. Bridge..."
+            disabled={isLoading}
+            autoComplete="off"
+            aria-autocomplete="list"
+            aria-expanded={menuCommands.length > 0}
+            className="w-full rounded-xl px-4 py-2.5 text-sm transition-colors duration-150 focus:outline-none"
+            style={{
+              background: "var(--color-surface)",
+              border: "1px solid var(--color-border)",
+              color: "var(--color-text)",
+            }}
+            onFocus={(e) => {
+              e.currentTarget.style.borderColor = "var(--color-primary)";
+              e.currentTarget.style.boxShadow = "0 0 0 3px var(--color-primary-dim)";
+            }}
+            onBlur={(e) => {
+              e.currentTarget.style.borderColor = "var(--color-border)";
+              e.currentTarget.style.boxShadow = "none";
+              setMenuCommands([]);
+            }}
+          />
+        </div>
         <button
           type="submit"
           disabled={isLoading || !input.trim()}

--- a/web/src/components/chat/slash-command-menu.tsx
+++ b/web/src/components/chat/slash-command-menu.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export interface SlashCommand {
+  name: string;
+  description: string;
+  usage: string; // display label, e.g. "/workout [type]"
+}
+
+export const SLASH_COMMANDS: SlashCommand[] = [
+  { name: "weekly",   description: "Weekly review summary",                                         usage: "/weekly" },
+  { name: "briefing", description: "Today's full briefing (weather, schedule, tasks, habits, recovery)", usage: "/briefing" },
+  { name: "workout",  description: "Log a workout",                                                 usage: "/workout [type]" },
+  { name: "habit",    description: "Mark a habit as done today",                                    usage: "/habit [name]" },
+  { name: "task",     description: "Add a new task",                                                usage: "/task [title]" },
+  { name: "weight",   description: "Log a weigh-in",                                               usage: "/weight [lbs]" },
+  { name: "meal",     description: "Log a meal",                                                    usage: "/meal [description]" },
+  { name: "journal",  description: "Open the journal prompt",                                       usage: "/journal" },
+];
+
+interface Props {
+  commands: SlashCommand[];
+  activeIndex: number;
+  onSelect: (command: SlashCommand) => void;
+  onHover: (index: number) => void;
+}
+
+export default function SlashCommandMenu({ commands, activeIndex, onSelect, onHover }: Props) {
+  const activeRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex]);
+
+  if (commands.length === 0) return null;
+
+  return (
+    <div
+      role="listbox"
+      aria-label="Slash commands"
+      className="absolute bottom-full left-0 right-0 mb-1.5 rounded-xl overflow-hidden"
+      style={{
+        background: "var(--color-surface-raised)",
+        border: "1px solid var(--color-border)",
+        boxShadow: "var(--shadow-lg)",
+        maxHeight: "calc(6 * 2.75rem)",
+        overflowY: "auto",
+        zIndex: 50,
+      }}
+    >
+      {commands.map((cmd, i) => (
+        <button
+          key={cmd.name}
+          ref={i === activeIndex ? activeRef : undefined}
+          role="option"
+          aria-selected={i === activeIndex}
+          type="button"
+          className="w-full text-left px-4 py-2.5 flex items-baseline gap-3 transition-colors duration-100"
+          style={{
+            background: i === activeIndex ? "var(--color-primary-dim)" : "transparent",
+            borderLeft: `2px solid ${i === activeIndex ? "var(--color-primary)" : "transparent"}`,
+          }}
+          onMouseEnter={() => onHover(i)}
+          onMouseDown={(e) => {
+            // prevent input blur before click fires
+            e.preventDefault();
+          }}
+          onClick={() => onSelect(cmd)}
+        >
+          <span
+            style={{
+              fontSize: 13,
+              fontWeight: 500,
+              color: "var(--color-primary)",
+              fontFamily: "ui-monospace, monospace",
+              flexShrink: 0,
+            }}
+          >
+            {cmd.usage}
+          </span>
+          <span style={{ fontSize: 12, color: "var(--color-text-muted)" }}>
+            {cmd.description}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `SlashCommandMenu` component — floating list above the chat input, max 6 rows visible, scrollable
- Trigger: typing `/` at the start of input or after a space; filters by prefix as more characters are typed (e.g. `/w` → `/weekly`, `/workout`, `/weight`)
- 8 built-in commands: `/weekly`, `/briefing`, `/workout [type]`, `/habit [name]`, `/task [title]`, `/weight [lbs]`, `/meal [description]`, `/journal`
- Keyboard nav: ↑/↓ arrows to move, Enter or Tab to select, Escape to dismiss; mouse hover updates active row
- Selection replaces the slash token with `/command ` (trailing space, no placeholder brackets) and returns focus to input
- `onMouseDown` prevents input blur so menu click completes correctly
- Menu positioned `bottom: 100%` relative to the input wrapper — naturally above the virtual keyboard on mobile
- Uses existing CSS custom properties (`--color-surface-raised`, `--color-border`, `--color-primary`, etc.)

## Test plan

- [ ] Type `/` — all 8 commands appear
- [ ] Type `/w` — list filters to `/weekly`, `/workout`, `/weight`
- [ ] Arrow keys navigate the active (highlighted) row
- [ ] Enter/Tab fills in the command and places cursor after it
- [ ] Escape closes the menu without changing input
- [ ] Click a menu item fills it in
- [ ] Type `/journal` fully — menu dismisses once no commands match the full name (only `/journal` left, then disappears after extra chars)
- [ ] Mid-input: `"remind me /brief"` — menu appears for `/brief`
- [ ] Mobile: menu appears above keyboard

Closes #63

🤖 Generated with [Claude Code](https://claude.ai/claude-code)