### PR TITLE
fix: meal log route missing user_id (issue #136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (meal log route missing user_id — issue #136)
+- **`user_id` added to insert payload** — `POST /api/meals/log` now resolves the authenticated user via `supabase.auth.getUser()` and includes `user_id` in the `meal_log` insert; returns `401 Unauthorized` if no session
+- **Service client replaced** — `createServiceClient` swapped for `createClient` from `@/lib/supabase/server` so the route operates under the user's session context
+
 ### Fixed (chat de-sync — messages disappear or appear out of order on refresh — issue #132)
 - **Early user message persistence** — user message and session row are now inserted at the start of the POST handler, before `streamText` is called; `onFinish` only inserts the assistant reply; messages now survive stream errors, timeouts, and aborts
 - **`position` column on `chat_messages`** — migration `20260413000005_chat_messages_position.sql` adds a `bigint position` column; each insert derives `MAX(position) + 1` within the session so ordering is deterministic and independent of `created_at` timestamp precision

--- a/web/src/app/api/meals/log/route.ts
+++ b/web/src/app/api/meals/log/route.ts
@@ -1,4 +1,4 @@
-import { createServiceClient } from "@/lib/supabase/service";
+import { createClient } from "@/lib/supabase/server";
 import { todayString } from "@/lib/timezone";
 
 interface MealLogBody {
@@ -27,11 +27,14 @@ export async function POST(req: Request) {
     return Response.json({ error: "meal_type must be breakfast, lunch, dinner, or snack" }, { status: 400 });
   }
 
-  const supabase = createServiceClient();
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return Response.json({ error: "Unauthorized" }, { status: 401 });
 
   const { data, error } = await supabase
     .from("meal_log")
     .insert({
+      user_id: user.id,
       meal_type: body.meal_type,
       notes: body.notes ?? null,
       date: body.date ?? todayString(),


### PR DESCRIPTION
## Summary

- Replaces `createServiceClient` with `createClient` from `@/lib/supabase/server` so the route operates under the authenticated session instead of the service role
- Resolves the authenticated user at the top of the handler; returns `401 Unauthorized` if unauthenticated
- Adds `user_id: user.id` to the `meal_log` insert payload
- Updates CHANGELOG

Closes #136

## Test plan

- [ ] POST `/api/meals/log` with a valid session inserts a row with the correct `user_id`
- [ ] POST `/api/meals/log` without a session returns `401 Unauthorized`

🤖 Generated with [Claude Code](https://claude.com/claude-code)