### PR TITLE
fix: exclude walking from workout count and goal progress

### DIFF
--- a/web/src/app/(protected)/fitness/page.tsx
+++ b/web/src/app/(protected)/fitness/page.tsx
@@ -46,8 +46,17 @@ export default async function FitnessPage() {
   ]);
 
   const fitnessData = (fitnessRes.data ?? []) as FitnessLog[];
-  const workouts = (workoutsRes.data ?? []) as WorkoutSession[];
+  const allWorkouts = (workoutsRes.data ?? []) as WorkoutSession[];
   const recoveryData = (recoveryRes.data ?? []) as Pick<RecoveryMetrics, "date" | "active_cal">[];
+
+  const workouts     = allWorkouts.filter((w) => !/walk/i.test(w.activity));
+  const walkSessions = allWorkouts.filter((w) => /walk/i.test(w.activity));
+
+  // "Walks this week" = last 7 days
+  const weekStart = daysAgoString(6);
+  const walksThisWeek = walkSessions.filter((w) => w.date >= weekStart);
+  const walkCount    = walksThisWeek.length;
+  const walkDuration = walksThisWeek.reduce((s, w) => s + (w.duration_mins ?? 0), 0);
 
   const goals: Record<string, number | null> = {};
   for (const row of profileRes.data ?? []) {
@@ -84,11 +93,31 @@ export default async function FitnessPage() {
 
       {/* Weekly frequency + active cal vs goals */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <WorkoutFreqChart
-          sessions={workouts}
-          weekCount={8}
-          goal={weeklyWorkoutGoal}
-        />
+        <div className="flex flex-col gap-2">
+          <WorkoutFreqChart
+            sessions={workouts}
+            weekCount={8}
+            goal={weeklyWorkoutGoal}
+          />
+          {walkCount > 0 && (
+            <div
+              className="rounded-lg px-4 py-2.5 flex items-center gap-3"
+              style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+            >
+              <span className="text-xs uppercase tracking-widest" style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}>
+                Walks this week
+              </span>
+              <span className="text-sm font-semibold tabular-nums" style={{ color: "var(--color-text)" }}>
+                {walkCount}
+              </span>
+              {walkDuration > 0 && (
+                <span className="text-xs tabular-nums" style={{ color: "var(--color-text-muted)" }}>
+                  {walkDuration >= 60 ? `${Math.floor(walkDuration / 60)}h ${walkDuration % 60}m` : `${walkDuration}m`}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
         <ActiveCalGoalChart
           data={recoveryData}
           goal={weeklyActiveCalGoal}
@@ -110,7 +139,7 @@ export default async function FitnessPage() {
         />
       </div>
 
-      <WorkoutHistoryTable workouts={workouts} />
+      <WorkoutHistoryTable workouts={allWorkouts} />
     </div>
   );
 }

--- a/web/src/app/(protected)/weekly/page.tsx
+++ b/web/src/app/(protected)/weekly/page.tsx
@@ -210,9 +210,12 @@ export default async function WeeklyPage() {
 
   // ── Workouts ──────────────────────────────────────────────────────────────
 
-  const workouts = (workoutsRes.data ?? []) as Pick<WorkoutSession, "date" | "activity" | "duration_mins" | "calories">[];
-  const totalDuration = workouts.reduce((s, w) => s + (w.duration_mins ?? 0), 0);
-  const totalCalories = workouts.reduce((s, w) => s + (w.calories ?? 0), 0);
+  const allWorkouts    = (workoutsRes.data ?? []) as Pick<WorkoutSession, "date" | "activity" | "duration_mins" | "calories">[];
+  const workouts       = allWorkouts.filter((w) => !/walk/i.test(w.activity));
+  const walkWorkouts   = allWorkouts.filter((w) => /walk/i.test(w.activity));
+  const totalDuration  = workouts.reduce((s, w) => s + (w.duration_mins ?? 0), 0);
+  const totalCalories  = workouts.reduce((s, w) => s + (w.calories ?? 0), 0);
+  const walkDuration   = walkWorkouts.reduce((s, w) => s + (w.duration_mins ?? 0), 0);
 
   // ── Recovery ─────────────────────────────────────────────────────────────
 
@@ -384,11 +387,11 @@ export default async function WeeklyPage() {
 
         {/* Workouts */}
         <Card title="Workouts" accent="var(--color-info)">
-          {workouts.length === 0 ? (
+          {allWorkouts.length === 0 ? (
             <p className="text-sm" style={{ color: "var(--color-text-faint)" }}>No sessions logged this week.</p>
           ) : (
             <div className="flex flex-col gap-4">
-              {/* Summary row */}
+              {/* Summary row — excludes walks */}
               <div className="grid grid-cols-3 gap-3">
                 {[
                   { label: "Sessions", value: workouts.length.toString() },
@@ -408,27 +411,63 @@ export default async function WeeklyPage() {
                 ))}
               </div>
 
-              {/* Session list */}
-              <div className="flex flex-col gap-1">
-                {workouts.map((w, i) => (
-                  <div key={i} className="flex items-center gap-2 text-sm">
-                    <span style={{ color: "var(--color-text-muted)", width: "3.5rem", flexShrink: 0, fontSize: 11 }}>
-                      {fmtDate(w.date)}
-                    </span>
-                    <span className="flex-1 truncate" style={{ color: "var(--color-text)" }}>{w.activity}</span>
-                    {w.duration_mins != null && (
-                      <span className="tabular-nums shrink-0 text-xs" style={{ color: "var(--color-text-muted)" }}>
-                        {w.duration_mins}m
+              {/* Session list — excludes walks */}
+              {workouts.length > 0 && (
+                <div className="flex flex-col gap-1">
+                  {workouts.map((w, i) => (
+                    <div key={i} className="flex items-center gap-2 text-sm">
+                      <span style={{ color: "var(--color-text-muted)", width: "3.5rem", flexShrink: 0, fontSize: 11 }}>
+                        {fmtDate(w.date)}
                       </span>
-                    )}
-                    {w.calories != null && (
-                      <span className="tabular-nums shrink-0 text-xs" style={{ color: "var(--color-text-muted)" }}>
-                        {Math.round(w.calories)} kcal
+                      <span className="flex-1 truncate" style={{ color: "var(--color-text)" }}>{w.activity}</span>
+                      {w.duration_mins != null && (
+                        <span className="tabular-nums shrink-0 text-xs" style={{ color: "var(--color-text-muted)" }}>
+                          {w.duration_mins}m
+                        </span>
+                      )}
+                      {w.calories != null && (
+                        <span className="tabular-nums shrink-0 text-xs" style={{ color: "var(--color-text-muted)" }}>
+                          {Math.round(w.calories)} kcal
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {/* Walks — secondary row */}
+              {walkWorkouts.length > 0 && (
+                <div style={{ borderTop: "1px solid var(--color-border)", paddingTop: 12 }}>
+                  <div className="flex items-center gap-3 mb-2">
+                    <p className="text-xs uppercase tracking-widest" style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}>
+                      Walks
+                    </p>
+                    <span className="text-xs tabular-nums font-semibold" style={{ color: "var(--color-text)" }}>
+                      {walkWorkouts.length}
+                    </span>
+                    {walkDuration > 0 && (
+                      <span className="text-xs tabular-nums" style={{ color: "var(--color-text-muted)" }}>
+                        {walkDuration >= 60 ? `${Math.floor(walkDuration / 60)}h ${walkDuration % 60}m` : `${walkDuration}m`}
                       </span>
                     )}
                   </div>
-                ))}
-              </div>
+                  <div className="flex flex-col gap-1">
+                    {walkWorkouts.map((w, i) => (
+                      <div key={i} className="flex items-center gap-2 text-sm">
+                        <span style={{ color: "var(--color-text-muted)", width: "3.5rem", flexShrink: 0, fontSize: 11 }}>
+                          {fmtDate(w.date)}
+                        </span>
+                        <span className="flex-1 truncate" style={{ color: "var(--color-text-muted)" }}>{w.activity}</span>
+                        {w.duration_mins != null && (
+                          <span className="tabular-nums shrink-0 text-xs" style={{ color: "var(--color-text-muted)" }}>
+                            {w.duration_mins}m
+                          </span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
           )}
         </Card>


### PR DESCRIPTION
Closes #121

## Summary
- Walking activities (case-insensitive `walk` match on `activity` field) are filtered out of the `WorkoutFreqChart` bar chart and all weekly session counts / goal progress calculations
- A **"Walks this week"** stat (count + total duration) is shown below the workout frequency chart on the Fitness page — only rendered when walks exist
- The **Weekly Review** workouts card adds a secondary "Walks" section below the workout session list, showing count, total duration, and per-walk rows — walks are excluded from the Sessions / Total Time / Calories summary tiles
- `WorkoutHistoryTable` on the Fitness page still shows all activities (walks included)
- Empty-state check in Weekly Review uses `allWorkouts.length` so a walks-only week doesn't incorrectly show "No sessions logged"

## Test plan
- [ ] Log or confirm a walk session exists in `workout_sessions` (activity contains "walk")
- [ ] Fitness page: walk does not appear in WorkoutFreqChart bar count; "Walks this week" pill appears below the chart with correct count and duration
- [ ] Fitness page: WorkoutHistoryTable still shows the walk row
- [ ] Weekly Review: Sessions tile count excludes walks; Total Time and Calories reflect workouts only
- [ ] Weekly Review: "Walks" section appears below session list with correct count and total duration
- [ ] No walks → "Walks this week" pill and "Walks" section are hidden entirely
- [ ] Walks-only week → Weekly Review shows 0 sessions in summary tiles but does not show "No sessions logged"

🤖 Generated with [Claude Code](https://claude.com/claude-code)