### PR TITLE
feat: demo account with seed data and nightly reset (issue #50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (demo account + multi-tenancy — issue #50)
+- **Multi-tenancy migration** — `user_id uuid references auth.users(id)` added to all 14 tables; existing rows backfilled with owner's auth UID; RLS policies updated from `using (true)` → `using (auth.uid() = user_id)`; per-user indexes added
+- **Demo account** — `demo@mr-bridge.app` with realistic seed data: Alex Chen persona, 7 habits at ~60% completion over 30 days, body comp trend arc, 18 workout sessions, 30 recovery nights, 10 tasks, 5 study entries, 4 journal entries, 5 recipes
+- **Groq chat for demo** — demo user's chat route swaps Anthropic for Groq Llama 3.3-70b (free tier); same tool interface, simplified Alex Chen system prompt
+- **Mock Gmail + Calendar** — `/api/google/gmail` and `/api/google/calendar` return hardcoded demo data for the demo user; chat tools do the same
+- **Nightly reset** — `scripts/reset_demo.py` wipes + reseeds; `/api/cron/reset-demo/route.ts` is `CRON_SECRET`-protected; Vercel cron at 3 AM PT
+- **Login UX** — "Try the demo" button auto-fills and signs in when `NEXT_PUBLIC_DEMO_EMAIL/PASSWORD` are set
+- **Demo banner** — shown in sidebar (desktop) and above tab bar (mobile) when signed in as demo user
+- **Python scripts** — `sync-oura.py`, `sync-fitbit.py`, `sync-googlefit.py`, `fetch_briefing_data.py`, `log_habit.py` now require `OWNER_USER_ID` in `.env` and filter all queries by it
+- **`scripts/print_owner_id.py`** — prints owner's Supabase UUID for use as `OWNER_USER_ID`
+- **README** — Demo account section (credentials, real vs mocked); Self-Hosting section (rename checklist, env var table, setup steps)
+
 ### Added (dismissible suggested nutrition card — issue #123)
 - **X button** on `SuggestedNutritionCard` — absolute top-right dismiss button; clicking upserts `nutrition_suggestion_dismissed: "true"` into the `profile` table via the existing `updateAction` server action; disabled state during pending transition
 - **Persistent dismissal** — card reads `values["nutrition_suggestion_dismissed"]` on render (server-loaded); returns null immediately if dismissed, surviving page reloads

--- a/README.md
+++ b/README.md
@@ -475,6 +475,96 @@ mr-bridge-assistant/
 
 ---
 
+## Demo Account
+
+A shared demo account lets visitors explore the app without touching real data. The demo user ("Alex Chen, software engineer, SF") has 30 days of realistic fitness, habit, recovery, and task data pre-loaded. Data resets nightly.
+
+### Using the demo
+
+On the login page, click **"Try the demo"** — it auto-fills credentials and signs you in. No registration required.
+
+Or sign in manually:
+- **Email:** `demo@mr-bridge.app`
+- **Password:** set in your deployment's `DEMO_PASSWORD` env var (see `.env.example`)
+
+The demo account is fully interactive: toggle habits, add tasks, chat with the AI, browse fitness data. All changes are wiped and reseeded at 3 AM PT each night.
+
+**What's real vs mocked:**
+| Feature | Demo behaviour |
+|---------|----------------|
+| Habits, tasks, fitness, recovery | Real data from Supabase (seeded) |
+| Chat (AI) | Groq Llama 3.3-70b — free tier, no Claude API cost |
+| Gmail | Hardcoded mock emails |
+| Google Calendar | Hardcoded mock events |
+| Fitbit / Oura sync | Not connected — seed data covers it |
+
+---
+
+## Self-Hosting
+
+This repo is designed to run as a personal deployment. If you fork it, choose a unique name for your app before deploying to avoid conflicts.
+
+### Places that reference "mr-bridge" by name
+
+Run a global find-and-replace on these before deploying:
+
+| Location | What to change |
+|----------|----------------|
+| `web/package.json` → `"name"` | `mr-bridge-web` → your app name |
+| Vercel project name | Set in the Vercel dashboard on first deploy |
+| Supabase project name | Set when creating the project |
+| `.env` → `NEXT_PUBLIC_APP_NAME` (if used) | Your app name |
+| Any hardcoded `mr-bridge.app` domains in `.env` | Your domain |
+
+### One-time setup after forking
+
+```bash
+# 1. Install dependencies
+cd web && npm install
+pip3 install -r scripts/requirements.txt
+
+# 2. Copy and fill environment variables
+cp .env.example .env
+# Edit .env — fill in Supabase, Anthropic, Google OAuth, Groq keys
+
+# 3. Run the schema migration in Supabase SQL editor
+# Copy contents of supabase/migrations/ and run in order
+
+# 4. Get your Supabase user ID for OWNER_USER_ID
+python3 scripts/print_owner_id.py
+# Add OWNER_USER_ID=<uuid> to .env
+
+# 5. Create the demo account in Supabase Auth dashboard
+# Email: demo@mr-bridge.app (or your chosen demo email)
+# Then add DEMO_EMAIL, DEMO_PASSWORD, DEMO_USER_ID to .env
+
+# 6. Seed the demo account
+python3 scripts/seed_demo.py
+
+# 7. Add NEXT_PUBLIC_DEMO_EMAIL and NEXT_PUBLIC_DEMO_PASSWORD to .env
+# (these are exposed to the browser to power the "Try demo" button)
+```
+
+### Required env vars
+
+| Variable | Description |
+|----------|-------------|
+| `SUPABASE_URL` | Supabase project URL |
+| `NEXT_PUBLIC_SUPABASE_URL` | Same as above (browser-accessible) |
+| `SUPABASE_SERVICE_ROLE_KEY` | Service role key (server-only) |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Anon key (browser) |
+| `ANTHROPIC_API_KEY` | Claude API key |
+| `GROQ_API_KEY` | Groq API key — free at console.groq.com |
+| `OWNER_USER_ID` | Your Supabase auth UUID (run `print_owner_id.py`) |
+| `DEMO_USER_ID` | Demo account's Supabase auth UUID |
+| `DEMO_EMAIL` | Demo account email |
+| `DEMO_PASSWORD` | Demo account password |
+| `NEXT_PUBLIC_DEMO_EMAIL` | Same as `DEMO_EMAIL` (exposes "Try demo" button) |
+| `NEXT_PUBLIC_DEMO_PASSWORD` | Same as `DEMO_PASSWORD` (powers auto-fill) |
+| `CRON_SECRET` | Secret for protecting cron endpoints |
+
+---
+
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md) for full version history.

--- a/scripts/_supabase.py
+++ b/scripts/_supabase.py
@@ -1,7 +1,7 @@
 """
 Shared Supabase client helper for sync scripts.
 Uses SUPABASE_SERVICE_ROLE_KEY (bypasses RLS).
-Import as: from _supabase import get_client, log_sync, urlopen_with_retry
+Import as: from _supabase import get_client, get_owner_user_id, log_sync, urlopen_with_retry
 """
 from __future__ import annotations
 
@@ -44,6 +44,20 @@ def get_client():
     if not url or not key:
         raise EnvironmentError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set in .env")
     return create_client(url, key)
+
+
+def get_owner_user_id() -> str:
+    """Return the real owner's user UUID from OWNER_USER_ID env var.
+    Raises if not set — sync scripts must never write rows without a user_id
+    to avoid touching demo data or writing orphaned rows.
+    """
+    uid = os.environ.get("OWNER_USER_ID", "")
+    if not uid:
+        raise EnvironmentError(
+            "OWNER_USER_ID must be set in .env. "
+            "Run: python3 scripts/print_owner_id.py to get your Supabase auth UID."
+        )
+    return uid
 
 
 def upsert(client, table: str, rows: list[dict], conflict: str | None = None) -> int:

--- a/scripts/fetch_briefing_data.py
+++ b/scripts/fetch_briefing_data.py
@@ -14,7 +14,7 @@ from datetime import date, timedelta
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _supabase import get_client
+from _supabase import get_client, get_owner_user_id
 from fetch_weather import fetch_weather, format_weather_line
 
 
@@ -28,6 +28,7 @@ def fmt_hrs(h) -> str:
 
 def main():
     client = get_client()
+    uid = get_owner_user_id()
     today = str(date.today())
     yesterday = str(date.today() - timedelta(days=1))
     seven_days_ago = str(date.today() - timedelta(days=7))
@@ -35,12 +36,13 @@ def main():
     # ── Query functions (closures) ─────────────────────────────────────────────
 
     def q_profile():
-        return client.table("profile").select("key,value").execute().data
+        return client.table("profile").select("key,value").eq("user_id", uid).execute().data
 
     def q_tasks():
         return (
             client.table("tasks")
             .select("title,priority,due_date,status")
+            .eq("user_id", uid)
             .eq("status", "active")
             .order("due_date", desc=False)
             .execute()
@@ -48,12 +50,13 @@ def main():
         )
 
     def q_habit_registry():
