### PR TITLE
fix: nutrition goal calculator defaults and disclaimer (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (nutrition goal calculator defaults — issue #114)
+- **Default protein option** changed from 0.8 g/lb to 1.0 g/lb; `PROTEIN_OPTIONS` reordered so 1.0 appears first and is selected on first render
+- **Disclaimer line** added below the macro preview in `SuggestedNutritionCard` — faint text noting the estimate is based on goal weight only and that Chat gives a more personalized result
+
 ### Added (7-day trailing average overlays — issue #112)
 - **`trailing7Avg` helper** (`health-breakdown.tsx`) — computes a 7-day trailing average client-side for any `{value: number | null}[]` series; for day N, averages all non-null values in the window [N-6, N]
 - **Weight chart** — second `<Line>` overlaid on the existing LineChart; dashed (`4 2`), muted slate color (`#64748B`), no dots, `connectNulls`; legend shows "Weight" + "7d avg"

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ A Next.js web app deployed on Vercel. Built against a full design system (DM San
 - **Journal** — Two-tab editor: *Reflect* (all 5 prompts visible, progress dots, 1.5s auto-save) and *Free Write* (open textarea with word count); collapsible history accordion
 - **Weekly Review** — Last 7 days at a glance: habit score + 7-day pill strip per habit with streak; tasks completed this week, still-active tasks with overdue callout; workout count/duration/calories; average readiness/sleep/HRV with per-day readiness column; body composition delta vs 7 days ago; journal entry count
 - **Meals** — Daily macro summary card (calories/protein/carbs/fat vs goals, progress bars with color coding); food photo analyzer with optional context prompt (Claude vision → macro estimation → log); 7-day meal history from Supabase
-- **Settings** — Profile key-values from Supabase `profile` table; Nutrition Goals section (calorie, protein, carbs, fat daily targets)
+- **Settings** — Profile key-values from Supabase `profile` table; Nutrition Goals section with a suggested macro calculator (goal mode × weight → calories; protein/fat/carbs breakdown; defaults to 1.0 g/lb protein); one-click Apply populates all nutrition goal fields
 
 **Local development:**
 ```bash

--- a/web/src/components/settings/profile-form.tsx
+++ b/web/src/components/settings/profile-form.tsx
@@ -120,9 +120,9 @@ const GOAL_MODES: { key: GoalMode; label: string; multiplier: number; descriptio
 ];
 
 const PROTEIN_OPTIONS: { value: number; label: string }[] = [
-  { value: 0.8, label: "0.8 g/lb" },
-  { value: 0.9, label: "0.9 g/lb" },
   { value: 1.0, label: "1.0 g/lb" },
+  { value: 0.9, label: "0.9 g/lb" },
+  { value: 0.8, label: "0.8 g/lb" },
 ];
 
 function suggestMacros(
@@ -151,7 +151,7 @@ function SuggestedNutritionCard({
   const weightGoal = parseFloat(values["weight_goal_lbs"] ?? "");
 
   const [mode, setMode]               = useState<GoalMode>("lose");
-  const [proteinPerLb, setProteinPerLb] = useState(0.8);
+  const [proteinPerLb, setProteinPerLb] = useState(1.0);
   const [applied, setApplied]         = useState(false);
   const [isPending, startTransition]  = useTransition();
 
@@ -230,6 +230,9 @@ function SuggestedNutritionCard({
           </p>
           <p className="text-xs mt-1" style={{ color: "var(--color-text-faint)" }}>
             {activeMode.description} · protein {proteinPerLb} g/lb · fat 25% of calories · carbs fill remainder
+          </p>
+          <p className="text-xs mt-1" style={{ color: "var(--color-text-faint)", opacity: 0.65 }}>
+            Rough estimate based on goal weight only — ask in Chat for a more personalized result.
           </p>
         </div>
         <button


### PR DESCRIPTION
## Summary

- Default protein option changed from 0.8 g/lb to **1.0 g/lb**; `PROTEIN_OPTIONS` reordered so 1.0 is first and selected on initial render
- Disclaimer added below the macro preview line in `SuggestedNutritionCard`: faint text noting the estimate is based on goal weight only and that Chat gives a more personalized result
- Skip Fix 3 (TDEE from current weight): no `Identity/Weight` or current weight key exists in the `profile` table; `fitness_log` has it but isn't available to the settings component — leaving the multipliers unchanged

Closes #114

## Test plan

- [ ] Open Settings → Nutrition Goals with `weight_goal_lbs` set
- [ ] Confirm `SuggestedNutritionCard` renders with 1.0 g/lb selected by default
- [ ] Confirm protein button order is 1.0 → 0.9 → 0.8
- [ ] Confirm disclaimer line appears below the macro preview, faint, one line
- [ ] Apply — verify all five goal fields update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)