### PR TITLE
fix: habit heatmap tooltip UUID and stale completed cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (habit heatmap bugs — issue #111)
+- **Tooltip showed UUID instead of habit name** — `HabitHeatmap` now accepts a `registry: HabitRegistry[]` prop (all habits, including inactive) used exclusively for name lookup; the existing `habits` prop (active only) continues to drive the completion ratio denominator; archived habits whose log entries appear in the window now resolve to their correct names
+- **Unchecked habits stayed green on heatmap** — `toggleHabit` server action in `habits/page.tsx` now DELETEs the row on uncheck rather than upserting `completed: false`; eliminates any residual `completed: true` rows that could survive a failed or no-op UPDATE and kept the heatmap cell green
+
 ### Added (conversational profile updates — issue #110)
 - **`update_profile` tool** (`web/src/app/api/chat/route.ts`) — upserts one or more `{key, value}` pairs into the `profile` table; available alongside `get_profile` in the chat assistant; the AI tells the user what it is about to write before calling the tool and confirms each saved key afterward
 - **Canonical key guidance** — system prompt instructs Bridge to use the flat canonical keys (`weight_goal_lbs`, `body_fat_goal_pct`, `weekly_workout_goal`, `weekly_active_cal_goal`, `calorie_goal`, `protein_goal`, `carbs_goal`, `fat_goal`, `fiber_goal`) when writing known fitness/nutrition goals so they surface immediately in the web UI and fitness charts; dot-notation (`sleep.goal.hrs`, `study.goal.mins_per_day`, etc.) for other goal domains

--- a/web/src/app/(protected)/habits/page.tsx
+++ b/web/src/app/(protected)/habits/page.tsx
@@ -16,9 +16,17 @@ import { getWindow } from "@/lib/window";
 async function toggleHabit(habitId: string, date: string, completed: boolean) {
   "use server";
   const supabase = await createClient();
-  await supabase
-    .from("habits")
-    .upsert({ habit_id: habitId, date, completed }, { onConflict: "habit_id,date" });
+  if (completed) {
+    await supabase
+      .from("habits")
+      .upsert({ habit_id: habitId, date, completed: true }, { onConflict: "habit_id,date" });
+  } else {
+    await supabase
+      .from("habits")
+      .delete()
+      .eq("habit_id", habitId)
+      .eq("date", date);
+  }
   revalidatePath("/habits");
   revalidatePath("/dashboard");
 }
@@ -51,9 +59,10 @@ export default async function HabitsPage() {
   const historyDays = Math.min(days, 90);
   const historyDates = getLastNDays(historyDays);
 
-  const [registryResult, todayLogsResult, historyLogsResult, allCompletedResult, weekLogsResult] =
+  const [registryResult, allRegistryResult, todayLogsResult, historyLogsResult, allCompletedResult, weekLogsResult] =
     await Promise.all([
       supabase.from("habit_registry").select("*").eq("active", true).order("category").order("name"),
+      supabase.from("habit_registry").select("*"),
       supabase.from("habits").select("*").eq("date", today),
       // Window-based history
       supabase
@@ -76,6 +85,7 @@ export default async function HabitsPage() {
     ]);
 
   const habits = (registryResult.data ?? []) as HabitRegistry[];
+  const allRegistry = (allRegistryResult.data ?? []) as HabitRegistry[];
   const todayLogs = (todayLogsResult.data ?? []) as HabitLog[];
   const historyLogs = (historyLogsResult.data ?? []) as HabitLog[];
   const allCompleted = (allCompletedResult.data ?? []) as { habit_id: string; date: string }[];
@@ -118,7 +128,7 @@ export default async function HabitsPage() {
           {/* Charts: Heatmap (2/3) + Radial (1/3) */}
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
             <div className="lg:col-span-2">
-              <HabitHeatmap habits={habits} logs={historyLogs} dates={heatmapDates} />
+              <HabitHeatmap habits={habits} registry={allRegistry} logs={historyLogs} dates={heatmapDates} />
             </div>
             <div>
               <RadialCompletion habits={habits} weekLogs={weekLogs} />

--- a/web/src/components/habits/heatmap.tsx
+++ b/web/src/components/habits/heatmap.tsx
@@ -4,9 +4,10 @@ import { useState } from "react";
 import type { HabitRegistry, HabitLog } from "@/lib/types";
 
 interface Props {
-  habits: HabitRegistry[];
-  logs: HabitLog[];   // all logs for the 90-day window
-  dates: string[];    // ordered list of date strings YYYY-MM-DD (90 days)
+  habits: HabitRegistry[];    // active habits only — used for completion ratio denominator
+  registry: HabitRegistry[];  // all habits including inactive — used for name lookup
+  logs: HabitLog[];           // all logs for the window
+  dates: string[];            // ordered list of date strings YYYY-MM-DD
 }
 
 function fmtDate(d: string) {
@@ -17,7 +18,7 @@ function fmtDate(d: string) {
   });
 }
 
-export function HabitHeatmap({ habits, logs, dates }: Props) {
+export function HabitHeatmap({ habits, registry, logs, dates }: Props) {
   const [tooltip, setTooltip] = useState<{ date: string; names: string[] } | null>(null);
 
   if (habits.length === 0 || dates.length === 0) {
@@ -42,8 +43,8 @@ export function HabitHeatmap({ habits, logs, dates }: Props) {
     completionMap.get(log.date)!.add(log.habit_id);
   }
 
-  // Build habit name map
-  const habitNames = new Map(habits.map((h) => [h.id, h.name]));
+  // Build habit name map from full registry (includes archived habits)
+  const habitNames = new Map(registry.map((h) => [h.id, h.name]));
 
   // Group dates into weeks (columns of 7)
   const weeks: string[][] = [];


### PR DESCRIPTION
Fixes #111

## Summary
- **Bug 1 (tooltip UUID):** `HabitHeatmap` built its name-lookup map from `habits` (active only). Archived habits whose logs appear in the window had no entry, so the tooltip fell back to the raw UUID. Added a `registry: HabitRegistry[]` prop (all habits including inactive) used exclusively for name lookup; `habits` (active only) remains the completion-ratio denominator.
- **Bug 2 (stale green cell):** `toggleHabit` was upserting `completed: false` on uncheck. If the UPDATE silently no-oped (e.g. constraint mismatch or RLS edge case), the existing `completed: true` row persisted and kept the heatmap cell green. Changed to `DELETE` on uncheck — a row now only exists when the habit is completed, making state unambiguous.

## Test plan
- [ ] Check a habit → heatmap cell turns green for today
- [ ] Uncheck that habit → heatmap cell clears (no longer green)
- [ ] Archive a habit that has historical logs → tooltip on old completed days shows the habit name, not the UUID
- [ ] Re-check an unchecked habit → cell returns to green correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)