### PR TITLE
feat: dismissible suggested nutrition card (issue #123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (dismissible suggested nutrition card — issue #123)
+- **X button** on `SuggestedNutritionCard` — absolute top-right dismiss button; clicking upserts `nutrition_suggestion_dismissed: "true"` into the `profile` table via the existing `updateAction` server action; disabled state during pending transition
+- **Persistent dismissal** — card reads `values["nutrition_suggestion_dismissed"]` on render (server-loaded); returns null immediately if dismissed, surviving page reloads
+- **"Recalculate suggested macros" link** — rendered in the Nutrition Goals section header only when the card is dismissed; clicking deletes the `nutrition_suggestion_dismissed` key via `deleteAction`, re-showing the card; spinner shown during pending transition
+- No schema migration required — uses the existing key-value `profile` table
+
 ### Added (Sleep & HRV by day in Weekly Review — issue #122)
 - **Weekly Review Recovery card** renamed from "Recovery Averages" to "Sleep & Recovery"
 - **"Sleep by day" row** added below "Readiness by day" — 7-day strip with color-coded score (green ≥80 / yellow ≥60 / red <60) and day number; sourced from `sleep_score` in `recovery_metrics`

--- a/web/src/components/settings/profile-form.tsx
+++ b/web/src/components/settings/profile-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { Check, Loader2 } from "lucide-react";
+import { Check, Loader2, X } from "lucide-react";
 
 interface Field {
   key: string;
@@ -144,9 +144,11 @@ function suggestMacros(
 function SuggestedNutritionCard({
   values,
   updateAction,
+  deleteAction,
 }: {
   values: Record<string, string>;
   updateAction: (key: string, value: string) => Promise<void>;
+  deleteAction: (key: string) => Promise<void>;
 }) {
   const weightGoal = parseFloat(values["weight_goal_lbs"] ?? "");
 
@@ -154,8 +156,10 @@ function SuggestedNutritionCard({
   const [proteinPerLb, setProteinPerLb] = useState(1.0);
   const [applied, setApplied]         = useState(false);
   const [isPending, startTransition]  = useTransition();
+  const [isDismissPending, startDismissTransition] = useTransition();
 
   if (!weightGoal || isNaN(weightGoal)) return null;
+  if (values["nutrition_suggestion_dismissed"] === "true") return null;
 
   const calMultiplier = GOAL_MODES.find((m) => m.key === mode)!.multiplier;
   const suggested     = suggestMacros(weightGoal, calMultiplier, proteinPerLb);
@@ -174,13 +178,30 @@ function SuggestedNutritionCard({
     });
   }
 
+  function dismiss() {
+    startDismissTransition(async () => {
+      await updateAction("nutrition_suggestion_dismissed", "true");
+    });
+  }
+
   const activeMode = GOAL_MODES.find((m) => m.key === mode)!;
 
   return (
     <div
-      className="mx-5 my-3 rounded-lg px-4 py-4 flex flex-col gap-3"
+      className="relative mx-5 my-3 rounded-lg px-4 py-4 flex flex-col gap-3"
       style={{ background: "rgba(99,102,241,0.08)", border: "1px solid rgba(99,102,241,0.22)" }}
     >
+      <button
+        onClick={dismiss}
+        disabled={isDismissPending}
+        title="Dismiss"
+        className="absolute top-2 right-2 flex items-center justify-center w-5 h-5 rounded transition-colors cursor-pointer disabled:opacity-40"
+        style={{ color: "var(--color-text-faint)" }}
+        onMouseOver={(e) => { e.currentTarget.style.color = "var(--color-text-muted)"; }}
+        onMouseOut={(e) => { e.currentTarget.style.color = "var(--color-text-faint)"; }}
+      >
+        <X size={13} />
+      </button>
       {/* Mode + protein controls */}
       <div className="flex flex-wrap items-center gap-3">
         <span className="text-xs font-medium shrink-0" style={{ color: "var(--color-primary)" }}>
@@ -342,6 +363,20 @@ function FieldRow({
   );
 }
 
+function RecalculateLink({ deleteAction }: { deleteAction: (key: string) => Promise<void> }) {
+  const [isPending, startTransition] = useTransition();
+  return (
+    <button
+      onClick={() => startTransition(async () => { await deleteAction("nutrition_suggestion_dismissed"); })}
+      disabled={isPending}
+      className="text-xs cursor-pointer disabled:opacity-40"
+      style={{ color: "var(--color-primary)" }}
+    >
+      {isPending ? <Loader2 size={11} className="animate-spin inline" /> : "Recalculate suggested macros"}
+    </button>
+  );
+}
+
 export function ProfileForm({ values, updateAction, deleteAction }: Props) {
   return (
     <div className="space-y-6">
@@ -389,12 +424,15 @@ export function ProfileForm({ values, updateAction, deleteAction }: Props) {
         className="rounded-xl overflow-hidden"
         style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
       >
-        <div className="px-5 py-4" style={{ borderBottom: "1px solid var(--color-border)" }}>
+        <div className="px-5 py-4 flex items-center justify-between" style={{ borderBottom: "1px solid var(--color-border)" }}>
           <p className="text-xs uppercase tracking-widest" style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}>
             Nutrition Goals
           </p>
+          {values["nutrition_suggestion_dismissed"] === "true" && (
+            <RecalculateLink deleteAction={deleteAction} />
+          )}
         </div>
-        <SuggestedNutritionCard values={values} updateAction={updateAction} />
+        <SuggestedNutritionCard values={values} updateAction={updateAction} deleteAction={deleteAction} />
         {NUTRITION_GOAL_FIELDS.map((field) => (
           <FieldRow
             key={field.key}


### PR DESCRIPTION
## Summary

- Adds an X dismiss button (absolute top-right) to `SuggestedNutritionCard` that upserts `nutrition_suggestion_dismissed: "true"` into the `profile` table; card hides immediately and stays hidden across reloads
- Adds a "Recalculate suggested macros" link in the Nutrition Goals section header, visible only when dismissed; clicking deletes the flag and re-shows the card
- No schema migration needed — uses the existing key-value `profile` table and the settings page's existing `updateAction`/`deleteAction` server actions

Closes #123

## Test plan

- [ ] Card shows normally when `nutrition_suggestion_dismissed` is not set
- [ ] Clicking X hides the card and the "Recalculate suggested macros" link appears in the section header
- [ ] Reloading the page keeps the card hidden (flag persisted in Supabase)
- [ ] Clicking "Recalculate suggested macros" re-shows the card and hides the link
- [ ] Both actions show spinner/disabled state during the pending transition
- [ ] Card still returns null when `weight_goal_lbs` is not set (existing behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)