### PR TITLE
feat: update_profile tool — AI can persist goals from chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (conversational profile updates — issue #110)
+- **`update_profile` tool** (`web/src/app/api/chat/route.ts`) — upserts one or more `{key, value}` pairs into the `profile` table; available alongside `get_profile` in the chat assistant; the AI tells the user what it is about to write before calling the tool and confirms each saved key afterward
+- **Canonical key guidance** — system prompt instructs Bridge to use the flat canonical keys (`weight_goal_lbs`, `body_fat_goal_pct`, `weekly_workout_goal`, `weekly_active_cal_goal`, `calorie_goal`, `protein_goal`, `carbs_goal`, `fat_goal`, `fiber_goal`) when writing known fitness/nutrition goals so they surface immediately in the web UI and fitness charts; dot-notation (`sleep.goal.hrs`, `study.goal.mins_per_day`, etc.) for other goal domains
+- **Model routing** — added "set my goal", "save my goal", "update my goal", "save that", "lock that in" to Sonnet trigger phrases so goal-setting conversations stay on Sonnet
+
 ### Added (ntfy.sh click-through URLs — issue #75)
 - **`scripts/notify.sh`** — new `--click-url <url>` argument; when provided, adds an `X-Click` header to the ntfy.sh curl call so tapping the notification opens the web app directly
 - **`scripts/check_hrv_alert.py`** — passes `--click-url ${APP_URL}/dashboard` to notify.sh when `APP_URL` is set

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -49,6 +49,8 @@ function selectModel(messages: { role: string; content: unknown }[]): "haiku" | 
     "progress", "what do you think", "advice", "suggest", "improve",
     "breakdown", "fitness goal", "meal plan", "workout plan",
     "schedule strategy", "is it worth", "explain why",
+    "set my goal", "save my goal", "update my goal", "set my target",
+    "save that", "save these", "write that to", "lock that in",
   ];
   if (complexPatterns.some((p) => msg.includes(p))) return "sonnet";
 
@@ -123,6 +125,7 @@ Tools available:
 - log_habit: mark a habit complete for a given date
 - get_fitness_summary: recent body composition, workouts, recovery metrics
 - get_profile: profile key/value store
+- update_profile: upsert one or more profile keys — use for goals, preferences, and targets agreed upon in conversation. Always tell the user what you're about to write before calling this, then confirm what was saved. For known fitness/nutrition goals, use the canonical keys so they appear in the web UI: weight_goal_lbs, body_fat_goal_pct, weekly_workout_goal, weekly_active_cal_goal, calorie_goal, protein_goal, carbs_goal, fat_goal, fiber_goal. For other goals (sleep, study, etc.) use dot-notation: sleep.goal.hrs, study.goal.mins_per_day, etc.
 - search_gmail: search Gmail with any query string, returns message IDs + metadata
 - get_email_body: fetch and decode the full plain-text body of an email by message ID
 - list_calendar_events: list events across all calendars for a date range (defaults to today); each event includes a calendarType field: "primary" (user's own events), "birthday" (auto-generated from contacts), "holiday" (subscription holiday calendars), "other" (shared/secondary). By default show only primary+other events; mention birthdays as reminders separately; omit holiday events unless the user asks. IMPORTANT: only report events that appear in the tool result — never infer or carry over events from conversation history
@@ -345,6 +348,42 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
           .order("key", { ascending: true });
         if (error) return { error: error.message };
         return data ?? [];
+      },
+    }),
+
+    update_profile: tool({
+      description:
+        "Upsert one or more profile key/value pairs. Use when the user explicitly agrees to save a goal, preference, or personal target. " +
+        "For known fitness/nutrition goals use the canonical flat keys (weight_goal_lbs, body_fat_goal_pct, weekly_workout_goal, " +
+        "weekly_active_cal_goal, calorie_goal, protein_goal, carbs_goal, fat_goal, fiber_goal) so they surface in the web UI. " +
+        "For other goals use dot-notation (sleep.goal.hrs, study.goal.mins_per_day, etc.). " +
+        "Always tell the user what you are about to write before calling this tool, then confirm each key that was saved.",
+      parameters: jsonSchema<{ updates: { key: string; value: string }[] }>({
+        type: "object",
+        required: ["updates"],
+        properties: {
+          updates: {
+            type: "array",
+            description: "Key/value pairs to upsert into the profile table.",
+            items: {
+              type: "object",
+              required: ["key", "value"],
+              properties: {
+                key: { type: "string", description: "Profile key." },
+                value: { type: "string", description: "Value to store (always a string)." },
+              },
+            },
+          },
+        },
+      }),
+      execute: async ({ updates }) => {
+        const rows = updates.map(({ key, value }) => ({ key, value }));
+        const { data, error } = await supabase
+          .from("profile")
+          .upsert(rows, { onConflict: "key" })
+          .select("key, value, updated_at");
+        if (error) return { error: error.message };
+        return { written: data ?? [] };
       },
     }),
 


### PR DESCRIPTION
Closes #110

## Summary
- **`update_profile` tool** — accepts `{key, value}[]`, upserts into `profile` table, returns saved rows; available alongside `get_profile` in the chat API
- **Canonical key routing** — system prompt instructs Bridge to use the existing flat keys (`weight_goal_lbs`, `calorie_goal`, etc.) for known fitness/nutrition goals so writes surface immediately in the Settings UI and fitness charts; dot-notation for other domains (`sleep.goal.hrs`, etc.)
- **Show-then-confirm behavior** — system prompt requires Bridge to preview what it will write before calling the tool, then confirm each key saved
- **Model routing** — "set my goal", "save my goal", "lock that in", etc. added to Sonnet trigger phrases so goal-setting conversations stay on Sonnet

## Test plan
- [ ] "Set my weight goal to 175 lbs" → Bridge previews write, calls `update_profile`, confirms `weight_goal_lbs = 175`
- [ ] Fitness page: WeightGoalChart goal line updates after save
- [ ] Settings: `weight_goal_lbs` field reflects new value
- [ ] "Set my calorie goal to 2100 and protein to 160g" → both keys in one tool call
- [ ] "Save my sleep goal as 8 hours" → writes `sleep.goal.hrs = 8`
- [ ] `get_profile` returns all keys including newly written ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)