### PR TITLE
fix: chat de-sync — messages disappear or appear out of order on refresh (issue #132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (chat de-sync — messages disappear or appear out of order on refresh — issue #132)
+- **Early user message persistence** — user message and session row are now inserted at the start of the POST handler, before `streamText` is called; `onFinish` only inserts the assistant reply; messages now survive stream errors, timeouts, and aborts
+- **`position` column on `chat_messages`** — migration `20260413000005_chat_messages_position.sql` adds a `bigint position` column; each insert derives `MAX(position) + 1` within the session so ordering is deterministic and independent of `created_at` timestamp precision
+- **Ordering by `position ASC`** — both `api/chat/sessions/[id]/route.ts` (history fetch) and the in-request context load in `api/chat/route.ts` now order by `position` instead of `created_at`
+- **Retry dedup guard** — before inserting the user message, the handler checks for an identical message in the same session inserted within the last 10 seconds; duplicate inserts on retry are skipped
+
 ### Added (calendar delete/move, conflict detection, deduplication — issue #129)
 - **`eventId` in `list_calendar_events`** — each returned event now includes `eventId` (Google Calendar event ID); tool description updated so Bridge knows to preserve it for follow-up calls
 - **`delete_calendar_event` tool** — deletes an event by `eventId`; system prompt rule requires Bridge to state title/date/time and obtain explicit user confirmation before calling

--- a/supabase/migrations/20260413000005_chat_messages_position.sql
+++ b/supabase/migrations/20260413000005_chat_messages_position.sql
@@ -1,0 +1,26 @@
+-- Add an explicit position column to chat_messages so messages can be ordered
+-- deterministically regardless of created_at timestamp precision.
+--
+-- Fixes issue #132: two rows inserted in the same batched insert share the same
+-- now() value, causing Postgres to return them in undefined order.
+
+alter table chat_messages add column if not exists position bigint;
+
+-- Backfill existing rows: assign position within each session ordered by
+-- created_at, then id as a tiebreaker.
+update chat_messages m
+set position = sub.rn
+from (
+  select
+    id,
+    row_number() over (
+      partition by session_id
+      order by created_at asc, id asc
+    ) as rn
+  from chat_messages
+) sub
+where m.id = sub.id;
+
+-- Index for ordered message fetching by session
+create index if not exists chat_messages_session_position_idx
+  on chat_messages (session_id, position);

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -152,13 +152,66 @@ export async function POST(req: Request) {
       .select("role, content")
       .eq("session_id", sessionId)
       .in("role", ["user", "assistant"])
-      .order("created_at", { ascending: true })
+      .order("position", { ascending: true, nullsFirst: false })
       .limit(20);
     if (data) {
       // Filter out empty-content messages — they cause Anthropic 400 errors
       contextMessages = (data as { role: "user" | "assistant"; content: string }[]).filter(
         (m) => m.content.trim() !== ""
       );
+    }
+  }
+
+  // Persist the session and user message immediately — before streaming starts.
+  // This ensures messages survive stream errors, timeouts, or aborts (fix for issue #132).
+  const lastUserMessage = messages[messages.length - 1];
+  const userMessageContent = typeof lastUserMessage?.content === "string"
+    ? lastUserMessage.content
+    : JSON.stringify(lastUserMessage?.content ?? "");
+
+  if (sessionId && userId && userMessageContent.trim()) {
+    try {
+      // Upsert the session — creates it if it doesn't exist yet (lazy session creation
+      // for new chats whose UUID was generated client-side before any DB write).
+      await supabase.from("chat_sessions").upsert(
+        { id: sessionId, user_id: userId, device: "web", last_active_at: new Date().toISOString() },
+        { onConflict: "id" }
+      );
+
+      // Dedup guard: skip insert if an identical user message was persisted in the
+      // last 10 seconds (handles retries — same message re-POSTed after a stream error).
+      const { data: recent } = await supabase
+        .from("chat_messages")
+        .select("id")
+        .eq("session_id", sessionId)
+        .eq("role", "user")
+        .eq("content", userMessageContent)
+        .gte("created_at", new Date(Date.now() - 10_000).toISOString())
+        .limit(1)
+        .maybeSingle();
+
+      if (!recent) {
+        // Derive next position: MAX(position) + 1 within this session.
+        const { data: posRow } = await supabase
+          .from("chat_messages")
+          .select("position")
+          .eq("session_id", sessionId)
+          .order("position", { ascending: false, nullsFirst: false })
+          .limit(1)
+          .maybeSingle();
+        const nextPos = ((posRow?.position as number | null) ?? 0) + 1;
+
+        await supabase.from("chat_messages").insert({
+          session_id: sessionId,
+          user_id: userId,
+          role: "user",
+          content: userMessageContent,
+          position: nextPos,
+        });
+      }
+    } catch (err) {
+      // Non-fatal — stream proceeds regardless; worst case the message is missing on refresh
+      console.error("[chat] early user message persist error:", err);
     }
   }
 
@@ -999,34 +1052,33 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
       console.error("[chat] streamText error:", JSON.stringify(error));
     },
     onFinish: async ({ text }) => {
-      if (!sessionId) return;
+      if (!sessionId || !userId) return;
       if (!text.trim()) return; // Don't persist empty assistant responses (failed/tool-only steps)
 
-      const lastUserMessage = messages[messages.length - 1];
-
       try {
-        // Upsert the session — creates it if it doesn't exist yet (lazy session creation
-        // for new chats whose UUID was generated client-side before any DB write).
-        const { error: sessionError } = await supabase.from("chat_sessions").upsert(
+        // Update session last_active_at to reflect completed turn.
+        await supabase.from("chat_sessions").upsert(
           { id: sessionId, user_id: userId, device: "web", last_active_at: new Date().toISOString() },
           { onConflict: "id" }
         );
-        if (sessionError) throw sessionError;
 
-        const { error: insertError } = await supabase.from("chat_messages").insert([
-          {
-            session_id: sessionId,
-            user_id: userId,
-            role: "user",
-            content: lastUserMessage.content,
-          },
-          {
-            session_id: sessionId,
-            user_id: userId,
-            role: "assistant",
-            content: text,
-          },
-        ]);
+        // Derive next position so the assistant message sorts after the user message.
+        const { data: posRow } = await supabase
+          .from("chat_messages")
+          .select("position")
+          .eq("session_id", sessionId)
+          .order("position", { ascending: false, nullsFirst: false })
+          .limit(1)
+          .maybeSingle();
+        const nextPos = ((posRow?.position as number | null) ?? 0) + 1;
+
+        const { error: insertError } = await supabase.from("chat_messages").insert({
+          session_id: sessionId,
+          user_id: userId,
+          role: "assistant",
+          content: text,
+          position: nextPos,
+        });
         if (insertError) throw insertError;
       } catch (err) {
         console.error("[chat] onFinish persist error:", err);

--- a/web/src/app/api/chat/sessions/[id]/route.ts
+++ b/web/src/app/api/chat/sessions/[id]/route.ts
@@ -18,7 +18,7 @@ export async function GET(
     .select("id, role, content, created_at")
     .eq("session_id", id)
     .in("role", ["user", "assistant"])
-    .order("created_at", { ascending: true })
+    .order("position", { ascending: true, nullsFirst: false })
     .limit(50);
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });


### PR DESCRIPTION
## Summary

- **Persist user message before streaming** — the user message and session row are now written to Supabase at the start of the POST handler, before `streamText` is called. `onFinish` only inserts the assistant reply. Messages now survive stream errors, timeouts, and aborts.
- **`position` column on `chat_messages`** — new migration (`20260413000005`) adds a `bigint position` column. Each insert computes `MAX(position) + 1` within the session, so message order is deterministic and independent of `created_at` timestamp precision.
- **Order by `position ASC`** — both the history fetch (`api/chat/sessions/[id]/route.ts`) and the in-request context load in `api/chat/route.ts` now order by `position` instead of `created_at`.
- **Retry dedup guard** — before inserting the user message, the handler checks for an identical message in the same session inserted within the last 10 seconds; duplicate inserts on retry are skipped.

Closes #132.

## Files changed

- `supabase/migrations/20260413000005_chat_messages_position.sql` — new migration
- `web/src/app/api/chat/route.ts` — early persistence, dedup guard, position assignment, onFinish cleanup
- `web/src/app/api/chat/sessions/[id]/route.ts` — order by position

## Test plan

- [ ] Send a message, kill the tab mid-stream — on reload the user message is present in the session
- [ ] Send a message that completes — on reload both messages appear in the correct order (user before assistant)
- [ ] Send the same message twice quickly (simulate retry) — only one user message row appears in the DB
- [ ] Run migration against Supabase — existing rows get backfilled positions based on created_at order

🤖 Generated with [Claude Code](https://claude.com/claude-code)