### PR TITLE
feat: Sleep & HRV by day in Weekly Review (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (Sleep & HRV by day in Weekly Review — issue #122)
+- **Weekly Review Recovery card** renamed from "Recovery Averages" to "Sleep & Recovery"
+- **"Sleep by day" row** added below "Readiness by day" — 7-day strip with color-coded score (green ≥80 / yellow ≥60 / red <60) and day number; sourced from `sleep_score` in `recovery_metrics`
+- **"HRV by day (ms)" row** added below Sleep — same strip layout, values rounded to nearest integer, colored `var(--color-info)`; sourced from `avg_hrv` in `recovery_metrics`
+
 ### Added (MB favicon and iOS touch icon — issue #117)
 - **`web/src/app/icon.svg`** — raw SVG monogram logo (solid indigo `#1d4ed8` background, `rx="7"` rounded corners); Next.js App Router auto-wires this as the browser favicon
 - **`web/src/app/apple-icon.png`** — 180×180 PNG rasterized from the SVG for iOS Add to Home Screen; solid `#1d4ed8` background, proportionally scaled paths

--- a/web/src/app/(protected)/weekly/page.tsx
+++ b/web/src/app/(protected)/weekly/page.tsx
@@ -473,7 +473,7 @@ export default async function WeeklyPage() {
         </Card>
 
         {/* Recovery */}
-        <Card title="Recovery Averages" accent={scoreColor(avgReadiness)}>
+        <Card title="Sleep & Recovery" accent={scoreColor(avgReadiness)}>
           {recoveryRows.length === 0 ? (
             <p className="text-sm" style={{ color: "var(--color-text-faint)" }}>No recovery data for this week.</p>
           ) : (
@@ -538,6 +538,60 @@ export default async function WeeklyPage() {
                           style={{ color: row?.readiness != null ? scoreColor(row.readiness) : "var(--color-text-faint)" }}
                         >
                           {row?.readiness != null ? row.readiness : "—"}
+                        </span>
+                        <span style={{ fontSize: 9, color: "var(--color-text-faint)" }}>
+                          {fmtDate(d).replace(/[A-Za-z]+ /, "")}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Per-day sleep pills */}
+              <div>
+                <p className="text-xs mb-2" style={{ color: "var(--color-text-muted)" }}>Sleep by day</p>
+                <div className="flex gap-2 flex-wrap">
+                  {last7Days.map((d) => {
+                    const row = recoveryRows.find((r) => r.date === d);
+                    return (
+                      <div
+                        key={d}
+                        title={`${fmtDate(d)}: ${row?.sleep_score != null ? `Sleep ${row.sleep_score}` : "no data"}`}
+                        className="flex flex-col items-center gap-0.5"
+                      >
+                        <span
+                          className="tabular-nums text-xs font-medium"
+                          style={{ color: row?.sleep_score != null ? scoreColor(row.sleep_score) : "var(--color-text-faint)" }}
+                        >
+                          {row?.sleep_score != null ? row.sleep_score : "—"}
+                        </span>
+                        <span style={{ fontSize: 9, color: "var(--color-text-faint)" }}>
+                          {fmtDate(d).replace(/[A-Za-z]+ /, "")}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Per-day HRV pills */}
+              <div>
+                <p className="text-xs mb-2" style={{ color: "var(--color-text-muted)" }}>HRV by day (ms)</p>
+                <div className="flex gap-2 flex-wrap">
+                  {last7Days.map((d) => {
+                    const row = recoveryRows.find((r) => r.date === d);
+                    return (
+                      <div
+                        key={d}
+                        title={`${fmtDate(d)}: ${row?.avg_hrv != null ? `HRV ${Math.round(row.avg_hrv)}ms` : "no data"}`}
+                        className="flex flex-col items-center gap-0.5"
+                      >
+                        <span
+                          className="tabular-nums text-xs font-medium"
+                          style={{ color: row?.avg_hrv != null ? "var(--color-info)" : "var(--color-text-faint)" }}
+                        >
+                          {row?.avg_hrv != null ? Math.round(row.avg_hrv) : "—"}
                         </span>
                         <span style={{ fontSize: 9, color: "var(--color-text-faint)" }}>
                           {fmtDate(d).replace(/[A-Za-z]+ /, "")}


### PR DESCRIPTION
## Summary

- Renames the Recovery card from "Recovery Averages" to "Sleep & Recovery"
- Adds **Sleep by day** strip below Readiness by day — color-coded via `scoreColor` (green ≥80 / yellow ≥60 / red <60), value + day number layout matches existing Readiness row
- Adds **HRV by day (ms)** strip below Sleep — values rounded to nearest integer, colored `var(--color-info)` (matches the avg HRV display in the big-scores section)

No new Supabase queries — `sleep_score` and `avg_hrv` were already fetched from `recovery_metrics`.

Closes #122

## Test plan

- [ ] Weekly Review loads without errors
- [ ] Sleep by day row shows 7 cells, each color-coded green/yellow/red based on score
- [ ] HRV by day row shows 7 cells with rounded ms values in info color
- [ ] Days with no recovery data show "—" in faint color for all three rows
- [ ] Card header reads "Sleep & Recovery"
- [ ] Tooltip on hover shows correct date and metric value

🤖 Generated with [Claude Code](https://claude.com/claude-code)