### PR TITLE
feat: workout deduplication and history table UI improvements (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (workout deduplication and history UI — issue #127)
+- **`ACTIVITY_ALIASES` map** in `scripts/sync-fitbit.py` and `web/src/lib/sync/fitbit.ts` — normalizes Fitbit variant names to canonical labels before dedup key is built and before DB insert (e.g. "Walking" → "Walk", "Running" → "Run", "Biking" → "Bike"); existing keys in the DB are also normalized during comparison so pre-migration rows are not re-inserted
+- **Time-overlap detection** in both sync paths — before inserting, checks if an existing workout on the same date has a `start_time` within ±5 minutes; prefers the row with HR data, then longer duration; inferior existing rows are deleted and replaced
+- **DB migration** `20260413000001_workout_sessions_unique_constraint.sql` — adds `unique (date, start_time, source)` constraint to `workout_sessions`
+- **`scripts/normalize_workout_activities.py`** — one-time script to normalize activity names in existing rows; run with `--yes` to apply; dry-run by default
+- **Workout history table** (`workout-history-table.tsx`) enhancements:
+  - Start time column — formatted as `h:mm AM/PM` from stored `HH:MM:SS`
+  - End time column — derived as `start_time + duration_mins`, same format
+  - HR Zones secondary line — `metadata.hr_zones` string ("Peak: 3m | Cardio: 12m") shown inline below the date cell when present
+  - Source badge — small pill showing "fitbit" / "manual" with accent color for fitbit
+  - Activity type filter — pill row above the table to filter by activity; resets to page 1 on change
+- **`WorkoutSession` type** (`web/src/lib/types.ts`) — added `metadata: { hr_zones: string | null } | null` field
+
 ### Added (demo account + multi-tenancy — issue #50)
 - **Multi-tenancy migration** — `user_id uuid references auth.users(id)` added to all 14 tables; existing rows backfilled with owner's auth UID; RLS policies updated from `using (true)` → `using (auth.uid() = user_id)`; per-user indexes added
 - **Demo account** — `demo@mr-bridge.app` with realistic seed data: Alex Chen persona, 7 habits at ~60% completion over 30 days, body comp trend arc, 18 workout sessions, 30 recovery nights, 10 tasks, 5 study entries, 4 journal entries, 5 recipes

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ flowchart LR
 - **Chat** — Conversational interface to Mr. Bridge; streams Claude responses with 13 built-in tools (tasks, habits, fitness, profile, Gmail, Calendar read + write, recipes, meals); slash command autocomplete
 - **Habits** — Daily toggle check-in with streaks, 90-day heatmap, streak bar chart, weekly radial completion chart
 - **Tasks** — Inline editing, priority, relative due dates, completed-tasks accordion
-- **Fitness** — Body composition charts (weight + BF%), weekly workout frequency, active calorie chart, full workout history table; goal progress overlays
+- **Fitness** — Body composition charts (weight + BF%), weekly workout frequency, active calorie chart, full workout history table (start/end time, HR zones, source badge, activity filter); goal progress overlays
 - **Journal** — Guided 5-prompt daily reflection + free-write tab; auto-save; collapsible history
 - **Weekly Review** — Last 7 days at a glance: habit scores, task completion, workout summary, recovery averages, body comp delta, journal count
 - **Meals** — Daily macro summary vs goals; food photo analyzer (photo → Claude vision → macro estimate → log); 7-day meal history
@@ -456,6 +456,7 @@ mr-bridge-assistant/
 │   ├── sync-googlefit.py                  # Google Fit weight → Supabase fitness_log
 │   ├── sync-oura.py                       # Oura Ring → recovery_metrics + workout_sessions
 │   ├── sync-fitbit.py                     # Fitbit workouts + body comp → Supabase
+│   ├── normalize_workout_activities.py    # One-time: normalize activity names to canonical aliases
 │   ├── sync-renpho.py                     # Renpho CSV → Supabase fitness_log (deprecated)
 │   ├── check_birthday_notif.py            # Birthday push alerts from Google Calendar
 │   ├── check_hrv_alert.py                 # HRV drop push alert (vs 7-day baseline)

--- a/scripts/normalize_workout_activities.py
+++ b/scripts/normalize_workout_activities.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+Normalize existing workout_sessions rows to use canonical activity names.
+
+Run once after deploying the ACTIVITY_ALIASES changes in sync-fitbit.py.
+Updates rows where the stored activity name differs from the canonical alias.
+
+Usage:
+  python3 scripts/normalize_workout_activities.py          # dry-run (print only)
+  python3 scripts/normalize_workout_activities.py --yes    # write to Supabase
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+ROOT = Path(__file__).parent.parent
+load_dotenv(ROOT / ".env")
+sys.path.insert(0, str(Path(__file__).parent))
+from _supabase import get_client, get_owner_user_id
+
+ACTIVITY_ALIASES: dict[str, str] = {
+    "Walking": "Walk",
+    "Running": "Run",
+    "Biking": "Bike",
+    "Cycling": "Bike",
+    "Outdoor Bike": "Bike",
+    "Swimming": "Swim",
+    "Hiking": "Hike",
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Normalize workout activity names in Supabase")
+    parser.add_argument("--yes", "-y", action="store_true", help="Write changes (default: dry-run)")
+    args = parser.parse_args()
+
+    client = get_client()
+    owner_user_id = get_owner_user_id()
+
+    rows = (
+        client.table("workout_sessions")
+        .select("id,activity")
+        .eq("user_id", owner_user_id)
+        .execute()
+        .data
+    )
+
+    updates: list[tuple[str, str, str]] = []
+    for r in rows:
+        canonical = ACTIVITY_ALIASES.get(r["activity"])
+        if canonical and canonical != r["activity"]:
+            updates.append((r["id"], r["activity"], canonical))
+
+    if not updates:
+        print("No activity names need normalization.")
+        return
+
+    print(f"{'ID':<38}  {'Old':<20}  {'New'}")
+    print("-" * 70)
+    for uid, old, new in updates:
+        print(f"{uid:<38}  {old:<20}  {new}")
+    print(f"\n{len(updates)} row(s) to update.")
+
+    if not args.yes:
+        print("\nDry run — pass --yes to apply.")
+        return
+
+    for uid, _old, new in updates:
+        client.table("workout_sessions").update({"activity": new}).eq("id", uid).execute()
+
+    print(f"\n[normalize] Updated {len(updates)} row(s).")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync-fitbit.py
+++ b/scripts/sync-fitbit.py
@@ -54,6 +54,24 @@ FITBIT_API_BASE = "https://api.fitbit.com"
 REDIRECT_URI = "http://localhost:8080"
 SCOPES = "activity heartrate weight"
 
+# Canonical activity names — map Fitbit variants to a single label so dedup
+# keys and history views stay consistent regardless of which name the API returns.
+ACTIVITY_ALIASES: dict[str, str] = {
+    "Walking": "Walk",
+    "Running": "Run",
+    "Biking": "Bike",
+    "Cycling": "Bike",
+    "Outdoor Bike": "Bike",
+    "Swimming": "Swim",
+    "Hiking": "Hike",
+    "Aerobic Workout": "Aerobic Workout",
+    "Sport": "Sport",
+}
+
+
+def normalize_activity(name: str) -> str:
+    return ACTIVITY_ALIASES.get(name, name)
+
 
 # ── OAuth helpers ──────────────────────────────────────────────────────────────
 
@@ -207,23 +225,28 @@ def fetch_workouts(access_token, start_date, end_date):
         time_str = raw_start[11:19] if len(raw_start) >= 19 else None  # HH:MM:SS
         avg_hr = a.get("averageHeartRate")
         calories = a.get("calories")
+        activity = normalize_activity(a.get("activityName", "Unknown"))
         rows.append({
             "date": date_str,
             "start_time": time_str,
-            "activity": a.get("activityName", "Unknown"),
+            "activity": activity,
             "duration_mins": duration_min,
             "calories": int(calories) if calories else None,
             "avg_hr": int(avg_hr) if avg_hr else None,
             "source": "fitbit",
-            "metadata": {"hr_zones": fmt_hr_zones(a.get("heartRateZones", []))} ,
+            "metadata": {"hr_zones": fmt_hr_zones(a.get("heartRateZones", []))},
             # dedup key (not written to DB)
-            "_key": f"{date_str}|{time_str}|{a.get('activityName', '')}",
+            "_key": f"{date_str}|{time_str}|{activity}",
         })
     return rows
 
 
 def existing_keys(client, user_id: str) -> set:
-    """Build dedup keys from Supabase to avoid re-inserting the same workout."""
+    """Build dedup keys from Supabase to avoid re-inserting the same workout.
+
+    Normalizes activity names from existing rows so pre-migration rows (with
+    un-aliased names like 'Walking') still match the new canonical keys.
+    """
     rows = (
         client.table("workout_sessions")
         .select("date,start_time,activity")
@@ -232,7 +255,88 @@ def existing_keys(client, user_id: str) -> set:
         .execute()
         .data
     )
-    return {f"{r['date']}|{r['start_time']}|{r['activity']}" for r in rows}
+    return {f"{r['date']}|{r['start_time']}|{normalize_activity(r['activity'])}" for r in rows}
+
+
+def fetch_existing_workouts(client, user_id: str, dates: set[str]) -> list[dict]:
+    """Fetch existing workout rows for a set of dates (for overlap detection)."""
+    if not dates:
+        return []
+    rows = (
+        client.table("workout_sessions")
+        .select("id,date,start_time,avg_hr,duration_mins")
+        .eq("source", "fitbit")
+        .eq("user_id", user_id)
+        .in_("date", list(dates))
+        .execute()
+        .data
+    )
+    return rows
+
+
+def _time_to_mins(t: str | None) -> int | None:
+    """Convert HH:MM:SS string to total minutes past midnight."""
+    if not t:
+        return None
+    parts = t.split(":")
+    return int(parts[0]) * 60 + int(parts[1])
+
+
+def _is_better(new_row: dict, existing_row: dict) -> bool:
+    """Return True if new_row is preferable to existing_row.
+
+    Priority: has HR data > no HR data; then longer duration wins.
+    """
+    new_hr = new_row.get("avg_hr") is not None
+    ex_hr = existing_row.get("avg_hr") is not None
+    if new_hr and not ex_hr:
+        return True
+    if not new_hr and ex_hr:
+        return False
+    return (new_row.get("duration_mins") or 0) > (existing_row.get("duration_mins") or 0)
+
+
+def filter_overlapping(
+    new_rows: list[dict],
+    existing_rows: list[dict],
+) -> tuple[list[dict], list[str]]:
+    """Compare new workouts against existing rows for time-overlap (±5 min).
+
+    Returns:
+        to_insert — rows that should be inserted (no overlap, or new row is better)
+        to_delete — IDs of existing rows to delete (replaced by a better new row)
+    """
+    OVERLAP_MINS = 5
+    # Index existing rows by date for quick lookup
+    by_date: dict[str, list[dict]] = {}
+    for r in existing_rows:
+        by_date.setdefault(r["date"], []).append(r)
+
+    to_insert: list[dict] = []
+    to_delete: list[str] = []
+
+    for new in new_rows:
+        new_mins = _time_to_mins(new.get("start_time"))
+        overlapped = False
+        for ex in by_date.get(new["date"], []):
+            ex_mins = _time_to_mins(ex.get("start_time"))
+            if new_mins is None or ex_mins is None:
+                continue
+            if abs(new_mins - ex_mins) <= OVERLAP_MINS:
+                overlapped = True
+                if _is_better(new, ex):
+                    to_delete.append(ex["id"])
+                    to_insert.append(new)
+                else:
+                    print(
+                        f"[sync-fitbit] Skipping {new['date']} {new.get('start_time')} "
+                        f"{new.get('activity')} — existing row preferred (HR/duration)"
+                    )
+                break
+        if not overlapped:
+            to_insert.append(new)
+
+    return to_insert, to_delete
 
 
 # ── Body composition ───────────────────────────────────────────────────────────
@@ -371,17 +475,24 @@ def main():
                 parts.append(f"BMI={r['bmi']}")
             print(f"  {r['date']} — {' | '.join(parts) if parts else 'no fields'}")
 
-    # Write workouts
+    # Write workouts — exact dedup first, then time-overlap check
     existing = existing_keys(client, owner_user_id)
-    new_workouts = [r for r in workout_rows if r["_key"] not in existing]
+    exact_new = [r for r in workout_rows if r["_key"] not in existing]
+
+    # Time-overlap detection: fetch full rows for dates that have candidates
+    candidate_dates = {r["date"] for r in exact_new}
+    existing_detail = fetch_existing_workouts(client, owner_user_id, candidate_dates)
+    new_workouts, ids_to_delete = filter_overlapping(exact_new, existing_detail)
 
     if new_workouts:
         print(f"\nNew workout entries ({len(new_workouts)}):")
         for r in new_workouts:
             hr_info = f" | Avg HR: {r['avg_hr']}" if r["avg_hr"] else ""
             print(f"  {r['date']} {r['start_time']} — {r['activity']} ({r['duration_mins']} min, {r['calories']} cal{hr_info})")
+    if ids_to_delete:
+        print(f"\nWorkouts to replace (overlap, inferior row): {len(ids_to_delete)} row(s)")
 
-    if not new_body and not new_workouts:
+    if not new_body and not new_workouts and not ids_to_delete:
         print("[sync-fitbit] No new data.")
         return
 
@@ -399,6 +510,10 @@ def main():
         print(f"[sync-fitbit] Synced {body_written} body composition row(s) to fitness_log.")
 
     workout_written = 0
+    if ids_to_delete:
+        client.table("workout_sessions").delete().in_("id", ids_to_delete).execute()
+        print(f"[sync-fitbit] Deleted {len(ids_to_delete)} inferior overlap row(s).")
+
     if new_workouts:
         # Strip the internal dedup key before inserting, add user_id
         sb_rows = [{k: v for k, v in r.items() if k != "_key"} | {"user_id": owner_user_id} for r in new_workouts]

--- a/supabase/migrations/20260413000004_workout_sessions_unique_constraint.sql
+++ b/supabase/migrations/20260413000004_workout_sessions_unique_constraint.sql
@@ -1,0 +1,7 @@
+-- Prevent duplicate workout_sessions rows for the same workout event per user.
+-- The combination of user_id + date + start_time + source is unique; a single
+-- source cannot produce two workouts starting at the exact same moment for the same user.
+
+alter table workout_sessions
+  add constraint workout_sessions_user_id_date_start_source_key
+  unique (user_id, date, start_time, source);

--- a/web/src/components/fitness/workout-history-table.tsx
+++ b/web/src/components/fitness/workout-history-table.tsx
@@ -21,15 +21,42 @@ function fmtDate(d: string) {
   });
 }
 
+/** Format HH:MM:SS → h:mm AM/PM */
+function fmtTime(t: string | null): string {
+  if (!t) return "—";
+  const [h, m] = t.split(":").map(Number);
+  const ampm = h >= 12 ? "PM" : "AM";
+  const h12 = h % 12 || 12;
+  return `${h12}:${String(m).padStart(2, "0")} ${ampm}`;
+}
+
+/** Compute end time from HH:MM:SS start + duration in minutes, formatted as h:mm AM/PM */
+function calcEndTime(startTime: string | null, durationMins: number | null): string {
+  if (!startTime || durationMins == null) return "—";
+  const [h, m] = startTime.split(":").map(Number);
+  const totalMins = h * 60 + m + durationMins;
+  const endH = Math.floor(totalMins / 60) % 24;
+  const endM = totalMins % 60;
+  const ampm = endH >= 12 ? "PM" : "AM";
+  const h12 = endH % 12 || 12;
+  return `${h12}:${String(endM).padStart(2, "0")} ${ampm}`;
+}
+
 function SortIcon({ col, sortKey, dir }: { col: SortKey; sortKey: SortKey; dir: SortDir }) {
   if (col !== sortKey) return <ChevronsUpDown size={12} style={{ opacity: 0.3 }} />;
   return dir === "asc" ? <ChevronUp size={12} /> : <ChevronDown size={12} />;
 }
 
+const SOURCE_COLORS: Record<string, string> = {
+  fitbit: "var(--color-accent, #6366f1)",
+  manual: "var(--color-text-muted)",
+};
+
 export function WorkoutHistoryTable({ workouts }: Props) {
   const [sortKey, setSortKey] = useState<SortKey>("date");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [page, setPage] = useState(0);
+  const [activityFilter, setActivityFilter] = useState<string>("All");
 
   function handleSort(key: SortKey) {
     if (key === sortKey) {
@@ -41,7 +68,13 @@ export function WorkoutHistoryTable({ workouts }: Props) {
     setPage(0);
   }
 
-  const sorted = [...workouts].sort((a, b) => {
+  // Unique activity types for the filter pills
+  const activityTypes = ["All", ...Array.from(new Set(workouts.map((w) => w.activity))).sort()];
+
+  const filtered =
+    activityFilter === "All" ? workouts : workouts.filter((w) => w.activity === activityFilter);
+
+  const sorted = [...filtered].sort((a, b) => {
     const av = a[sortKey] ?? "";
     const bv = b[sortKey] ?? "";
     const cmp = av < bv ? -1 : av > bv ? 1 : 0;
@@ -63,12 +96,18 @@ export function WorkoutHistoryTable({ workouts }: Props) {
     whiteSpace: "nowrap",
   };
 
+  const thNoSort: React.CSSProperties = {
+    ...thStyle,
+    cursor: "default",
+  };
+
   const tdBase: React.CSSProperties = {
     paddingTop: 10,
-    paddingBottom: 10,
+    paddingBottom: 4,
     borderTop: "1px solid var(--color-border)",
     fontSize: 13,
     color: "var(--color-text)",
+    verticalAlign: "top",
   };
 
   return (
@@ -76,66 +115,192 @@ export function WorkoutHistoryTable({ workouts }: Props) {
       className="rounded-xl p-5"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
-      <p className="text-xs uppercase tracking-widest mb-4" style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}>
+      <p
+        className="text-xs uppercase tracking-widest mb-4"
+        style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}
+      >
         Workout History
       </p>
 
       {workouts.length === 0 ? (
-        <p style={{ fontSize: 14, color: "var(--color-text-faint)", paddingTop: 8 }}>No workouts logged</p>
+        <p style={{ fontSize: 14, color: "var(--color-text-faint)", paddingTop: 8 }}>
+          No workouts logged
+        </p>
       ) : (
         <>
+          {/* Activity type filter pills */}
+          <div className="flex flex-wrap gap-1.5 mb-4">
+            {activityTypes.map((type) => (
+              <button
+                key={type}
+                onClick={() => {
+                  setActivityFilter(type);
+                  setPage(0);
+                }}
+                className="px-2.5 py-1 rounded-full text-xs transition-colors duration-150 cursor-pointer"
+                style={{
+                  fontSize: 11,
+                  fontWeight: activityFilter === type ? 600 : 400,
+                  background:
+                    activityFilter === type
+                      ? "var(--color-accent, #6366f1)"
+                      : "var(--color-surface-raised, rgba(255,255,255,0.05))",
+                  color:
+                    activityFilter === type
+                      ? "#fff"
+                      : "var(--color-text-muted)",
+                  border: "1px solid var(--color-border)",
+                }}
+              >
+                {type}
+              </button>
+            ))}
+          </div>
+
           <div className="overflow-x-auto">
-            <table className="w-full" style={{ borderCollapse: "collapse", minWidth: 480 }}>
+            <table className="w-full" style={{ borderCollapse: "collapse", minWidth: 700 }}>
               <thead>
                 <tr>
                   {([
-                    { key: "date" as SortKey, label: "Date" },
-                    { key: "activity" as SortKey, label: "Activity" },
-                    { key: "duration_mins" as SortKey, label: "Duration" },
-                    { key: "calories" as SortKey, label: "Calories" },
-                    { key: "avg_hr" as SortKey, label: "Avg HR" },
-                  ] as { key: SortKey; label: string }[]).map(({ key, label }) => (
-                    <th key={key} style={thStyle} onClick={() => handleSort(key)}>
+                    { key: "date" as SortKey, label: "Date", sortable: true },
+                    { key: "activity" as SortKey, label: "Activity", sortable: true },
+                    { key: "duration_mins" as SortKey, label: "Duration", sortable: true },
+                    { key: "calories" as SortKey, label: "Calories", sortable: true },
+                    { key: "avg_hr" as SortKey, label: "Avg HR", sortable: true },
+                  ] as { key: SortKey; label: string; sortable: boolean }[]).map(({ key, label, sortable }) => (
+                    <th
+                      key={key}
+                      style={sortable ? thStyle : thNoSort}
+                      onClick={sortable ? () => handleSort(key) : undefined}
+                    >
                       <span className="flex items-center gap-1">
                         {label}
-                        <SortIcon col={key} sortKey={sortKey} dir={sortDir} />
+                        {sortable && <SortIcon col={key} sortKey={sortKey} dir={sortDir} />}
                       </span>
                     </th>
                   ))}
+                  <th style={thNoSort}>Start</th>
+                  <th style={thNoSort}>End</th>
+                  <th style={thNoSort}>Source</th>
                 </tr>
               </thead>
               <tbody>
-                {pageData.map((w, i) => (
-                  <tr key={i}>
-                    <td style={{ ...tdBase, color: "var(--color-text-muted)" }}>{fmtDate(w.date)}</td>
-                    <td style={{ ...tdBase, fontWeight: 500, textTransform: "capitalize" }}>{w.activity ?? "—"}</td>
-                    <td style={{ ...tdBase, color: "var(--color-text-muted)", fontVariantNumeric: "tabular-nums" }}>
-                      {w.duration_mins != null ? `${w.duration_mins}m` : "—"}
-                    </td>
-                    <td style={{ ...tdBase, color: "var(--color-text-muted)", fontVariantNumeric: "tabular-nums" }}>
-                      {w.calories != null ? `${w.calories}` : "—"}
-                    </td>
-                    <td style={{ ...tdBase, color: "var(--color-text-muted)", fontVariantNumeric: "tabular-nums" }}>
-                      {w.avg_hr != null ? `${w.avg_hr} bpm` : "—"}
-                    </td>
-                  </tr>
-                ))}
+                {pageData.map((w, i) => {
+                  const hrZones = w.metadata?.hr_zones;
+                  return (
+                    <tr key={i}>
+                      <td style={{ ...tdBase, color: "var(--color-text-muted)" }}>
+                        <div style={{ paddingBottom: hrZones ? 6 : 10 }}>{fmtDate(w.date)}</div>
+                        {hrZones && (
+                          <div
+                            style={{
+                              fontSize: 11,
+                              color: "var(--color-text-faint, var(--color-text-muted))",
+                              paddingBottom: 8,
+                              paddingTop: 2,
+                            }}
+                          >
+                            {hrZones}
+                          </div>
+                        )}
+                      </td>
+                      <td style={{ ...tdBase, fontWeight: 500, textTransform: "capitalize" }}>
+                        <div style={{ paddingBottom: hrZones ? 6 : 10 }}>{w.activity ?? "—"}</div>
+                        {hrZones && <div style={{ paddingBottom: 8, paddingTop: 2 }} />}
+                      </td>
+                      <td
+                        style={{
+                          ...tdBase,
+                          color: "var(--color-text-muted)",
+                          fontVariantNumeric: "tabular-nums",
+                        }}
+                      >
+                        {w.duration_mins != null ? `${w.duration_mins}m` : "—"}
+                      </td>
+                      <td
+                        style={{
+                          ...tdBase,
+                          color: "var(--color-text-muted)",
+                          fontVariantNumeric: "tabular-nums",
+                        }}
+                      >
+                        {w.calories != null ? `${w.calories}` : "—"}
+                      </td>
+                      <td
+                        style={{
+                          ...tdBase,
+                          color: "var(--color-text-muted)",
+                          fontVariantNumeric: "tabular-nums",
+                        }}
+                      >
+                        {w.avg_hr != null ? `${w.avg_hr} bpm` : "—"}
+                      </td>
+                      <td
+                        style={{
+                          ...tdBase,
+                          color: "var(--color-text-muted)",
+                          fontVariantNumeric: "tabular-nums",
+                        }}
+                      >
+                        {fmtTime(w.start_time)}
+                      </td>
+                      <td
+                        style={{
+                          ...tdBase,
+                          color: "var(--color-text-muted)",
+                          fontVariantNumeric: "tabular-nums",
+                        }}
+                      >
+                        {calcEndTime(w.start_time, w.duration_mins)}
+                      </td>
+                      <td style={tdBase}>
+                        {w.source ? (
+                          <span
+                            style={{
+                              display: "inline-block",
+                              fontSize: 10,
+                              fontWeight: 500,
+                              letterSpacing: "0.04em",
+                              padding: "2px 7px",
+                              borderRadius: 999,
+                              border: "1px solid var(--color-border)",
+                              color: SOURCE_COLORS[w.source] ?? "var(--color-text-muted)",
+                              textTransform: "lowercase",
+                            }}
+                          >
+                            {w.source}
+                          </span>
+                        ) : (
+                          "—"
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>
 
           {/* Pagination */}
           {totalPages > 1 && (
-            <div className="flex items-center justify-between mt-4 pt-3" style={{ borderTop: "1px solid var(--color-border)" }}>
+            <div
+              className="flex items-center justify-between mt-4 pt-3"
+              style={{ borderTop: "1px solid var(--color-border)" }}
+            >
               <span style={{ fontSize: 12, color: "var(--color-text-muted)" }}>
-                {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, sorted.length)} of {sorted.length}
+                {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, sorted.length)} of{" "}
+                {sorted.length}
               </span>
               <div className="flex gap-2">
                 <button
                   onClick={() => setPage((p) => Math.max(0, p - 1))}
                   disabled={page === 0}
                   className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs transition-colors duration-150 cursor-pointer disabled:opacity-40 disabled:cursor-default"
-                  style={{ background: "transparent", border: "1px solid var(--color-border)", color: "var(--color-text-muted)" }}
+                  style={{
+                    background: "transparent",
+                    border: "1px solid var(--color-border)",
+                    color: "var(--color-text-muted)",
+                  }}
                 >
                   <ChevronLeft size={13} /> Prev
                 </button>
@@ -143,7 +308,11 @@ export function WorkoutHistoryTable({ workouts }: Props) {
                   onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
                   disabled={page === totalPages - 1}
                   className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs transition-colors duration-150 cursor-pointer disabled:opacity-40 disabled:cursor-default"
-                  style={{ background: "transparent", border: "1px solid var(--color-border)", color: "var(--color-text-muted)" }}
+                  style={{
+                    background: "transparent",
+                    border: "1px solid var(--color-border)",
+                    color: "var(--color-text-muted)",
+                  }}
                 >
                   Next <ChevronRight size={13} />
                 </button>

--- a/web/src/lib/sync/fitbit.ts
+++ b/web/src/lib/sync/fitbit.ts
@@ -71,6 +71,39 @@ function fmtHrZones(zones: Record<string, unknown>[]): string | null {
   return parts.length ? parts.join(" | ") : null;
 }
 
+// Canonical activity names — map Fitbit variants to a single label so dedup
+// keys and history views stay consistent regardless of which name the API returns.
+const ACTIVITY_ALIASES: Record<string, string> = {
+  Walking: "Walk",
+  Running: "Run",
+  Biking: "Bike",
+  Cycling: "Bike",
+  "Outdoor Bike": "Bike",
+  Swimming: "Swim",
+  Hiking: "Hike",
+};
+
+function normalizeActivity(name: string): string {
+  return ACTIVITY_ALIASES[name] ?? name;
+}
+
+function timeToMins(t: string | null): number | null {
+  if (!t) return null;
+  const [h, m] = t.split(":").map(Number);
+  return h * 60 + m;
+}
+
+function isBetter(
+  newRow: { avg_hr?: number | null; duration_mins?: number | null },
+  exRow: { avg_hr?: number | null; duration_mins?: number | null },
+): boolean {
+  const newHr = newRow.avg_hr != null;
+  const exHr = exRow.avg_hr != null;
+  if (newHr && !exHr) return true;
+  if (!newHr && exHr) return false;
+  return (newRow.duration_mins ?? 0) > (exRow.duration_mins ?? 0);
+}
+
 // ---------------------------------------------------------------------------
 // Main sync function
 // ---------------------------------------------------------------------------
@@ -176,16 +209,17 @@ export async function syncFitbit(db: SupabaseClient): Promise<FitbitSyncResult> 
     const calories = a.calories as number | undefined;
     const zones = (a.heartRateZones as Record<string, unknown>[] | undefined) ?? [];
 
+    const activity = normalizeActivity((a.activityName as string) ?? "Unknown");
     workoutRows.push({
       date: dateStr,
       start_time: timeStr,
-      activity: (a.activityName as string) ?? "Unknown",
+      activity,
       duration_mins: durationMin,
       calories: calories != null ? Math.round(calories) : null,
       avg_hr: avgHr != null ? Math.round(avgHr) : null,
       source: "fitbit",
       metadata: { hr_zones: fmtHrZones(zones) },
-      _key: `${dateStr}|${timeStr}|${(a.activityName as string) ?? ""}`,
+      _key: `${dateStr}|${timeStr}|${activity}`,
     });
   }
 
@@ -193,20 +227,56 @@ export async function syncFitbit(db: SupabaseClient): Promise<FitbitSyncResult> 
   if (workoutRows.length) {
     const { data: existingWorkouts } = await db
       .from("workout_sessions")
-      .select("date,start_time,activity")
+      .select("id,date,start_time,activity,avg_hr,duration_mins")
       .eq("source", "fitbit");
 
+    const existingList = (existingWorkouts ?? []) as {
+      id: string;
+      date: string;
+      start_time: string | null;
+      activity: string;
+      avg_hr: number | null;
+      duration_mins: number | null;
+    }[];
+
+    // Exact dedup — normalize existing names to match new canonical keys
     const existingKeys = new Set(
-      ((existingWorkouts ?? []) as { date: string; start_time: string; activity: string }[]).map(
-        (r) => `${r.date}|${r.start_time}|${r.activity}`,
-      ),
+      existingList.map((r) => `${r.date}|${r.start_time}|${normalizeActivity(r.activity)}`),
     );
+    const exactNew = workoutRows.filter((r) => !existingKeys.has(r._key as string));
 
-    const newWorkouts = workoutRows
-      .filter((r) => !existingKeys.has(r._key as string))
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      .map(({ _key, ...rest }) => rest);
+    // Time-overlap detection (±5 min on same date)
+    const OVERLAP_MINS = 5;
+    const byDate = new Map<string, typeof existingList>();
+    for (const r of existingList) byDate.set(r.date, [...(byDate.get(r.date) ?? []), r]);
 
+    const toInsert: Record<string, unknown>[] = [];
+    const toDelete: string[] = [];
+
+    for (const newRow of exactNew) {
+      const newMins = timeToMins(newRow.start_time as string | null);
+      let overlapped = false;
+      for (const ex of byDate.get(newRow.date as string) ?? []) {
+        const exMins = timeToMins(ex.start_time);
+        if (newMins == null || exMins == null) continue;
+        if (Math.abs(newMins - exMins) <= OVERLAP_MINS) {
+          overlapped = true;
+          if (isBetter(newRow as { avg_hr?: number | null; duration_mins?: number | null }, ex)) {
+            toDelete.push(ex.id);
+            toInsert.push(newRow);
+          }
+          break;
+        }
+      }
+      if (!overlapped) toInsert.push(newRow);
+    }
+
+    if (toDelete.length) {
+      await db.from("workout_sessions").delete().in("id", toDelete);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const newWorkouts = toInsert.map(({ _key, ...rest }) => rest);
     if (newWorkouts.length) {
       const { error } = await db.from("workout_sessions").insert(newWorkouts);
       if (error) throw new Error(`workout_sessions insert: ${error.message}`);

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -47,6 +47,7 @@ export interface WorkoutSession {
   avg_hr: number | null;
   notes: string | null;
   source: string | null;
+  metadata: { hr_zones: string | null } | null;
 }
 
 export interface RecoveryMetrics {


### PR DESCRIPTION
## Summary

- **Activity name normalization** — `ACTIVITY_ALIASES` map in both `scripts/sync-fitbit.py` and `web/src/lib/sync/fitbit.ts` maps Fitbit name variants to canonical labels (e.g. Walking→Walk, Running→Run, Biking→Bike) before the dedup key is built and before insert; existing DB keys are normalized during comparison so pre-migration rows are not re-inserted
- **DB unique constraint** — migration `20260413000004` adds `unique (date, start_time, source)` to `workout_sessions`
- **Time-overlap detection** — both sync paths check ±5 min window on same date before inserting; prefer HR data then longer duration; delete inferior existing row and insert the better one
- **`normalize_workout_activities.py`** — one-time script to normalize existing rows (`--yes` to apply, dry-run by default); run after deploying
- **Workout history table** — Start time, End time columns (h:mm AM/PM); HR zones secondary line from `metadata.hr_zones`; source badge pill; activity type filter pills; `metadata` field added to `WorkoutSession` type

## Test plan

- [ ] Run `python3 scripts/normalize_workout_activities.py` — verify dry-run output, then `--yes` to apply
- [ ] Run `python3 scripts/sync-fitbit.py --yes` — confirm no duplicates re-inserted; check normalization in output
- [ ] Trigger web sync via `/api/cron/sync` or the sync button — confirm no `workout_sessions insert` error from the unique constraint
- [ ] Open Fitness page → Workout History table — verify Start/End time columns, HR zones line, source badge, and activity filter pills render correctly
- [ ] Filter by an activity type — confirm table filters and resets to page 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)