-        return client.table("habit_registry").select("id,name").eq("active", True).execute().data
+        return client.table("habit_registry").select("id,name").eq("active", True).eq("user_id", uid).execute().data
 
     def q_habits():
         return (
             client.table("habits")
             .select("habit_id,date,completed")
+            .eq("user_id", uid)
             .gte("date", seven_days_ago)
             .lte("date", today)
             .execute()
@@ -64,6 +67,7 @@ def main():
         return (
             client.table("fitness_log")
             .select("date,weight_lb,body_fat_pct,bmi,muscle_mass_lb,visceral_fat,source")
+            .eq("user_id", uid)
             .not_.is_("body_fat_pct", "null")
             .order("date", desc=True)
             .limit(2)
@@ -75,6 +79,7 @@ def main():
         return (
             client.table("workout_sessions")
             .select("activity,duration_mins,calories,avg_hr,start_time")
+            .eq("user_id", uid)
             .eq("date", yesterday)
             .order("start_time")
             .execute()
@@ -85,6 +90,7 @@ def main():
         return (
             client.table("workout_sessions")
             .select("activity,duration_mins,calories,avg_hr,start_time")
+            .eq("user_id", uid)
             .eq("date", today)
             .order("start_time")
             .execute()
@@ -95,6 +101,7 @@ def main():
         return (
             client.table("recovery_metrics")
             .select("*")
+            .eq("user_id", uid)
             .order("date", desc=True)
             .limit(1)
             .execute()
@@ -105,6 +112,7 @@ def main():
         return (
             client.table("study_log")
             .select("date,subject,duration_mins,notes")
+            .eq("user_id", uid)
             .gte("date", seven_days_ago)
             .order("date", desc=True)
             .execute()
@@ -115,6 +123,7 @@ def main():
         return (
             client.table("meal_log")
             .select("date,meal_type,notes,recipe_id")
+            .eq("user_id", uid)
             .gte("date", seven_days_ago)
             .order("date", desc=True)
             .execute()

--- a/scripts/log_habit.py
+++ b/scripts/log_habit.py
@@ -15,7 +15,7 @@ from datetime import date
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _supabase import get_client, log_sync
+from _supabase import get_client, get_owner_user_id, log_sync
 
 HABIT_ALIASES = {
     "floss": "Floss",
@@ -36,9 +36,10 @@ def main():
     args = parser.parse_args()
 
     client = get_client()
+    owner_user_id = get_owner_user_id()
 
-    # Fetch habit registry
-    registry = client.table("habit_registry").select("id,name").execute().data
+    # Fetch habit registry (owner only)
+    registry = client.table("habit_registry").select("id,name").eq("user_id", owner_user_id).execute().data
     habit_id_map = {r["name"].lower(): r["id"] for r in registry}
 
     rows = []
@@ -52,6 +53,7 @@ def main():
             unrecognized.append(h)
             continue
         rows.append({
+            "user_id": owner_user_id,
             "habit_id": hid,
             "date": args.date,
             "completed": True,

--- a/scripts/print_owner_id.py
+++ b/scripts/print_owner_id.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+Print the authenticated user's Supabase UUID.
+Run this after the multi-tenancy migration to get the value for OWNER_USER_ID in .env.
+
+Usage: python3 scripts/print_owner_id.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+ROOT = Path(__file__).parent.parent
+load_dotenv(ROOT / ".env")
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _supabase import get_client
+
+
+def main():
+    client = get_client()
+    # List all auth users (service role only)
+    resp = client.auth.admin.list_users()
+    users = resp if isinstance(resp, list) else getattr(resp, "users", [])
+
+    demo_email = os.environ.get("DEMO_EMAIL", "demo@mr-bridge.app")
+    real_users = [u for u in users if getattr(u, "email", "") != demo_email]
+
+    if not real_users:
+        print("[error] No non-demo users found in auth.users.")
+        sys.exit(1)
+
+    if len(real_users) > 1:
+        print("[warn] Multiple non-demo users found — using the first one (oldest).")
+        real_users.sort(key=lambda u: getattr(u, "created_at", ""))
+
+    u = real_users[0]
+    uid = getattr(u, "id", None)
+    email = getattr(u, "email", "unknown")
+    print(f"Owner user:  {email}")
+    print(f"Owner UUID:  {uid}")
+    print()
+    print(f"Add to .env:")
+    print(f"OWNER_USER_ID={uid}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reset_demo.py
+++ b/scripts/reset_demo.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Reset the demo account: wipe all demo user data, then re-run seed_demo.py.
+Called nightly by the Vercel cron job via /api/cron/reset-demo.
+
+Usage:
+  python3 scripts/reset_demo.py [--yes]
+
+Requires DEMO_USER_ID in .env.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+ROOT = Path(__file__).parent.parent
+load_dotenv(ROOT / ".env")
+sys.path.insert(0, str(Path(__file__).parent))
+from _supabase import get_client
+
+DEMO_USER_ID = os.environ.get("DEMO_USER_ID", "")
+
+# Tables to wipe (in dependency order — children before parents)
+TABLES = [
+    "chat_messages",
+    "chat_sessions",
+    "habits",
+    "habit_registry",
+    "meal_log",
+    "recipes",
+    "study_log",
+    "journal_entries",
+    "workout_sessions",
+    "recovery_metrics",
+    "fitness_log",
+    "tasks",
+    "timer_state",
+    "profile",
+]
+
+
+def wipe_demo_data(client):
+    for table in TABLES:
+        resp = client.table(table).delete().eq("user_id", DEMO_USER_ID).execute()
+        deleted = len(resp.data) if resp.data else 0
+        print(f"[reset] {table}: deleted {deleted} rows")
+
+
+def main():
+    if not DEMO_USER_ID:
+        print("[error] DEMO_USER_ID not set in .env")
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(description="Reset demo account data")
+    parser.add_argument("--yes", "-y", action="store_true", help="Skip confirmation")
+    args = parser.parse_args()
+
+    if not args.yes:
+        confirm = input(f"Wipe all data for demo user {DEMO_USER_ID} and reseed? [y/N] ").strip().lower()
+        if confirm != "y":
+            print("Aborted.")
+            return
+
+    client = get_client()
+    print(f"[reset] Wiping demo user: {DEMO_USER_ID}")
+    wipe_demo_data(client)
+
+    print("[reset] Reseeding...")
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).parent / "seed_demo.py")],
+        capture_output=False,
+    )
+    if result.returncode != 0:
+        print(f"[reset] seed_demo.py exited with code {result.returncode}")
+        sys.exit(result.returncode)
+
+    print("[reset] Demo account reset complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""
+Seed the demo account with realistic data for persona:
+  Alex Chen — software engineer, San Francisco
+
+Generates:
+  - profile: Alex Chen, SF location, goals
+  - habit_registry + habits: 7 habits, ~60% completion over 30 days
+  - tasks: 10 tasks (mix of active + completed)
+  - fitness_log: 30-day body composition trend (slow improvement arc)
+  - workout_sessions: varied workouts over 30 days
+  - recovery_metrics: 30 nights of sleep/HRV data
+  - study_log: recent entries
+  - journal_entries: 4 entries with demo persona tone
+
+Usage:
+  python3 scripts/seed_demo.py
+
+Requires DEMO_USER_ID in .env.
+"""
+from __future__ import annotations
+
+import os
+import random
+import sys
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+ROOT = Path(__file__).parent.parent
+load_dotenv(ROOT / ".env")
+sys.path.insert(0, str(Path(__file__).parent))
+from _supabase import get_client
+
+DEMO_USER_ID = os.environ.get("DEMO_USER_ID", "")
+
+
+def require_demo_user_id():
+    if not DEMO_USER_ID:
+        print("[error] DEMO_USER_ID not set in .env")
+        sys.exit(1)
+
+
+def today_minus(n: int) -> str:
+    return str(date.today() - timedelta(days=n))
+
+
+def seed_profile(client):
+    rows = [
+        {"user_id": DEMO_USER_ID, "key": "name",            "value": "Alex"},
+        {"user_id": DEMO_USER_ID, "key": "Identity/Name",   "value": "Alex Chen"},
+        {"user_id": DEMO_USER_ID, "key": "Identity/Role",   "value": "Software Engineer"},
+        {"user_id": DEMO_USER_ID, "key": "Identity/Location","value": "San Francisco, CA"},
+        {"user_id": DEMO_USER_ID, "key": "location_city",   "value": "San Francisco"},
+        {"user_id": DEMO_USER_ID, "key": "weight_goal_lbs", "value": "172"},
+        {"user_id": DEMO_USER_ID, "key": "body_fat_goal_pct","value": "15"},
+        {"user_id": DEMO_USER_ID, "key": "weekly_workout_goal","value": "4"},
+        {"user_id": DEMO_USER_ID, "key": "calorie_goal",    "value": "2200"},
+        {"user_id": DEMO_USER_ID, "key": "protein_goal",    "value": "165"},
+        {"user_id": DEMO_USER_ID, "key": "sleep.goal.hrs",  "value": "8"},
+        {"user_id": DEMO_USER_ID, "key": "pantry_staples",  "value": "olive oil, garlic, onions, rice, pasta, canned tomatoes, eggs, chicken breast"},
+        {"user_id": DEMO_USER_ID, "key": "dietary_preferences","value": "high protein, moderate carbs; no dietary restrictions"},
+        {"user_id": DEMO_USER_ID, "key": "cuisine_preferences","value": "Japanese, Mediterranean, American"},
+    ]
+    client.table("profile").upsert(rows, on_conflict="user_id,key").execute()
+    print(f"[seed] profile: {len(rows)} keys")
+
+
+def seed_habits(client):
+    habit_defs = [
+        ("Morning workout", "fitness",  "💪"),
+        ("Read 20 min",     "learning", "📖"),
+        ("No alcohol",      "health",   "🚫"),
+        ("8h sleep",        "recovery", "😴"),
+        ("Meditate",        "mindset",  "🧘"),
+        ("Code side project","learning","💻"),
+        ("Journal",         "mindset",  "📝"),
+    ]
+
+    # Insert registry
+    registry_rows = [
+        {
+            "user_id": DEMO_USER_ID,
+            "name":    name,
+            "category":cat,
+            "emoji":   emoji,
+            "active":  True,
+        }
+        for name, cat, emoji in habit_defs
+    ]
+    resp = client.table("habit_registry").upsert(
+        registry_rows, on_conflict="user_id,name"
+    ).execute()
+    registry = resp.data
+    print(f"[seed] habit_registry: {len(registry)} habits")
+
+    # Build id map
+    id_map = {r["name"]: r["id"] for r in registry}
+
+    # Generate 30 days of completions at ~60% rate
+    # Some habits are slightly more/less consistent for realism
+    completion_rates = {
+        "Morning workout":  0.55,
+        "Read 20 min":      0.70,
+        "No alcohol":       0.80,
+        "8h sleep":         0.50,
+        "Meditate":         0.45,
+        "Code side project":0.60,
+        "Journal":          0.35,
+    }
+    rng = random.Random(42)  # deterministic seed
+    habit_rows = []
+    for days_ago in range(30, 0, -1):
+        d = today_minus(days_ago)
+        for name, _, _ in habit_defs:
+            if rng.random() < completion_rates[name]:
+                habit_rows.append({
+                    "user_id":   DEMO_USER_ID,
+                    "habit_id":  id_map[name],
+                    "date":      d,
+                    "completed": True,
+                })
+
+    client.table("habits").upsert(
+        habit_rows, on_conflict="habit_id,date"
+    ).execute()
+    print(f"[seed] habits: {len(habit_rows)} completions over 30 days")
+
+
+def seed_tasks(client):
+    tasks = [
+        # Active
+        {"title": "Ship v2 of the search API",         "priority": "high",   "status": "active",    "category": "work",     "due_date": today_minus(-3)},
+        {"title": "Write design doc for auth refactor","priority": "high",   "status": "active",    "category": "work",     "due_date": today_minus(-7)},
+        {"title": "Set up home gym pull-up bar",       "priority": "medium", "status": "active",    "category": "fitness",  "due_date": None},
+        {"title": "Read Designing Data-Intensive Apps","priority": "medium", "status": "active",    "category": "learning", "due_date": None},
+        {"title": "Schedule dentist appointment",      "priority": "low",    "status": "active",    "category": "personal", "due_date": today_minus(-10)},
+        {"title": "Migrate PostgreSQL to v16",         "priority": "medium", "status": "active",    "category": "work",     "due_date": today_minus(-14)},
+        # Completed
+        {"title": "Review PR: rate limiter service",  "priority": "high",   "status": "completed", "category": "work",     "due_date": None, "completed_at": f"{today_minus(2)}T10:30:00Z"},
+        {"title": "Meal prep for the week",           "priority": "low",    "status": "completed", "category": "personal", "due_date": None, "completed_at": f"{today_minus(3)}T18:00:00Z"},
+        {"title": "30-min cardio 3x this week",       "priority": "medium", "status": "completed", "category": "fitness",  "due_date": None, "completed_at": f"{today_minus(1)}T07:15:00Z"},
+        {"title": "Update resume",                    "priority": "low",    "status": "completed", "category": "personal", "due_date": None, "completed_at": f"{today_minus(5)}T20:00:00Z"},
+    ]
+    rows = [{"user_id": DEMO_USER_ID, **t} for t in tasks]
+    client.table("tasks").insert(rows).execute()
+    print(f"[seed] tasks: {len(rows)}")
+
+
+def seed_fitness(client):
+    # 30-day body composition arc: slow improvement
+    # Start: 182 lb, 21% BF → End: 179 lb, 20% BF
+    rng = random.Random(7)
+    fitness_rows = []
+    for days_ago in range(30, 0, -3):  # every 3 days = 10 entries
+        d = today_minus(days_ago)
+        progress = (30 - days_ago) / 30.0  # 0 → 1 over time
+        weight = round(182.0 - (3.0 * progress) + rng.uniform(-0.5, 0.5), 1)
+        bf_pct = round(21.0 - (1.0 * progress) + rng.uniform(-0.3, 0.3), 1)
+        bmi    = round(weight / (70.0 / 0.453592) / (1.78 ** 2) * 703, 1)
+        lean   = round(weight * (1 - bf_pct / 100), 1)
+        fitness_rows.append({
+            "user_id":       DEMO_USER_ID,
+            "date":          d,
+            "weight_lb":     weight,
+            "body_fat_pct":  bf_pct,
+            "bmi":           bmi,
+            "muscle_mass_lb":lean,
+            "visceral_fat":  8.0,
+            "source":        "renpho",
+        })
+    client.table("fitness_log").upsert(fitness_rows, on_conflict="user_id,date,source").execute()
+    print(f"[seed] fitness_log: {len(fitness_rows)} body comp entries")
+
+
+def seed_workouts(client):
+    rng = random.Random(13)
+    workout_templates = [
+        ("Running",          30,  280, 148, "Neighborhood run, good pace"),
+        ("Weight Training",  55,  320, 138, "Push day: bench, shoulder press, triceps"),
+        ("Weight Training",  60,  340, 142, "Pull day: rows, pulldowns, curls"),
+        ("Cycling",          45,  390, 155, "Outdoor ride around the bay trail"),
+        ("HIIT",             25,  310, 162, "Tabata intervals"),
+        ("Weight Training",  50,  310, 135, "Leg day: squats, RDLs, lunges"),
+        ("Running",          40,  360, 152, "Tempo run, 5K in 24 min"),
+        ("Yoga",             45,   95, 105, "Morning flow, recovery session"),
+    ]
+    rows = []
+    used_days: set[int] = set()
+    for days_ago in range(28, 1, -1):
+        if len(rows) >= 18:
+            break
+        # ~4x/week = skip some days
+        if rng.random() > 0.57:
+            continue
+        if days_ago in used_days:
+            continue
+        used_days.add(days_ago)
+        activity, dur, cal, hr, notes = rng.choice(workout_templates)
+        rows.append({
+            "user_id":      DEMO_USER_ID,
+            "date":         today_minus(days_ago),
+            "start_time":   f"0{rng.randint(6,8)}:{'0' if rng.randint(0,1) else '3'}0:00",
+            "activity":     activity,
+            "duration_mins":dur + rng.randint(-5, 5),
+            "calories":     cal + rng.randint(-20, 20),
+            "avg_hr":       hr  + rng.randint(-5, 5),
+            "notes":        notes,
+            "source":       "manual",
+        })
+    client.table("workout_sessions").insert(rows).execute()
+    print(f"[seed] workout_sessions: {len(rows)} sessions")
+
+
+def seed_recovery(client):
+    rng = random.Random(19)
+    rows = []
+    for days_ago in range(30, 0, -1):
+        d = today_minus(days_ago)
+        # Simulate a realistic pattern: weekends slightly worse sleep
+        weekday = (date.today() - timedelta(days=days_ago)).weekday()  # 0=Mon
+        is_weekend = weekday >= 5
+        base_sleep = 6.8 if is_weekend else 7.4
+        total_sleep = round(base_sleep + rng.uniform(-0.6, 0.6), 2)
+        deep  = round(total_sleep * rng.uniform(0.18, 0.22), 2)
+        rem   = round(total_sleep * rng.uniform(0.22, 0.27), 2)
+        hrv   = int(rng.gauss(52, 8))
+        rhr   = int(rng.gauss(58, 3))
+        readiness = int(min(100, max(40, rng.gauss(72, 10))))
+        sleep_score = int(min(100, max(40, rng.gauss(74, 8))))
+        rows.append({
+            "user_id":        DEMO_USER_ID,
+            "date":           d,
+            "total_sleep_hrs":total_sleep,
+            "deep_hrs":       deep,
+            "rem_hrs":        rem,
+            "avg_hrv":        max(25, hrv),
+            "resting_hr":     max(45, rhr),
+            "readiness":      readiness,
+            "sleep_score":    sleep_score,
+            "active_cal":     int(rng.gauss(450, 80)),
+            "source":         "oura",
+        })
+    client.table("recovery_metrics").upsert(rows, on_conflict="user_id,date").execute()
+    print(f"[seed] recovery_metrics: {len(rows)} nights")
+
+
+def seed_study_log(client):
+    entries = [
+        {"date": today_minus(2),  "subject": "System Design",     "duration_mins": 45, "notes": "Read chapter on consistent hashing and distributed caches"},
+        {"date": today_minus(4),  "subject": "TypeScript",         "duration_mins": 60, "notes": "Worked through advanced generics and conditional types"},
+        {"date": today_minus(7),  "subject": "System Design",     "duration_mins": 50, "notes": "Kafka vs RabbitMQ comparison, studied message queue patterns"},
+        {"date": today_minus(10), "subject": "Algorithms",         "duration_mins": 40, "notes": "LeetCode: binary search problems, sliding window patterns"},
+        {"date": today_minus(14), "subject": "Go",                 "duration_mins": 75, "notes": "Built a small HTTP server with custom middleware chain"},
+    ]
+    rows = [{"user_id": DEMO_USER_ID, **e} for e in entries]
+    client.table("study_log").insert(rows).execute()
+    print(f"[seed] study_log: {len(rows)} entries")
+
+
+def seed_journal(client):
+    entries = [
+        {
+            "date":     today_minus(1),
+            "content":  "Good training week. Hit 4 workouts, sleep has been better since cutting caffeine after 2pm. The search API refactor is almost done — need to ship it by EOD Thursday.",
+            "response": "Four workouts in a week with improved sleep consistency is real progress. Cutting late caffeine is one of the highest-ROI sleep interventions — worth keeping. Thursday deadline on the search API: block 2 hours tomorrow morning while focus is high.",
+        },
+        {
+            "date":     today_minus(5),
+            "content":  "Struggled with motivation this week. Only made it to the gym twice. Work has been stressful — big deployment went sideways and we spent most of Thursday debugging. Didn't sleep great either.",
+            "response": "Deployment incidents are draining — context switches plus the stress carry into recovery. Two workouts during a high-stress week is not a failure, it's appropriate load management. Sleep quality after incidents is usually worse. Prioritize one simple, low-demand workout this weekend to reset.",
+        },
+        {
+            "date":     today_minus(12),
+            "content":  "Feeling really good lately. Weight is trending down, workouts feel strong. Starting to think about running a half marathon in the spring.",
+            "response": "Trend confirmation: weight down 1.8 lb over three weeks, body fat moving in the right direction. Half marathon in spring is feasible — base mileage is already there from the weekly runs. Recommend picking a specific race date; having it on the calendar changes training discipline.",
+        },
+        {
+            "date":     today_minus(20),
+            "content":  "Trying to get back into reading more. Used to read a book a week in college, now barely finish one a month. Too much time on my phone in the evenings.",
+            "response": "Reading volume drops when phone use fills the same time slot — they compete directly. The 20-min daily reading habit you added addresses this if applied consistently in the pre-sleep window. Rate yourself on the habit at end of week rather than end of day; it reduces the friction of individual misses.",
+        },
+    ]
+    rows = [{"user_id": DEMO_USER_ID, **e} for e in entries]
+    client.table("journal_entries").insert(rows).execute()
+    print(f"[seed] journal_entries: {len(rows)} entries")
+
+
+def seed_recipes(client):
+    recipes = [
+        {
+            "name":         "High-Protein Chicken Bowl",
+            "cuisine":      "American",
+            "ingredients":  "chicken breast 6oz, brown rice 1 cup cooked, broccoli 1 cup, olive oil, garlic, soy sauce, sesame oil",
+            "instructions": "Season chicken with garlic and olive oil, grill or pan-sear 6 min/side. Serve over rice with steamed broccoli. Drizzle soy sauce and sesame oil.",
+            "tags":         ["high-protein", "meal-prep", "quick"],
+        },
+        {
+            "name":         "Greek Salmon with Tzatziki",
+            "cuisine":      "Mediterranean",
+            "ingredients":  "salmon fillet 6oz, cucumber, Greek yogurt, dill, lemon, garlic, olive oil, cherry tomatoes, spinach",
+            "instructions": "Marinate salmon in lemon, olive oil, garlic. Grill 4 min/side. Make tzatziki: grated cucumber + yogurt + dill + garlic. Serve with salad.",
+            "tags":         ["high-protein", "omega-3", "mediterranean"],
+        },
+        {
+            "name":         "Overnight Oats",
+            "cuisine":      "American",
+            "ingredients":  "rolled oats 1/2 cup, Greek yogurt 1/2 cup, almond milk 1/2 cup, chia seeds 1 tbsp, banana, honey, mixed berries",
+            "instructions": "Combine oats, yogurt, milk, chia seeds in jar. Refrigerate overnight. Top with banana and berries before eating.",
+            "tags":         ["breakfast", "meal-prep", "high-protein"],
+        },
+        {
+            "name":         "Spicy Tuna Rice Bowl",
+            "cuisine":      "Japanese",
+            "ingredients":  "tuna canned 5oz, white rice 1 cup cooked, sriracha, mayo 1 tbsp, cucumber, avocado, soy sauce, sesame seeds",
+            "instructions": "Mix tuna with sriracha and mayo. Build bowl: rice base, tuna, sliced cucumber, avocado. Top with soy sauce and sesame seeds.",
+            "tags":         ["quick", "japanese", "high-protein"],
+        },
+        {
+            "name":         "Turkey and Veggie Stir Fry",
+            "cuisine":      "American",
+            "ingredients":  "ground turkey 8oz, bell peppers 2, snap peas 1 cup, onion, garlic, ginger, soy sauce, oyster sauce, sesame oil, brown rice",
+            "instructions": "Brown turkey in wok. Add garlic, ginger, onion, peppers, snap peas. Stir fry 5 min. Add sauces, toss, serve over rice.",
+            "tags":         ["high-protein", "meal-prep", "quick"],
+        },
+    ]
+    rows = [{"user_id": DEMO_USER_ID, **r} for r in recipes]
+    client.table("recipes").insert(rows).execute()
+    print(f"[seed] recipes: {len(rows)} recipes")
+
+
+def main():
+    require_demo_user_id()
+    client = get_client()
+
+    print(f"[seed] Seeding demo account: {DEMO_USER_ID}")
+    seed_profile(client)
+    seed_habits(client)
+    seed_tasks(client)
+    seed_fitness(client)
+    seed_workouts(client)
+    seed_recovery(client)
+    seed_study_log(client)
+    seed_journal(client)
+    seed_recipes(client)
+    print("[seed] Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync-fitbit.py
+++ b/scripts/sync-fitbit.py
@@ -46,7 +46,7 @@ from dotenv import load_dotenv
 ROOT = Path(__file__).parent.parent
 load_dotenv(ROOT / ".env")
 sys.path.insert(0, str(Path(__file__).parent))
-from _supabase import get_client, upsert, log_sync, urlopen_with_retry, HTTP_TIMEOUT
+from _supabase import get_client, get_owner_user_id, upsert, log_sync, urlopen_with_retry, HTTP_TIMEOUT
 
 FITBIT_AUTH_URL = "https://www.fitbit.com/oauth2/authorize"
 FITBIT_TOKEN_URL = "https://api.fitbit.com/oauth2/token"
@@ -222,12 +222,13 @@ def fetch_workouts(access_token, start_date, end_date):
     return rows
 
 
-def existing_keys(client) -> set:
+def existing_keys(client, user_id: str) -> set:
     """Build dedup keys from Supabase to avoid re-inserting the same workout."""
     rows = (
         client.table("workout_sessions")
         .select("date,start_time,activity")
         .eq("source", "fitbit")
+        .eq("user_id", user_id)
         .execute()
         .data
     )
@@ -287,8 +288,8 @@ def fetch_body_data(access_token, start_date, end_date, raw=False):
     return rows
 
 
-def existing_body_dates(client) -> set:
-    rows = client.table("fitness_log").select("date").eq("source", "fitbit_body").execute().data
+def existing_body_dates(client, user_id: str) -> set:
+    rows = client.table("fitness_log").select("date").eq("source", "fitbit_body").eq("user_id", user_id).execute().data
     return {r["date"] for r in rows}
 
 
@@ -352,9 +353,10 @@ def main():
     workout_rows = fetch_workouts(access_token, start_str, end_str)
 
     client = get_client()
+    owner_user_id = get_owner_user_id()
 
     # Write body composition
-    existing_body = existing_body_dates(client)
+    existing_body = existing_body_dates(client, owner_user_id)
     new_body = [r for r in body_rows if r["date"] not in existing_body]
 
     if new_body:
@@ -370,7 +372,7 @@ def main():
             print(f"  {r['date']} — {' | '.join(parts) if parts else 'no fields'}")
 
     # Write workouts
-    existing = existing_keys(client)
+    existing = existing_keys(client, owner_user_id)
     new_workouts = [r for r in workout_rows if r["_key"] not in existing]
 
     if new_workouts:
@@ -391,15 +393,15 @@ def main():
 
     body_written = 0
     if new_body:
-        sb_body = [{**r, "source": "fitbit_body"} for r in sorted(new_body, key=lambda x: x["date"])]
+        sb_body = [{**r, "source": "fitbit_body", "user_id": owner_user_id} for r in sorted(new_body, key=lambda x: x["date"])]
         body_written = upsert(client, "fitness_log", sb_body)
         log_sync(client, "fitbit_body", "ok", body_written)
         print(f"[sync-fitbit] Synced {body_written} body composition row(s) to fitness_log.")
 
     workout_written = 0
     if new_workouts:
-        # Strip the internal dedup key before inserting
-        sb_rows = [{k: v for k, v in r.items() if k != "_key"} for r in new_workouts]
+        # Strip the internal dedup key before inserting, add user_id
+        sb_rows = [{k: v for k, v in r.items() if k != "_key"} | {"user_id": owner_user_id} for r in new_workouts]
         workout_written = upsert(client, "workout_sessions", sb_rows)
         log_sync(client, "fitbit", "ok", workout_written)
         print(f"[sync-fitbit] Synced {workout_written} workout row(s) to workout_sessions.")

--- a/scripts/sync-googlefit.py
+++ b/scripts/sync-googlefit.py
@@ -44,7 +44,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 ROOT = Path(__file__).parent.parent
 load_dotenv(ROOT / ".env")
 sys.path.insert(0, str(Path(__file__).parent))
-from _supabase import get_client, upsert, log_sync, urlopen_with_retry
+from _supabase import get_client, get_owner_user_id, upsert, log_sync, urlopen_with_retry
 
 
 FITNESS_SCOPES = ["https://www.googleapis.com/auth/fitness.body.read"]
@@ -209,11 +209,11 @@ def fetch_body_composition(creds, start_ms, end_ms) -> tuple[list[dict], dict[st
     return rows, type_to_sources
 
 
-def existing_dates(client) -> set:
+def existing_dates(client, user_id: str) -> set:
     # Skip dates that already have body-comp data from a richer source (any row with bf%)
     # and dates we've already written via google_fit (weight-only)
-    rich = client.table("fitness_log").select("date").not_.is_("body_fat_pct", "null").execute().data
-    gfit = client.table("fitness_log").select("date").eq("source", "google_fit").execute().data
+    rich = client.table("fitness_log").select("date").not_.is_("body_fat_pct", "null").eq("user_id", user_id).execute().data
+    gfit = client.table("fitness_log").select("date").eq("source", "google_fit").eq("user_id", user_id).execute().data
     return {r["date"] for r in rich} | {r["date"] for r in gfit}
 
 
@@ -275,7 +275,8 @@ def main():
         return
 
     client = get_client()
-    existing = existing_dates(client)
+    owner_user_id = get_owner_user_id()
+    existing = existing_dates(client, owner_user_id)
     new_rows = [r for r in rows if r["date"] not in existing]
 
     if not new_rows:
@@ -300,7 +301,7 @@ def main():
             return
 
     sb_rows = [
-        {**{k: v for k, v in r.items() if v is not None}, "source": "google_fit"}
+        {**{k: v for k, v in r.items() if v is not None}, "source": "google_fit", "user_id": owner_user_id}
         for r in sorted(new_rows, key=lambda x: x["date"])
     ]
     written = upsert(client, "fitness_log", sb_rows)

--- a/scripts/sync-oura.py
+++ b/scripts/sync-oura.py
@@ -25,7 +25,7 @@ from dotenv import load_dotenv
 ROOT = Path(__file__).parent.parent
 load_dotenv(ROOT / ".env")
 sys.path.insert(0, str(Path(__file__).parent))
-from _supabase import get_client, upsert, log_sync, urlopen_with_retry
+from _supabase import get_client, get_owner_user_id, upsert, log_sync, urlopen_with_retry
 
 
 def oura_get(endpoint: str, start_date: str, end_date: str, required: bool = True) -> dict | None:
@@ -309,22 +309,23 @@ def fetch_oura_workouts(start_dt: str, end_dt: str) -> list[dict]:
     return rows
 
 
-def existing_dates(client) -> set:
-    rows = client.table("recovery_metrics").select("date").execute().data
+def existing_dates(client, user_id: str) -> set:
+    rows = client.table("recovery_metrics").select("date").eq("user_id", user_id).execute().data
     return {r["date"] for r in rows}
 
 
-def sync_oura_workouts(client, workout_rows: list[dict], start_date: str, end_date: str) -> int:
+def sync_oura_workouts(client, workout_rows: list[dict], start_date: str, end_date: str, user_id: str) -> int:
     """
     Replace all oura-source workout_sessions rows in the date range, then insert fresh.
     Returns number of rows written.
     """
     if not workout_rows:
         return 0
-    # Clear existing oura workouts in the range to avoid duplicates
+    # Clear existing oura workouts in the range to avoid duplicates (owner only)
     client.table("workout_sessions") \
         .delete() \
         .eq("source", "oura") \
+        .eq("user_id", user_id) \
         .gte("date", start_date) \
         .lte("date", end_date) \
         .execute()
@@ -368,7 +369,8 @@ def main():
         return
 
     client = get_client()
-    existing = existing_dates(client)
+    owner_user_id = get_owner_user_id()
+    existing = existing_dates(client, owner_user_id)
     new_dates    = [d for d in all_dates if d not in existing]
     update_dates = [d for d in all_dates if d in existing]
 
@@ -450,6 +452,7 @@ def main():
             meta["hr_max_day"] = hr["hr_max_day"]
 
         sb_rows.append({
+            "user_id":         owner_user_id,
             "date":            d,
             "bedtime":         sd.get("bedtime"),
             "total_sleep_hrs": sd.get("total_sleep_hrs"),
@@ -470,7 +473,9 @@ def main():
         })
 
     written = upsert(client, "recovery_metrics", sb_rows, conflict="date")
-    workout_written = sync_oura_workouts(client, workout_rows, start_str, now.strftime("%Y-%m-%d"))
+    # Add user_id to workout rows before inserting
+    workout_rows_with_uid = [{**r, "user_id": owner_user_id} for r in workout_rows]
+    workout_written = sync_oura_workouts(client, workout_rows_with_uid, start_str, now.strftime("%Y-%m-%d"), owner_user_id)
     log_sync(client, "oura", "ok", written + workout_written)
     print(f"[sync-oura] Upserted {written} recovery row(s), {workout_written} workout row(s) to Supabase.")
 

--- a/supabase/migrations/20260413000000_add_user_id_multitenancy.sql
+++ b/supabase/migrations/20260413000000_add_user_id_multitenancy.sql
@@ -1,0 +1,204 @@
+-- Mr. Bridge — Multi-tenancy Migration
+-- Adds user_id to all 14 data tables, backfills real owner, updates RLS.
+-- sync_log stays global (no user scope needed).
+--
+-- Strategy:
+--   1. Add user_id as nullable
+--   2. Backfill all existing rows with the real owner's auth UID
+--      (first non-demo user in auth.users, or the single existing user)
+--   3. Set NOT NULL
+--   4. Drop old "authenticated full access" policies
+--   5. Create new per-user RLS policies
+
+-- ============================================================
+-- STEP 1 — Add nullable user_id to all 14 tables
+-- ============================================================
+
+alter table habit_registry    add column if not exists user_id uuid references auth.users(id) on delete cascade;
+alter table habits             add column if not exists user_id uuid references auth.users(id) on delete cascade;
+alter table tasks              add column if not exists user_id uuid references auth.users(id) on delete cascade;
+alter table study_log          add column if not exists user_id uuid references auth.users(id) on delete cascade;
+alter table fitness_log        add column if not exists user_id uuid references auth.users(id) on delete cascade;
+alter table workout_sessions   add column if not exists user_id uuid references auth.users(id) on delete cascade;
+alter table recovery_metrics   add column if not exists user_id uuid references auth.users(id) on delete cascade;
+alter table recipes            add column if not exists user_id uuid references auth.users(id) on delete cascade;
+alter table meal_log           add column if not exists user_id uuid references auth.users(id) on delete cascade;
+alter table profile            add column if not exists user_id uuid references auth.users(id) on delete cascade;
+alter table chat_sessions      add column if not exists user_id uuid references auth.users(id) on delete cascade;
+alter table chat_messages      add column if not exists user_id uuid references auth.users(id) on delete cascade;
+alter table timer_state        add column if not exists user_id uuid references auth.users(id) on delete cascade;
+alter table journal_entries    add column if not exists user_id uuid references auth.users(id) on delete cascade;
+
+-- ============================================================
+-- STEP 2 — Backfill existing rows with the real owner's UID
+-- ============================================================
+
+do $$
+declare
+  owner_uid uuid;
+begin
+  -- Find the real owner: first user in auth.users who is not the demo account.
+  -- If demo@mr-bridge.app doesn't exist yet, this just returns the first user.
+  select id into owner_uid
+  from auth.users
+  where email != 'demo@mr-bridge.app'
+  order by created_at asc
+  limit 1;
+
+  if owner_uid is null then
+    raise notice 'No owner found in auth.users — skipping backfill. Run migration again after creating the real account.';
+    return;
+  end if;
+
+  raise notice 'Backfilling all tables with owner_uid = %', owner_uid;
+
+  update habit_registry    set user_id = owner_uid where user_id is null;
+  update habits             set user_id = owner_uid where user_id is null;
+  update tasks              set user_id = owner_uid where user_id is null;
+  update study_log          set user_id = owner_uid where user_id is null;
+  update fitness_log        set user_id = owner_uid where user_id is null;
+  update workout_sessions   set user_id = owner_uid where user_id is null;
+  update recovery_metrics   set user_id = owner_uid where user_id is null;
+  update recipes            set user_id = owner_uid where user_id is null;
+  update meal_log           set user_id = owner_uid where user_id is null;
+  update profile            set user_id = owner_uid where user_id is null;
+  update chat_sessions      set user_id = owner_uid where user_id is null;
+  update chat_messages      set user_id = owner_uid where user_id is null;
+  update timer_state        set user_id = owner_uid where user_id is null;
+  update journal_entries    set user_id = owner_uid where user_id is null;
+end $$;
+
+-- ============================================================
+-- STEP 3 — Enforce NOT NULL now that rows are backfilled
+-- ============================================================
+
+alter table habit_registry    alter column user_id set not null;
+alter table habits             alter column user_id set not null;
+alter table tasks              alter column user_id set not null;
+alter table study_log          alter column user_id set not null;
+alter table fitness_log        alter column user_id set not null;
+alter table workout_sessions   alter column user_id set not null;
+alter table recovery_metrics   alter column user_id set not null;
+alter table recipes            alter column user_id set not null;
+alter table meal_log           alter column user_id set not null;
+alter table profile            alter column user_id set not null;
+alter table chat_sessions      alter column user_id set not null;
+alter table chat_messages      alter column user_id set not null;
+alter table timer_state        alter column user_id set not null;
+alter table journal_entries    alter column user_id set not null;
+
+-- Add indexes for fast per-user queries
+create index if not exists habit_registry_user_id_idx    on habit_registry    (user_id);
+create index if not exists habits_user_id_idx             on habits             (user_id);
+create index if not exists tasks_user_id_idx              on tasks              (user_id);
+create index if not exists study_log_user_id_idx          on study_log          (user_id);
+create index if not exists fitness_log_user_id_idx        on fitness_log        (user_id);
+create index if not exists workout_sessions_user_id_idx   on workout_sessions   (user_id);
+create index if not exists recovery_metrics_user_id_idx   on recovery_metrics   (user_id);
+create index if not exists recipes_user_id_idx            on recipes            (user_id);
+create index if not exists meal_log_user_id_idx           on meal_log           (user_id);
+create index if not exists profile_user_id_idx            on profile            (user_id);
+create index if not exists chat_sessions_user_id_idx      on chat_sessions      (user_id);
+create index if not exists chat_messages_user_id_idx      on chat_messages      (user_id);
+create index if not exists timer_state_user_id_idx        on timer_state        (user_id);
+create index if not exists journal_entries_user_id_idx    on journal_entries    (user_id);
+
+-- ============================================================
+-- STEP 4 — Drop the old "authenticated full access" policies
+-- ============================================================
+
+drop policy if exists "authenticated full access" on habit_registry;
+drop policy if exists "authenticated full access" on habits;
+drop policy if exists "authenticated full access" on tasks;
+drop policy if exists "authenticated full access" on study_log;
+drop policy if exists "authenticated full access" on fitness_log;
+drop policy if exists "authenticated full access" on workout_sessions;
+drop policy if exists "authenticated full access" on recovery_metrics;
+drop policy if exists "authenticated full access" on recipes;
+drop policy if exists "authenticated full access" on meal_log;
+drop policy if exists "authenticated full access" on profile;
+drop policy if exists "authenticated full access" on sync_log;
+drop policy if exists "authenticated full access" on chat_sessions;
+drop policy if exists "authenticated full access" on chat_messages;
+drop policy if exists "authenticated full access" on timer_state;
+drop policy if exists "authenticated full access" on journal_entries;
+
+-- ============================================================
+-- STEP 5 — New per-user RLS policies (own data only)
+-- ============================================================
+
+create policy "users access own data" on habit_registry
+  for all to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "users access own data" on habits
+  for all to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "users access own data" on tasks
+  for all to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "users access own data" on study_log
+  for all to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "users access own data" on fitness_log
+  for all to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "users access own data" on workout_sessions
+  for all to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "users access own data" on recovery_metrics
+  for all to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "users access own data" on recipes
+  for all to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "users access own data" on meal_log
+  for all to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "users access own data" on profile
+  for all to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- sync_log: any authenticated user can read/write (global integration log)
+create policy "authenticated full access" on sync_log
+  for all to authenticated
+  using (true)
+  with check (true);
+
+create policy "users access own data" on chat_sessions
+  for all to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "users access own data" on chat_messages
+  for all to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "users access own data" on timer_state
+  for all to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "users access own data" on journal_entries
+  for all to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.2.11",
+        "@ai-sdk/groq": "^3.0.35",
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.49.4",
         "ai": "^4.3.15",
@@ -45,6 +46,51 @@
       },
       "peerDependencies": {
         "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/groq": {
+      "version": "3.0.35",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/groq/-/groq-3.0.35.tgz",
+      "integrity": "sha512-LXoPwSKaqXst9LyLN2J7gK8n7RldQLbP2zsnBYxXcOsXKrtceksqtbsmGXujvab2TM9FisquAw/ZG2hTbD5vnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/groq/node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/groq/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
@@ -867,6 +913,12 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.103.0",
@@ -1967,6 +2019,15 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.2.11",
+    "@ai-sdk/groq": "^3.0.35",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.49.4",
     "ai": "^4.3.15",

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -1,10 +1,58 @@
 import { anthropic } from "@ai-sdk/anthropic";
+import { createGroq } from "@ai-sdk/groq";
 import { todayString, daysAgoString, startOfDayRFC3339, endOfDayRFC3339, addDays } from "@/lib/timezone";
 import { streamText, tool, jsonSchema, wrapLanguageModel } from "ai";
 import type { LanguageModelV1Middleware } from "ai";
 import { createServiceClient } from "@/lib/supabase/service";
+import { createClient } from "@/lib/supabase/server";
 import { google } from "googleapis";
 import { getGoogleAuthClient } from "@/lib/google-auth";
+
+// ── Demo mock data ───────────────────────────────────────────────────────────
+const DEMO_EMAILS = [
+  {
+    id: "demo-email-1",
+    from: "UPS Tracking <tracking@ups.com>",
+    subject: "Your package is out for delivery today",
+    date: "Mon, 13 Apr 2026 08:14:00 -0700",
+    body: "Hi Alex, your package is out for delivery today. Estimated delivery: today by 8pm. Track at ups.com.",
+  },
+  {
+    id: "demo-email-2",
+    from: "Alaska Airlines <noreply@alaskaair.com>",
+    subject: "Flight Confirmation: SFO → SEA Apr 20",
+    date: "Thu, 10 Apr 2026 11:02:00 -0700",
+    body: "Your flight AS 321 on April 20 from San Francisco (SFO) to Seattle (SEA) is confirmed. Departs 7:45am, arrives 9:50am. Confirmation code: KXZP94.",
+  },
+  {
+    id: "demo-email-3",
+    from: "Figma <notifications@figma.com>",
+    subject: "Action required: Accept team invite from Lena Park",
+    date: "Mon, 13 Apr 2026 09:47:00 -0700",
+    body: "Lena Park has invited you to join the 'Product Design' team on Figma. Click here to accept.",
+  },
+  {
+    id: "demo-email-4",
+    from: "Hacker News Digest <digest@hackernewsdigest.com>",
+    subject: "Top stories: Llama 4 benchmarks, SQLite as a backend",
+    date: "Mon, 13 Apr 2026 06:30:00 -0700",
+    body: "Top HN stories this week: Llama 4 beats GPT-4o on several benchmarks; SQLite as production backend — when it makes sense; Cloudflare Workers hits 100M active deployments.",
+  },
+  {
+    id: "demo-email-5",
+    from: "DocuSign <dse@docusign.net>",
+    subject: "Invoice #4421 — please sign",
+    date: "Fri, 11 Apr 2026 15:12:00 -0700",
+    body: "Alex Chen, a document has been sent to you for signature by Acme Corp. Invoice #4421 for $1,240.00 is ready for your review. This request will expire in 7 days.",
+  },
+];
+
+const DEMO_CALENDAR_EVENTS = [
+  { title: "Morning run", start: `${new Date().toISOString().slice(0, 10)}T06:30:00`, end: `${new Date().toISOString().slice(0, 10)}T07:15:00`, allDay: false, calendar: "Alex Chen", calendarType: "primary", location: null },
+  { title: "Team standup", start: `${new Date().toISOString().slice(0, 10)}T09:00:00`, end: `${new Date().toISOString().slice(0, 10)}T09:30:00`, allDay: false, calendar: "Alex Chen", calendarType: "primary", location: "Google Meet" },
+  { title: "Lunch w/ Priya", start: `${new Date().toISOString().slice(0, 10)}T12:30:00`, end: `${new Date().toISOString().slice(0, 10)}T13:30:00`, allDay: false, calendar: "Alex Chen", calendarType: "primary", location: "Tartine Manufactory" },
+  { title: "Gym — push day", start: `${new Date().toISOString().slice(0, 10)}T18:00:00`, end: `${new Date().toISOString().slice(0, 10)}T19:00:00`, allDay: false, calendar: "Alex Chen", calendarType: "primary", location: "Equinox SoMa" },
+];
 
 const retryOnOverload: LanguageModelV1Middleware = {
   wrapStream: async ({ doStream }) => {
@@ -75,16 +123,26 @@ export async function POST(req: Request) {
   const { messages, sessionId } = await req.json();
   console.log("[chat] sessionId:", sessionId, "messages:", messages.length);
 
+  // Resolve the authenticated user (needed for per-user data scoping)
+  const serverClient = await createClient();
+  const { data: { user } } = await serverClient.auth.getUser();
+  const userId = user?.id ?? null;
+  const demoUserId = process.env.DEMO_USER_ID ?? null;
+  const isDemo = !!(userId && demoUserId && userId === demoUserId);
+
   const supabase = createServiceClient();
 
   // Fetch user name from profile for personalised system prompt
   let userName: string | null = null;
-  const { data: nameRow } = await supabase
-    .from("profile")
-    .select("value")
-    .eq("key", "name")
-    .maybeSingle();
-  if (nameRow) userName = nameRow.value as string;
+  if (userId) {
+    const { data: nameRow } = await supabase
+      .from("profile")
+      .select("value")
+      .eq("user_id", userId)
+      .eq("key", "name")
+      .maybeSingle();
+    if (nameRow) userName = nameRow.value as string;
+  }
 
   // Load the last 20 messages from this session as context
   let contextMessages: { role: "user" | "assistant"; content: string }[] = [];
@@ -104,8 +162,28 @@ export async function POST(req: Request) {
     }
   }
 
-  const userLabel = userName ?? "the user";
-  const systemPrompt = `You are Mr. Bridge, ${userLabel}'s personal AI assistant.
+  const userLabel = userName ?? (isDemo ? "Alex" : "the user");
+  const systemPrompt = isDemo
+    ? `You are Mr. Bridge, a personal AI assistant. Today's date is ${todayString()}.
+You are currently running in demo mode for a fictional persona: Alex Chen, a software engineer based in San Francisco.
+Address the user as "Alex" — naturally in conversation, not robotically after every sentence.
+
+Style: Direct, structured, high-density. No filler, no emojis, no motivational language.
+Quantify wherever possible. Conservative estimates. Lead with the answer, then reasoning.
+Do not narrate before calling tools. Call the tool directly and respond after.
+
+This is a demo account with realistic but fictional data. All data changes are reset nightly.
+You have access to Alex's demo data via tools: tasks, habits, fitness, recovery, profile, recipes, meal log, Gmail (simulated), and Calendar (simulated).
+
+Tools available:
+- get_tasks, add_task, complete_task
+- get_habits_today, log_habit
+- get_fitness_summary
+- get_profile, update_profile
+- search_gmail, get_email_body (returns demo emails)
+- list_calendar_events, create_calendar_event (returns demo events)
+- get_recipes, log_meal`
+    : `You are Mr. Bridge, ${userLabel}'s personal AI assistant.
 Today's date is ${todayString()}.
 ${userName ? `Address the user as "${userName}" — use their name naturally in conversation, not robotically after every sentence.` : 'If you learn the user\'s name during the conversation, use it naturally going forward.'}
 
@@ -164,11 +242,13 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
         },
       }),
       execute: async ({ status = "active" }) => {
-        const { data, error } = await supabase
+        let q = supabase
           .from("tasks")
           .select("id, title, priority, status, due_date, category, completed_at, created_at")
           .eq("status", status)
           .order("created_at", { ascending: false });
+        if (userId) q = q.eq("user_id", userId);
+        const { data, error } = await q;
         if (error) return { error: error.message };
         return data ?? [];
       },
@@ -201,7 +281,7 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
         }
         const { data, error } = await supabase
           .from("tasks")
-          .insert({ title, priority: priority ?? null, category: category ?? null, due_date: due_date ?? null, status: "active" })
+          .insert({ user_id: userId, title, priority: priority ?? null, category: category ?? null, due_date: due_date ?? null, status: "active" })
           .select("id, title, priority, status, due_date, category, created_at")
           .single();
         if (error) return { error: error.message };
@@ -219,12 +299,12 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
         },
       }),
       execute: async ({ id }) => {
-        const { data, error } = await supabase
+        let q = supabase
           .from("tasks")
           .update({ status: "completed", completed_at: new Date().toISOString() })
-          .eq("id", id)
-          .select("id, title, status, completed_at")
-          .single();
+          .eq("id", id);
+        if (userId) q = q.eq("user_id", userId);
+        const { data, error } = await q.select("id, title, status, completed_at").single();
         if (error) return { error: error.message };
         return data;
       },
@@ -240,10 +320,10 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
       }),
       execute: async ({ date }) => {
         const targetDate = date ?? todayString();
-        const [registryResult, logsResult] = await Promise.all([
-          supabase.from("habit_registry").select("id, name, emoji, category").eq("active", true),
-          supabase.from("habits").select("habit_id, completed, notes").eq("date", targetDate),
-        ]);
+        let regQ = supabase.from("habit_registry").select("id, name, emoji, category").eq("active", true);
+        let logQ = supabase.from("habits").select("habit_id, completed, notes").eq("date", targetDate);
+        if (userId) { regQ = regQ.eq("user_id", userId); logQ = logQ.eq("user_id", userId); }
+        const [registryResult, logsResult] = await Promise.all([regQ, logQ]);
         if (registryResult.error) return { error: registryResult.error.message };
         const logMap = new Map(
           (logsResult.data ?? []).map((l: { habit_id: string; completed: boolean; notes: string | null }) => [l.habit_id, l])
@@ -272,19 +352,21 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
       }),
       execute: async ({ name, date, notes }) => {
         const targetDate = date ?? todayString();
-        const { data: habits, error: lookupError } = await supabase
+        let habQ = supabase
           .from("habit_registry")
           .select("id, name")
           .ilike("name", `%${name}%`)
           .eq("active", true)
           .limit(1);
+        if (userId) habQ = habQ.eq("user_id", userId);
+        const { data: habits, error: lookupError } = await habQ;
         if (lookupError) return { error: lookupError.message };
         if (!habits || habits.length === 0) return { error: `No active habit matching "${name}" found.` };
         const habit = habits[0];
         const { data, error } = await supabase
           .from("habits")
           .upsert(
-            { habit_id: habit.id, date: targetDate, completed: true, notes: notes ?? null },
+            { user_id: userId, habit_id: habit.id, date: targetDate, completed: true, notes: notes ?? null },
             { onConflict: "habit_id,date" }
           )
           .select("habit_id, date, completed, notes")
@@ -308,24 +390,25 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
       execute: async ({ days = 7 }) => {
         const sinceStr = daysAgoString(days);
 
-        const [bodyCompResult, workoutsResult, recoveryResult] = await Promise.all([
-          supabase
-            .from("fitness_log")
-            .select("date, weight_lb, body_fat_pct, bmi, muscle_mass_lb, visceral_fat, source")
-            .not("body_fat_pct", "is", null)
-            .order("date", { ascending: false })
-            .limit(2),
-          supabase
-            .from("workout_sessions")
-            .select("date, activity, duration_mins, calories, avg_hr, notes")
-            .gte("date", sinceStr)
-            .order("date", { ascending: false }),
-          supabase
-            .from("recovery_metrics")
-            .select("date, avg_hrv, resting_hr, sleep_score, readiness, source")
-            .order("date", { ascending: false })
-            .limit(1),
-        ]);
+        let bodyQ = supabase
+          .from("fitness_log")
+          .select("date, weight_lb, body_fat_pct, bmi, muscle_mass_lb, visceral_fat, source")
+          .not("body_fat_pct", "is", null)
+          .order("date", { ascending: false })
+          .limit(2);
+        let workQ = supabase
+          .from("workout_sessions")
+          .select("date, activity, duration_mins, calories, avg_hr, notes")
+          .gte("date", sinceStr)
+          .order("date", { ascending: false });
+        let recQ = supabase
+          .from("recovery_metrics")
+          .select("date, avg_hrv, resting_hr, sleep_score, readiness, source")
+          .order("date", { ascending: false })
+          .limit(1);
+        if (userId) { bodyQ = bodyQ.eq("user_id", userId); workQ = workQ.eq("user_id", userId); recQ = recQ.eq("user_id", userId); }
+
+        const [bodyCompResult, workoutsResult, recoveryResult] = await Promise.all([bodyQ, workQ, recQ]);
 
         return {
           body_composition: bodyCompResult.data ?? [],
@@ -342,10 +425,9 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
         properties: {},
       }),
       execute: async () => {
-        const { data, error } = await supabase
-          .from("profile")
-          .select("key, value, updated_at")
-          .order("key", { ascending: true });
+        let q = supabase.from("profile").select("key, value, updated_at").order("key", { ascending: true });
+        if (userId) q = q.eq("user_id", userId);
+        const { data, error } = await q;
         if (error) return { error: error.message };
         return data ?? [];
       },
@@ -377,10 +459,10 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
         },
       }),
       execute: async ({ updates }) => {
-        const rows = updates.map(({ key, value }) => ({ key, value }));
+        const rows = updates.map(({ key, value }) => ({ key, value, ...(userId ? { user_id: userId } : {}) }));
         const { data, error } = await supabase
           .from("profile")
-          .upsert(rows, { onConflict: "key" })
+          .upsert(rows, { onConflict: "user_id,key" })
           .select("key, value, updated_at");
         if (error) return { error: error.message };
         return { written: data ?? [] };
@@ -405,6 +487,14 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
         },
       }),
       execute: async ({ query, max_results = 5 }) => {
+        if (isDemo) {
+          // Return mock emails filtered loosely by query keywords
+          const q = query.toLowerCase();
+          const mockEmails = DEMO_EMAILS.filter((e) =>
+            !q || e.subject.toLowerCase().includes(q.split(" ")[0]) || q.includes("unread") || q.includes("subject:")
+          ).slice(0, Math.min(max_results, 5));
+          return { results: mockEmails };
+        }
         try {
           const auth = getGoogleAuthClient();
           const gmail = google.gmail({ version: "v1", auth });
@@ -462,6 +552,11 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
         },
       }),
       execute: async ({ message_id }) => {
+        if (isDemo) {
+          const email = DEMO_EMAILS.find((e) => e.id === message_id);
+          if (!email) return { error: "Email not found" };
+          return { id: message_id, from: email.from, subject: email.subject, date: email.date, body: email.body ?? email.subject, truncated: false };
+        }
         try {
           const auth = getGoogleAuthClient();
           const gmail = google.gmail({ version: "v1", auth });
@@ -546,6 +641,9 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
         },
       }),
       execute: async ({ date, days = 1 }) => {
+        if (isDemo) {
+          return { events: DEMO_CALENDAR_EVENTS, count: DEMO_CALENDAR_EVENTS.length };
+        }
         try {
           const startDate = date ?? todayString();
           const endDate = addDays(startDate, Math.max(1, days) - 1);
@@ -641,6 +739,9 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
         },
       }),
       execute: async ({ title, date, start_time, end_time, location, description, all_day = false }) => {
+        if (isDemo) {
+          return { id: `demo-${Date.now()}`, title, start: { date, dateTime: start_time ? `${date}T${start_time}:00` : date }, end: { date, dateTime: end_time ? `${date}T${end_time}:00` : date }, note: "Demo mode — event not saved to real calendar." };
+        }
         try {
           if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
             return { error: `date must be YYYY-MM-DD, got: "${date}"` };
@@ -709,6 +810,7 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
         let req = supabase
           .from("recipes")
           .select("id, name, cuisine, ingredients, instructions, tags");
+        if (userId) req = req.eq("user_id", userId);
         if (query) {
           req = req.or(`name.ilike.%${query}%,ingredients.ilike.%${query}%`);
         }
@@ -747,6 +849,7 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
         const { data, error } = await supabase
           .from("meal_log")
           .insert({
+            user_id: userId,
             meal_type,
             notes: notes ?? null,
             recipe_id: recipe_id ?? null,
@@ -765,19 +868,25 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
     }),
   };
 
-  const modelTier = selectModel(messages);
-  console.log(`[chat] model=${modelTier} session=${sessionId} msg="${messages[messages.length - 1]?.content?.toString().slice(0, 80)}"`);
-  const selectedModel = wrapLanguageModel({
-    model: anthropic(modelTier === "haiku" ? "claude-haiku-4-5-20251001" : "claude-sonnet-4-6"),
-    middleware: retryOnOverload,
-  });
+  // Select model: demo → Groq Llama (free tier); real user → Anthropic tier selection
+  let selectedModel;
+  if (isDemo) {
+    const groq = createGroq({ apiKey: process.env.GROQ_API_KEY });
+    selectedModel = groq("llama-3.3-70b-versatile");
+    console.log(`[chat] model=groq/llama-3.3-70b-versatile (demo) session=${sessionId}`);
+  } else {
+    const modelTier = selectModel(messages);
+    console.log(`[chat] model=${modelTier} session=${sessionId} msg="${messages[messages.length - 1]?.content?.toString().slice(0, 80)}"`);
+    selectedModel = wrapLanguageModel({
+      model: anthropic(modelTier === "haiku" ? "claude-haiku-4-5-20251001" : "claude-sonnet-4-6"),
+      middleware: retryOnOverload,
+    });
+  }
 
-  const result = streamText({
-    model: selectedModel,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const streamOptions: Parameters<typeof streamText>[0] = {
+    model: selectedModel as any,
     system: systemPrompt,
-    providerOptions: {
-      anthropic: { cacheControl: { type: "ephemeral" } },
-    },
     messages: [...contextMessages, ...cleanMessages],
     tools,
     maxSteps: 25,
@@ -794,7 +903,7 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
         // Upsert the session — creates it if it doesn't exist yet (lazy session creation
         // for new chats whose UUID was generated client-side before any DB write).
         const { error: sessionError } = await supabase.from("chat_sessions").upsert(
-          { id: sessionId, device: "web", last_active_at: new Date().toISOString() },
+          { id: sessionId, user_id: userId, device: "web", last_active_at: new Date().toISOString() },
           { onConflict: "id" }
         );
         if (sessionError) throw sessionError;
@@ -802,11 +911,13 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
         const { error: insertError } = await supabase.from("chat_messages").insert([
           {
             session_id: sessionId,
+            user_id: userId,
             role: "user",
             content: lastUserMessage.content,
           },
           {
             session_id: sessionId,
+            user_id: userId,
             role: "assistant",
             content: text,
           },
@@ -816,7 +927,16 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
         console.error("[chat] onFinish persist error:", err);
       }
     },
-  });
+  };
+
+  // Only pass Anthropic cache options for non-demo (Groq doesn't support providerOptions)
+  if (!isDemo) {
+    streamOptions.providerOptions = {
+      anthropic: { cacheControl: { type: "ephemeral" } },
+    };
+  }
+
+  const result = streamText(streamOptions);
 
   return result.toDataStreamResponse();
 }

--- a/web/src/app/api/cron/reset-demo/route.ts
+++ b/web/src/app/api/cron/reset-demo/route.ts
@@ -1,0 +1,247 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/service";
+
+// Tables to wipe (children first to respect FK constraints)
+const TABLES = [
+  "chat_messages",
+  "chat_sessions",
+  "habits",
+  "habit_registry",
+  "meal_log",
+  "recipes",
+  "study_log",
+  "journal_entries",
+  "workout_sessions",
+  "recovery_metrics",
+  "fitness_log",
+  "tasks",
+  "timer_state",
+  "profile",
+] as const;
+
+export async function GET(req: Request) {
+  // Protect with CRON_SECRET — Vercel passes this as Authorization header
+  const authHeader = req.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const demoUserId = process.env.DEMO_USER_ID;
+  if (!demoUserId) {
+    return NextResponse.json({ error: "DEMO_USER_ID not configured" }, { status: 500 });
+  }
+
+  const supabase = createServiceClient();
+  const log: Record<string, number> = {};
+
+  // Wipe all demo user data
+  for (const table of TABLES) {
+    const { error } = await supabase
+      .from(table)
+      .delete()
+      .eq("user_id", demoUserId);
+    if (error) {
+      console.error(`[reset-demo] Error deleting from ${table}:`, error.message);
+    }
+    log[table] = 0; // Supabase delete doesn't return count reliably via service client
+  }
+
+  // Reseed via the seed API (calls seed_demo.py server-side via the Python script)
+  // Since this runs in Vercel serverless we can't spawn a Python process directly.
+  // Instead, inline the seed logic using the Supabase service client.
+  const seedResult = await seedDemoData(supabase, demoUserId);
+
+  console.log("[reset-demo] Reset complete.", { deleted: log, seeded: seedResult });
+  return NextResponse.json({ ok: true, deleted: log, seeded: seedResult });
+}
+
+type SupabaseClient = ReturnType<typeof createServiceClient>;
+
+async function seedDemoData(supabase: SupabaseClient, uid: string) {
+  const today = new Date();
+  const daysAgo = (n: number) => {
+    const d = new Date(today);
+    d.setDate(d.getDate() - n);
+    return d.toISOString().slice(0, 10);
+  };
+
+  // Profile
+  const profileRows = [
+    { user_id: uid, key: "name",               value: "Alex" },
+    { user_id: uid, key: "Identity/Name",       value: "Alex Chen" },
+    { user_id: uid, key: "Identity/Role",       value: "Software Engineer" },
+    { user_id: uid, key: "Identity/Location",   value: "San Francisco, CA" },
+    { user_id: uid, key: "location_city",       value: "San Francisco" },
+    { user_id: uid, key: "weight_goal_lbs",     value: "172" },
+    { user_id: uid, key: "body_fat_goal_pct",   value: "15" },
+    { user_id: uid, key: "weekly_workout_goal", value: "4" },
+    { user_id: uid, key: "calorie_goal",        value: "2200" },
+    { user_id: uid, key: "protein_goal",        value: "165" },
+    { user_id: uid, key: "sleep.goal.hrs",      value: "8" },
+    { user_id: uid, key: "pantry_staples",      value: "olive oil, garlic, onions, rice, pasta, canned tomatoes, eggs, chicken breast" },
+    { user_id: uid, key: "dietary_preferences", value: "high protein, moderate carbs; no dietary restrictions" },
+    { user_id: uid, key: "cuisine_preferences", value: "Japanese, Mediterranean, American" },
+  ];
+  await supabase.from("profile").upsert(profileRows, { onConflict: "user_id,key" });
+
+  // Habit registry
+  const habitDefs = [
+    { name: "Morning workout",   category: "fitness",  emoji: "💪" },
+    { name: "Read 20 min",       category: "learning", emoji: "📖" },
+    { name: "No alcohol",        category: "health",   emoji: "🚫" },
+    { name: "8h sleep",          category: "recovery", emoji: "😴" },
+    { name: "Meditate",          category: "mindset",  emoji: "🧘" },
+    { name: "Code side project", category: "learning", emoji: "💻" },
+    { name: "Journal",           category: "mindset",  emoji: "📝" },
+  ];
+  const { data: registry } = await supabase
+    .from("habit_registry")
+    .upsert(
+      habitDefs.map((h) => ({ user_id: uid, ...h, active: true })),
+      { onConflict: "user_id,name" }
+    )
+    .select("id, name");
+
+  // Habit logs — ~60% completion over 30 days
+  if (registry) {
+    const rates: Record<string, number> = {
+      "Morning workout": 0.55, "Read 20 min": 0.70, "No alcohol": 0.80,
+      "8h sleep": 0.50, "Meditate": 0.45, "Code side project": 0.60, "Journal": 0.35,
+    };
+    const idMap: Record<string, string> = Object.fromEntries(registry.map((r) => [r.name, r.id]));
+    const habitRows = [];
+    // Deterministic pseudo-random using day + habit index as seed
+    for (let dago = 30; dago > 0; dago--) {
+      const d = daysAgo(dago);
+      for (let hi = 0; hi < habitDefs.length; hi++) {
+        const h = habitDefs[hi];
+        const hash = ((dago * 31 + hi * 17) % 100) / 100;
+        if (hash < rates[h.name]) {
+          habitRows.push({ user_id: uid, habit_id: idMap[h.name], date: d, completed: true });
+        }
+      }
+    }
+    await supabase.from("habits").upsert(habitRows, { onConflict: "habit_id,date" });
+  }
+
+  // Tasks
+  const taskRows = [
+    { user_id: uid, title: "Ship v2 of the search API",          priority: "high",   status: "active",    category: "work",     due_date: daysAgo(-3) },
+    { user_id: uid, title: "Write design doc for auth refactor", priority: "high",   status: "active",    category: "work",     due_date: daysAgo(-7) },
+    { user_id: uid, title: "Set up home gym pull-up bar",        priority: "medium", status: "active",    category: "fitness"  },
+    { user_id: uid, title: "Read Designing Data-Intensive Apps", priority: "medium", status: "active",    category: "learning" },
+    { user_id: uid, title: "Schedule dentist appointment",       priority: "low",    status: "active",    category: "personal", due_date: daysAgo(-10) },
+    { user_id: uid, title: "Migrate PostgreSQL to v16",          priority: "medium", status: "active",    category: "work",     due_date: daysAgo(-14) },
+    { user_id: uid, title: "Review PR: rate limiter service",    priority: "high",   status: "completed", category: "work",     completed_at: `${daysAgo(2)}T10:30:00Z` },
+    { user_id: uid, title: "Meal prep for the week",            priority: "low",    status: "completed", category: "personal", completed_at: `${daysAgo(3)}T18:00:00Z` },
+    { user_id: uid, title: "30-min cardio 3x this week",        priority: "medium", status: "completed", category: "fitness",  completed_at: `${daysAgo(1)}T07:15:00Z` },
+    { user_id: uid, title: "Update resume",                     priority: "low",    status: "completed", category: "personal", completed_at: `${daysAgo(5)}T20:00:00Z` },
+  ];
+  await supabase.from("tasks").insert(taskRows);
+
+  // Fitness log — 30-day body comp arc
+  const fitnessRows = [];
+  for (let i = 0; i < 10; i++) {
+    const dago = 30 - i * 3;
+    const progress = i / 9;
+    const hash = ((i * 37) % 10) / 10 - 0.5;
+    fitnessRows.push({
+      user_id: uid,
+      date: daysAgo(dago),
+      weight_lb: Math.round((182.0 - 3.0 * progress + hash * 0.5) * 10) / 10,
+      body_fat_pct: Math.round((21.0 - 1.0 * progress + hash * 0.3) * 10) / 10,
+      bmi: 26.1,
+      muscle_mass_lb: Math.round((182.0 - 3.0 * progress) * 0.79 * 10) / 10,
+      visceral_fat: 8.0,
+      source: "renpho",
+    });
+  }
+  await supabase.from("fitness_log").upsert(fitnessRows, { onConflict: "user_id,date,source" });
+
+  // Workout sessions
+  const workoutTemplates = [
+    ["Running",         30, 280, 148, "Neighborhood run"],
+    ["Weight Training", 55, 320, 138, "Push day"],
+    ["Weight Training", 60, 340, 142, "Pull day"],
+    ["Cycling",         45, 390, 155, "Bay trail ride"],
+    ["HIIT",            25, 310, 162, "Tabata intervals"],
+    ["Weight Training", 50, 310, 135, "Leg day"],
+    ["Running",         40, 360, 152, "Tempo run"],
+    ["Yoga",            45,  95, 105, "Morning flow"],
+  ] as const;
+  const workoutRows = [];
+  let wcount = 0;
+  for (let dago = 28; dago > 1 && wcount < 18; dago--) {
+    if ((dago * 13) % 7 > 4) continue; // ~57% of days
+    const t = workoutTemplates[(dago * 7 + wcount) % workoutTemplates.length];
+    workoutRows.push({
+      user_id: uid,
+      date: daysAgo(dago),
+      start_time: `0${6 + (dago % 3)}:${(dago % 2) === 0 ? "00" : "30"}:00`,
+      activity: t[0],
+      duration_mins: t[1] + (dago % 5) - 2,
+      calories: t[2] + (dago % 10) - 5,
+      avg_hr: t[3] + (dago % 8) - 4,
+      notes: t[4],
+      source: "manual",
+    });
+    wcount++;
+  }
+  await supabase.from("workout_sessions").insert(workoutRows);
+
+  // Recovery metrics — 30 nights
+  const recoveryRows = [];
+  for (let dago = 30; dago > 0; dago--) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - dago);
+    const isWeekend = d.getDay() === 0 || d.getDay() === 6;
+    const hashA = ((dago * 11) % 10) / 10;
+    const hashB = ((dago * 17) % 10) / 10;
+    recoveryRows.push({
+      user_id: uid,
+      date: daysAgo(dago),
+      total_sleep_hrs: Math.round(((isWeekend ? 6.8 : 7.4) + hashA * 1.2 - 0.6) * 100) / 100,
+      deep_hrs: Math.round((hashA * 0.4 + 1.3) * 100) / 100,
+      rem_hrs: Math.round((hashB * 0.5 + 1.6) * 100) / 100,
+      avg_hrv: Math.max(25, Math.round(52 + hashA * 16 - 8)),
+      resting_hr: Math.max(45, Math.round(58 + hashB * 6 - 3)),
+      readiness: Math.min(100, Math.max(40, Math.round(72 + hashA * 20 - 10))),
+      sleep_score: Math.min(100, Math.max(40, Math.round(74 + hashB * 16 - 8))),
+      active_cal: Math.round(450 + hashA * 160 - 80),
+      source: "oura",
+    });
+  }
+  await supabase.from("recovery_metrics").upsert(recoveryRows, { onConflict: "user_id,date" });
+
+  // Study log
+  const studyRows = [
+    { user_id: uid, date: daysAgo(2),  subject: "System Design",  duration_mins: 45, notes: "Consistent hashing and distributed caches" },
+    { user_id: uid, date: daysAgo(4),  subject: "TypeScript",      duration_mins: 60, notes: "Advanced generics and conditional types" },
+    { user_id: uid, date: daysAgo(7),  subject: "System Design",  duration_mins: 50, notes: "Kafka vs RabbitMQ" },
+    { user_id: uid, date: daysAgo(10), subject: "Algorithms",      duration_mins: 40, notes: "Binary search and sliding window" },
+    { user_id: uid, date: daysAgo(14), subject: "Go",              duration_mins: 75, notes: "Custom HTTP middleware chain" },
+  ];
+  await supabase.from("study_log").insert(studyRows);
+
+  // Journal
+  const journalRows = [
+    { user_id: uid, date: daysAgo(1),  content: "Good training week. Hit 4 workouts, sleep has been better since cutting caffeine after 2pm.",   response: "Four workouts with improved sleep is solid progress. Caffeine cut is high-ROI." },
+    { user_id: uid, date: daysAgo(5),  content: "Struggled this week — only gym twice, big deployment went sideways Thursday.",                    response: "Two workouts during an incident week is load management, not failure. Rest, then reset." },
+    { user_id: uid, date: daysAgo(12), content: "Feeling really good. Weight trending down, workouts strong. Thinking about a half marathon.",     response: "Weight down 1.8 lb over 3 weeks. Half marathon is feasible — pick a race date to anchor training." },
+    { user_id: uid, date: daysAgo(20), content: "Trying to read more. Barely finish a book a month now — too much phone in the evenings.",         response: "Phone and reading compete for the same time slot. 20-min daily habit applied in the pre-sleep window breaks it." },
+  ];
+  await supabase.from("journal_entries").insert(journalRows);
+
+  // Recipes
+  const recipeRows = [
+    { user_id: uid, name: "High-Protein Chicken Bowl", cuisine: "American",      ingredients: "chicken breast, brown rice, broccoli, olive oil, garlic, soy sauce",        instructions: "Grill chicken, serve over rice with steamed broccoli.", tags: ["high-protein", "meal-prep"] },
+    { user_id: uid, name: "Greek Salmon",               cuisine: "Mediterranean", ingredients: "salmon fillet, cucumber, Greek yogurt, dill, lemon, olive oil, spinach",     instructions: "Grill salmon, serve with tzatziki and salad.",           tags: ["high-protein", "mediterranean"] },
+    { user_id: uid, name: "Overnight Oats",             cuisine: "American",      ingredients: "rolled oats, Greek yogurt, almond milk, chia seeds, banana, berries",        instructions: "Mix and refrigerate overnight. Top with fruit.",          tags: ["breakfast", "meal-prep"] },
+    { user_id: uid, name: "Spicy Tuna Rice Bowl",       cuisine: "Japanese",      ingredients: "tuna, white rice, sriracha, mayo, cucumber, avocado, soy sauce",             instructions: "Mix tuna with sriracha/mayo, build bowl with rice.",      tags: ["quick", "japanese"] },
+    { user_id: uid, name: "Turkey Stir Fry",            cuisine: "American",      ingredients: "ground turkey, bell peppers, snap peas, garlic, ginger, soy sauce, rice",   instructions: "Brown turkey, stir-fry veggies, serve over rice.",        tags: ["high-protein", "quick"] },
+  ];
+  await supabase.from("recipes").insert(recipeRows);
+
+  return { tables: ["profile", "habit_registry", "habits", "tasks", "fitness_log", "workout_sessions", "recovery_metrics", "study_log", "journal_entries", "recipes"] };
+}

--- a/web/src/app/api/google/calendar/route.ts
+++ b/web/src/app/api/google/calendar/route.ts
@@ -2,6 +2,7 @@ import { google } from "googleapis";
 import { NextResponse } from "next/server";
 import { startOfTodayRFC3339, endOfTodayRFC3339, USER_TZ } from "@/lib/timezone";
 import { getGoogleAuthClient } from "@/lib/google-auth";
+import { createClient } from "@/lib/supabase/server";
 
 export interface CalendarEvent {
   time: string;
@@ -24,7 +25,24 @@ function formatTime(dateTimeStr: string | null | undefined, dateStr: string | nu
   });
 }
 
+const today = new Date().toISOString().slice(0, 10);
+const DEMO_EVENTS: CalendarEvent[] = [
+  { time: "6:30 AM",  title: "Morning run",    calendarName: "Alex Chen", isPrimary: true, isBirthday: false },
+  { time: "9:00 AM",  title: "Team standup",   calendarName: "Alex Chen", isPrimary: true, isBirthday: false, location: "Google Meet" },
+  { time: "12:30 PM", title: "Lunch w/ Priya", calendarName: "Alex Chen", isPrimary: true, isBirthday: false, location: "Tartine Manufactory" },
+  { time: "6:00 PM",  title: "Gym — push day", calendarName: "Alex Chen", isPrimary: true, isBirthday: false, location: "Equinox SoMa" },
+];
+// suppress unused variable warning from linter
+void today;
+
 export async function GET() {
+  // Return mock data for demo user
+  const serverClient = await createClient();
+  const { data: { user } } = await serverClient.auth.getUser();
+  if (user?.id && user.id === process.env.DEMO_USER_ID) {
+    return NextResponse.json({ events: DEMO_EVENTS });
+  }
+
   try {
     const auth = getGoogleAuthClient();
     const calendar = google.calendar({ version: "v3", auth });

--- a/web/src/app/api/google/gmail/route.ts
+++ b/web/src/app/api/google/gmail/route.ts
@@ -1,6 +1,7 @@
 import { google } from "googleapis";
 import { NextResponse } from "next/server";
 import { getGoogleAuthClient } from "@/lib/google-auth";
+import { createClient } from "@/lib/supabase/server";
 
 export interface EmailSummary {
   from: string;
@@ -21,7 +22,21 @@ function getHeader(headers: { name?: string | null; value?: string | null }[], n
   return headers.find((h) => h.name?.toLowerCase() === name.toLowerCase())?.value ?? "";
 }
 
+const DEMO_EMAILS: EmailSummary[] = [
+  { from: "UPS Tracking", subject: "Your package is out for delivery today",        receivedAt: "Mon, 13 Apr 2026 08:14:00 -0700", account: "personal" },
+  { from: "Alaska Airlines", subject: "Flight Confirmation: SFO → SEA Apr 20",     receivedAt: "Thu, 10 Apr 2026 11:02:00 -0700", account: "personal" },
+  { from: "Figma",          subject: "Action required: Accept team invite",         receivedAt: "Mon, 13 Apr 2026 09:47:00 -0700", account: "professional" },
+  { from: "DocuSign",       subject: "Invoice #4421 — please sign",                 receivedAt: "Fri, 11 Apr 2026 15:12:00 -0700", account: "professional" },
+];
+
 export async function GET() {
+  // Return mock data for demo user
+  const serverClient = await createClient();
+  const { data: { user } } = await serverClient.auth.getUser();
+  if (user?.id && user.id === process.env.DEMO_USER_ID) {
+    return NextResponse.json({ emails: DEMO_EMAILS });
+  }
+
   try {
     const auth = getGoogleAuthClient();
     const gmail = google.gmail({ version: "v1", auth });

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -5,6 +5,9 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useState } from "react";
 import Logo from "@/components/ui/logo";
 
+const DEMO_EMAIL = process.env.NEXT_PUBLIC_DEMO_EMAIL ?? "";
+const DEMO_PASSWORD = process.env.NEXT_PUBLIC_DEMO_PASSWORD ?? "";
+
 type State = "idle" | "loading" | "error";
 
 function LoginForm() {
@@ -16,20 +19,29 @@ function LoginForm() {
   const hasAuthError = searchParams.get("error") === "auth_error";
   const router = useRouter();
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
+  async function signIn(e: string, p: string) {
     setState("loading");
     setErrorMsg("");
-
     const supabase = createClient();
-    const { error } = await supabase.auth.signInWithPassword({ email, password });
-
+    const { error } = await supabase.auth.signInWithPassword({ email: e, password: p });
     if (error) {
       setErrorMsg(error.message);
       setState("error");
     } else {
       router.push("/");
     }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    await signIn(email, password);
+  }
+
+  async function handleDemoLogin() {
+    if (!DEMO_EMAIL || !DEMO_PASSWORD) return;
+    setEmail(DEMO_EMAIL);
+    setPassword(DEMO_PASSWORD);
+    await signIn(DEMO_EMAIL, DEMO_PASSWORD);
   }
 
   return (
@@ -92,6 +104,29 @@ function LoginForm() {
             {state === "loading" ? "Signing in..." : "Sign in"}
           </button>
         </form>
+
+        {DEMO_EMAIL && DEMO_PASSWORD && (
+          <div className="pt-2">
+            <div className="relative">
+              <div className="absolute inset-0 flex items-center">
+                <div className="w-full border-t border-neutral-800" />
+              </div>
+              <div className="relative flex justify-center text-xs">
+                <span className="bg-neutral-950 px-3 text-neutral-600">or</span>
+              </div>
+            </div>
+            <button
+              onClick={handleDemoLogin}
+              disabled={state === "loading"}
+              className="mt-4 w-full border border-neutral-700 text-neutral-300 rounded-lg px-4 py-2.5 text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:border-neutral-500 hover:text-neutral-100 transition-colors"
+            >
+              Try the demo
+            </button>
+            <p className="mt-2 text-center text-xs text-neutral-600">
+              Fictional persona · read-write · resets nightly
+            </p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/src/components/nav.tsx
+++ b/web/src/components/nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   LayoutDashboard,
   Activity,
@@ -17,6 +17,7 @@ import {
   X,
 } from "lucide-react";
 import Logo from "@/components/ui/logo";
+import { createClient } from "@/lib/supabase/client";
 
 const NAV_ITEMS = [
   { href: "/dashboard", label: "Dashboard",  icon: LayoutDashboard },
@@ -43,6 +44,16 @@ function isActive(pathname: string, href: string) {
 export default function Nav() {
   const pathname = usePathname();
   const [showMore, setShowMore] = useState(false);
+  const [isDemo, setIsDemo] = useState(false);
+
+  useEffect(() => {
+    const demoEmail = process.env.NEXT_PUBLIC_DEMO_EMAIL;
+    if (!demoEmail) return;
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      setIsDemo(user?.email === demoEmail);
+    });
+  }, []);
 
   // Is the current page one of the "More" pages? If so, highlight the More button.
   const moreIsActive = MOBILE_MORE.some((item) => isActive(pathname, item.href));
@@ -92,7 +103,27 @@ export default function Nav() {
             );
           })}
         </div>
+
+        {/* Demo banner — desktop */}
+        {isDemo && (
+          <div
+            className="mx-3 mb-4 px-3 py-2.5 rounded-lg text-xs"
+            style={{ background: "var(--color-primary-dim)", color: "var(--color-primary)" }}
+          >
+            Demo account — changes reset nightly
+          </div>
+        )}
       </nav>
+
+      {/* Demo banner — mobile (above tab bar) */}
+      {isDemo && (
+        <div
+          className="lg:hidden fixed left-0 right-0 z-40 px-4 py-1.5 text-center text-xs"
+          style={{ bottom: 56, background: "var(--color-primary-dim)", color: "var(--color-primary)" }}
+        >
+          Demo account — changes reset nightly
+        </div>
+      )}
 
       {/* ── Mobile bottom tab bar (< lg) ────────────────────────────── */}
       <nav

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/sync",
       "schedule": "0 14 * * *"
+    },
+    {
+      "path": "/api/cron/reset-demo",
+      "schedule": "0 11 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **Multi-tenancy** — adds `user_id` to all 14 tables, backfills existing rows with the real owner's auth UID, updates RLS policies to `using (auth.uid() = user_id)` per user
- **Demo account** — `demo@mr-bridge.app` seeded with Alex Chen persona (SF engineer): 7 habits at ~60% completion, 30-day body comp arc, 18 workouts, 30 recovery nights, 10 tasks, recipes, journal entries
- **Groq chat** — demo users are served by Groq Llama 3.3-70b (free tier) instead of Claude; same tool interface, simplified system prompt
- **Mock integrations** — Gmail and Calendar routes return hardcoded demo data for the demo user; chat tools do the same inline
- **Nightly reset** — `reset_demo.py` + `/api/cron/reset-demo` (CRON_SECRET-protected); Vercel cron at 3 AM PT
- **Login UX** — "Try the demo" button auto-fills + signs in when env vars are set
- **Demo banner** — visible in sidebar (desktop) and above tab bar (mobile) when signed in as demo
- **Python scripts** — all sync scripts now require `OWNER_USER_ID` in `.env` and filter all queries by it; `print_owner_id.py` helper added
- **README** — Demo account section (credentials, real vs mocked table); Self-Hosting section (rename checklist, required env vars, setup steps)

## New env vars required

```
OWNER_USER_ID=<uuid>          # real owner — run scripts/print_owner_id.py
DEMO_USER_ID=<uuid>           # demo account auth UID
DEMO_EMAIL=demo@mr-bridge.app
DEMO_PASSWORD=<password>
NEXT_PUBLIC_DEMO_EMAIL=demo@mr-bridge.app
NEXT_PUBLIC_DEMO_PASSWORD=<password>
CRON_SECRET=<secret>
GROQ_API_KEY=<key>            # free at console.groq.com
```

## Deployment checklist

- [ ] Run migration in Supabase SQL editor (`supabase/migrations/20260413000000_add_user_id_multitenancy.sql`)
- [ ] Run `python3 scripts/print_owner_id.py` → add `OWNER_USER_ID` to `.env`
- [ ] Create `demo@mr-bridge.app` in Supabase Auth dashboard → add `DEMO_USER_ID`, `DEMO_EMAIL`, `DEMO_PASSWORD` to `.env`
- [ ] Run `python3 scripts/seed_demo.py` to seed demo data
- [ ] Add `NEXT_PUBLIC_DEMO_EMAIL`, `NEXT_PUBLIC_DEMO_PASSWORD`, `CRON_SECRET`, `GROQ_API_KEY` to Vercel env vars
- [ ] Verify: sign in as real user → see only real data; sign in as demo → see only Alex Chen data

## Test plan

- [ ] Run migration → existing real data loads correctly
- [ ] Sign in as demo → only seed data visible, no real data crossover
- [ ] Toggle a habit, add a task → scoped to demo user
- [ ] Chat as demo → Groq responds, tools return demo data
- [ ] Gmail/Calendar cards → mock data renders
- [ ] Trigger `/api/cron/reset-demo` with `Authorization: Bearer <CRON_SECRET>` → reseeds
- [ ] Sign back in as real user → data untouched
- [ ] "Try the demo" button on login page → auto-signs in
- [ ] Demo banner visible in nav while signed in as demo

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)