### PR TITLE
feat: ntfy.sh notifications link to web app when tapped (#75)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,8 @@ GOOGLE_FIT_REFRESH_TOKEN=<obtained-via-python3-scripts/sync-googlefit.py---setup
 # ── Notifications (ntfy.sh) ───────────────────────────────────────────────────
 # See docs/notifications-setup.md — pick any unique topic string
 NTFY_TOPIC=mr-bridge-yourname-1234
+# Base URL of your deployed web app — tapping a notification opens this URL + the relevant path
+APP_URL=https://your-app.vercel.app
 
 # ── Voice interface (Jarvis) — optional ──────────────────────────────────────
 ANTHROPIC_API_KEY=<your-anthropic-api-key>

--- a/.github/workflows/weekly-review-nudge.yml
+++ b/.github/workflows/weekly-review-nudge.yml
@@ -10,8 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send weekly review notification via ntfy.sh
+        env:
+          NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
+          APP_URL: ${{ secrets.APP_URL }}
         run: |
-          curl -s -X POST "https://ntfy.sh/${{ secrets.NTFY_TOPIC }}" \
+          CURL_ARGS=(-s -X POST "https://ntfy.sh/$NTFY_TOPIC" \
             -H "Title: Mr. Bridge — Weekly Review" \
-            -H "Priority: high" \
-            -d "Time for your weekly review. Open Mr. Bridge and run /weekly-review."
+            -H "Priority: high")
+          if [[ -n "$APP_URL" ]]; then
+            CURL_ARGS+=(-H "Click: ${APP_URL}/weekly")
+          fi
+          curl "${CURL_ARGS[@]}" -d "Time for your weekly review. Open Mr. Bridge and run /weekly-review."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (ntfy.sh click-through URLs — issue #75)
+- **`scripts/notify.sh`** — new `--click-url <url>` argument; when provided, adds an `X-Click` header to the ntfy.sh curl call so tapping the notification opens the web app directly
+- **`scripts/check_hrv_alert.py`** — passes `--click-url ${APP_URL}/dashboard` to notify.sh when `APP_URL` is set
+- **`scripts/check_weather_alert.py`** — passes `--click-url ${APP_URL}/dashboard`
+- **`scripts/check_birthday_notif.py`** — passes `--click-url ${APP_URL}/dashboard`
+- **`scripts/check_daily_alerts.py`** — passes `--click-url ${APP_URL}/tasks`
+- **`scripts/check_task_due_alerts.py`** — passes `--click-url ${APP_URL}/tasks`
+- **`.github/workflows/weekly-review-nudge.yml`** — adds `Click: ${APP_URL}/weekly` header when `APP_URL` GitHub Actions secret is set
+- **`.env.example`** — added `APP_URL=https://your-app.vercel.app`; click URLs are skipped gracefully if the variable is absent
+
 ### Added (fitness goal progress charts — issue #66)
 - **Fitness Goals section in Settings** — four new fields added to `ProfileForm` in a dedicated "Fitness Goals" card: `weekly_workout_goal` (sessions/week), `weekly_active_cal_goal` (kcal/week), `weight_goal_lbs` (target lbs), `body_fat_goal_pct` (target %); stored as profile key-value pairs; inline save/delete matches existing field pattern
 - **Suggested Nutrition card** — appears in the "Nutrition Goals" section when both `weight_goal_lbs` and `body_fat_goal_pct` are set; computes macros from fitness goals using: 1 g protein/lb lean mass, 0.4 g fat/lb goal weight, 15× bodyweight calories, carbs fill the remainder; one-click "Apply" populates all four nutrition goal fields via server actions

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ pip3 install -r scripts/requirements.txt
 Add profile data directly via the Supabase dashboard or the web interface Settings page. Recipes populate the `recipes` table; the session briefing reads `memory/meal_log.md` locally as a fallback until recipe display ships in the web interface.
 
 ### 6. Set up push notifications (Android, macOS, Windows)
-See [docs/notifications-setup.md](docs/notifications-setup.md). Add `NTFY_TOPIC` as a GitHub Actions secret for the Sunday weekly review cloud nudge.
+See [docs/notifications-setup.md](docs/notifications-setup.md). Add `NTFY_TOPIC` as a GitHub Actions secret for the Sunday weekly review cloud nudge. Optionally add `APP_URL` (your Vercel deployment URL) to both `.env` and GitHub Actions secrets — when set, tapping any notification opens the relevant page in the web app.
 
 ### 7. Connect Google Calendar + Gmail
 Open Claude Code in the project directory, run `/mcp`, and authenticate with your Google account.

--- a/scripts/check_birthday_notif.py
+++ b/scripts/check_birthday_notif.py
@@ -24,6 +24,7 @@ from googleapiclient.discovery import build
 ROOT = Path(__file__).parent.parent
 load_dotenv(ROOT / ".env")
 NOTIFY_SCRIPT = ROOT / "scripts" / "notify.sh"
+CLICK_PATH = "/dashboard"
 
 
 def get_credentials() -> Credentials:
@@ -96,12 +97,13 @@ def main() -> None:
             if is_birthday_event(title, cal_name):
                 birthdays_today.append(person_name(title))
 
+    app_url = os.environ.get("APP_URL", "").rstrip("/")
     for name in birthdays_today:
+        cmd = ["bash", str(NOTIFY_SCRIPT), "--title", "Birthday Today", "--message", f"It's {name}'s birthday today."]
+        if app_url:
+            cmd += ["--click-url", f"{app_url}{CLICK_PATH}"]
         try:
-            subprocess.run(
-                ["bash", str(NOTIFY_SCRIPT), "--title", "Birthday Today", "--message", f"It's {name}'s birthday today."],
-                check=True,
-            )
+            subprocess.run(cmd, check=True)
         except Exception as e:
             print(f"[check_birthday_notif] notify error for {name}: {e}", file=sys.stderr)
 

--- a/scripts/check_daily_alerts.py
+++ b/scripts/check_daily_alerts.py
@@ -10,6 +10,7 @@ Requires: supabase, python-dotenv
 """
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from datetime import date
@@ -20,6 +21,7 @@ sys.path.insert(0, str(ROOT / "scripts"))
 from _supabase import get_client
 
 NOTIFY_SCRIPT = ROOT / "scripts" / "notify.sh"
+CLICK_PATH = "/tasks"
 
 
 def get_profile_value(client, key: str) -> str | None:
@@ -80,11 +82,12 @@ def main() -> None:
         is_today = due == today_str
         title = "Task Due Today" if is_today else "Task Overdue"
         message = f"{name} — due {due}" if not is_today else f"{name} — due today"
+        app_url = os.environ.get("APP_URL", "").rstrip("/")
+        cmd = ["bash", str(NOTIFY_SCRIPT), "--title", title, "--message", message]
+        if app_url:
+            cmd += ["--click-url", f"{app_url}{CLICK_PATH}"]
         try:
-            subprocess.run(
-                ["bash", str(NOTIFY_SCRIPT), "--title", title, "--message", message],
-                check=True,
-            )
+            subprocess.run(cmd, check=True)
             fired += 1
         except Exception as e:
             print(f"[check_daily_alerts] notify error for task '{name}': {e}", file=sys.stderr)

--- a/scripts/check_hrv_alert.py
+++ b/scripts/check_hrv_alert.py
@@ -10,6 +10,7 @@ Requires: supabase, python-dotenv
 """
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from datetime import date, timedelta
@@ -20,6 +21,7 @@ sys.path.insert(0, str(ROOT / "scripts"))
 from _supabase import get_client
 
 NOTIFY_SCRIPT = ROOT / "scripts" / "notify.sh"
+CLICK_PATH = "/dashboard"
 DEFAULT_THRESHOLD = 20  # percent
 
 
@@ -103,11 +105,12 @@ def main() -> None:
         f"HRV is {today_hrv:.0f}ms — {drop_pct:.0f}% below 7-day avg "
         f"({baseline:.0f}ms). Consider rest or deload."
     )
+    app_url = os.environ.get("APP_URL", "").rstrip("/")
+    cmd = ["bash", str(NOTIFY_SCRIPT), "--title", title, "--message", message]
+    if app_url:
+        cmd += ["--click-url", f"{app_url}{CLICK_PATH}"]
     try:
-        subprocess.run(
-            ["bash", str(NOTIFY_SCRIPT), "--title", title, "--message", message],
-            check=True,
-        )
+        subprocess.run(cmd, check=True)
         set_profile_value(client, "hrv_alert_last_notified", today_str)
         print(f"[check_hrv_alert] Alert fired: {message}")
     except Exception as e:

--- a/scripts/check_task_due_alerts.py
+++ b/scripts/check_task_due_alerts.py
@@ -12,6 +12,7 @@ Requires: supabase, python-dotenv
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from datetime import date, datetime, timezone
@@ -24,6 +25,7 @@ from _supabase import get_client
 NOTIFY_SCRIPT = ROOT / "scripts" / "notify.sh"
 CACHE_KEY = "task_notif_cache"
 DEDUP_HOURS = 24
+CLICK_PATH = "/tasks"
 
 
 def get_profile_value(client, key: str) -> str | None:
@@ -73,10 +75,11 @@ def needs_notification(task_id: str, cache: dict[str, str]) -> bool:
 
 
 def send_notify(title: str, message: str) -> None:
-    subprocess.run(
-        ["bash", str(NOTIFY_SCRIPT), "--title", title, "--message", message],
-        check=True,
-    )
+    app_url = os.environ.get("APP_URL", "").rstrip("/")
+    cmd = ["bash", str(NOTIFY_SCRIPT), "--title", title, "--message", message]
+    if app_url:
+        cmd += ["--click-url", f"{app_url}{CLICK_PATH}"]
+    subprocess.run(cmd, check=True)
 
 
 def main() -> None:

--- a/scripts/check_weather_alert.py
+++ b/scripts/check_weather_alert.py
@@ -15,6 +15,7 @@ Requires: supabase, python-dotenv
 """
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from datetime import date
@@ -26,6 +27,7 @@ from _supabase import get_client
 from fetch_weather import fetch_weather
 
 NOTIFY_SCRIPT    = ROOT / "scripts" / "notify.sh"
+CLICK_PATH       = "/dashboard"
 PRECIP_THRESHOLD = 0.2    # inches
 HIGH_THRESHOLD   = 95.0   # °F
 LOW_THRESHOLD    = 28.0   # °F
@@ -50,11 +52,12 @@ def set_profile_value(client, key: str, value: str) -> None:
 
 
 def _fire(title: str, message: str) -> bool:
+    app_url = os.environ.get("APP_URL", "").rstrip("/")
+    cmd = ["bash", str(NOTIFY_SCRIPT), "--title", title, "--message", message]
+    if app_url:
+        cmd += ["--click-url", f"{app_url}{CLICK_PATH}"]
     try:
-        subprocess.run(
-            ["bash", str(NOTIFY_SCRIPT), "--title", title, "--message", message],
-            check=True,
-        )
+        subprocess.run(cmd, check=True)
         print(f"[check_weather_alert] Alert fired: {message}")
         return True
     except Exception as e:

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 # Mr. Bridge — notification sender (macOS + Android)
-# Usage: ./scripts/notify.sh --title "Title" --message "Message"
+# Usage: ./scripts/notify.sh --title "Title" --message "Message" [--click-url "https://..."]
 
 TITLE="Mr. Bridge"
 MESSAGE=""
+CLICK_URL=""
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ENV_FILE="$SCRIPT_DIR/../.env"
 
@@ -11,6 +12,7 @@ while [[ "$#" -gt 0 ]]; do
   case $1 in
     --title) TITLE="$2"; shift ;;
     --message) MESSAGE="$2"; shift ;;
+    --click-url) CLICK_URL="$2"; shift ;;
     *) echo "Unknown arg: $1"; exit 1 ;;
   esac
   shift
@@ -30,7 +32,9 @@ if [[ -f "$ENV_FILE" ]]; then
 fi
 
 if [[ -n "$NTFY_TOPIC" ]]; then
-  curl -s -X POST "https://ntfy.sh/$NTFY_TOPIC" \
-    -H "Title: $TITLE" \
-    -d "$MESSAGE" > /dev/null
+  CURL_ARGS=(-s -X POST "https://ntfy.sh/$NTFY_TOPIC" -H "Title: $TITLE")
+  if [[ -n "$CLICK_URL" ]]; then
+    CURL_ARGS+=(-H "Click: $CLICK_URL")
+  fi
+  curl "${CURL_ARGS[@]}" -d "$MESSAGE" > /dev/null
 fi


### PR DESCRIPTION
## Summary

- `notify.sh` gains a `--click-url <url>` argument that adds an `X-Click` header to the ntfy.sh push, so tapping the notification opens the specified URL
- Each alert script reads `APP_URL` from `.env` and passes the relevant path:
  - HRV drop → `/dashboard`
  - Weather alerts → `/dashboard`
  - Birthday alerts → `/dashboard`
  - Task due/overdue (`check_daily_alerts.py`, `check_task_due_alerts.py`) → `/tasks`
- `weekly-review-nudge.yml` (GitHub Actions) adds `Click: ${APP_URL}/weekly` when the `APP_URL` secret is set
- `APP_URL` added to `.env.example` with instructions; click URLs are skipped silently when the variable is absent

## Test plan

- [ ] Add `APP_URL=https://your-app.vercel.app` to `.env`
- [ ] Trigger `check_hrv_alert.py` manually — verify ntfy notification opens `/dashboard`
- [ ] Trigger `check_task_due_alerts.py` manually — verify notification opens `/tasks`
- [ ] Remove `APP_URL` from `.env` — verify scripts still fire notifications without error
- [ ] Run `weekly-review-nudge.yml` via `workflow_dispatch` with `APP_URL` secret set — verify notification opens `/weekly`

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)