### PR TITLE
fix: food photo upload fails on mobile (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (food photo upload fails on mobile — issue #135)
+- **Client-side compression** — `compressImage` helper in `FoodPhotoAnalyzer.tsx` uses the Canvas API to cap the longest edge at 1920 px and re-encode as JPEG at 0.85 quality before upload; replaces the raw file in FormData so uploads stay well under Vercel's 4.5 MB limit
+- **HEIC early rejection (client)** — if the selected file is `image/heic` or ends in `.heic`, an error is shown immediately with instructions to switch iPhone Camera to "Most Compatible"; no upload is attempted
+- **Safe JSON parsing** — `handleFileChange` checks `content-type` before calling `.json()`; a non-JSON 413 response is detected from the body text and surfaces "Image is too large to upload. Please try a smaller photo."
+- **Server-side size guard lowered to 4 MB** — `MAX_SIZE` in `analyze-photo/route.ts` changed from 10 MB to 4 MB (below Vercel's 4.5 MB cutoff); error message updated to match; returns `413` so the client can detect it
+- **HEIC server-side rejection** — `SUPPORTED_TYPES` check added after file-type validation; unsupported formats return `415 Unsupported Media Type` with a descriptive message
+
 ### Fixed (meal log route missing user_id — issue #136)
 - **`user_id` added to insert payload** — `POST /api/meals/log` now resolves the authenticated user via `supabase.auth.getUser()` and includes `user_id` in the `meal_log` insert; returns `401 Unauthorized` if no session
 - **Service client replaced** — `createServiceClient` swapped for `createClient` from `@/lib/supabase/server` so the route operates under the user's session context

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ flowchart LR
 - **Fitness** — Body composition charts (weight + BF%), weekly workout frequency, active calorie chart, full workout history table (start/end time, HR zones, source badge, activity filter); goal progress overlays
 - **Journal** — Guided 5-prompt daily reflection + free-write tab; auto-save; collapsible history
 - **Weekly Review** — Last 7 days at a glance: habit scores, task completion, workout summary, recovery averages, body comp delta, journal count
-- **Meals** — Daily macro summary vs goals; food photo analyzer (photo → Claude vision → macro estimate → log); 7-day meal history
+- **Meals** — Daily macro summary vs goals; food photo analyzer (photo → client-side compression → Claude vision → macro estimate → log); HEIC detection with user-friendly guidance; 7-day meal history
 - **Push notifications** — HRV drop alerts, task due-date reminders, weather warnings, birthday reminders, weekly review nudge via ntfy.sh (Android/iOS/macOS)
 
 ---

--- a/web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx
+++ b/web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx
@@ -55,16 +55,75 @@ export default function FoodPhotoAnalyzer() {
     if (fileInputRef.current) fileInputRef.current.value = "";
   }
 
+  async function compressImage(file: File): Promise<Blob> {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      const objectUrl = URL.createObjectURL(file);
+      img.onload = () => {
+        URL.revokeObjectURL(objectUrl);
+        const MAX_EDGE = 1920;
+        let { width, height } = img;
+        if (width > MAX_EDGE || height > MAX_EDGE) {
+          if (width >= height) {
+            height = Math.round((height * MAX_EDGE) / width);
+            width = MAX_EDGE;
+          } else {
+            width = Math.round((width * MAX_EDGE) / height);
+            height = MAX_EDGE;
+          }
+        }
+        const canvas = document.createElement("canvas");
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) return reject(new Error("Canvas unavailable"));
+        ctx.drawImage(img, 0, 0, width, height);
+        canvas.toBlob(
+          (blob) => {
+            if (blob) resolve(blob);
+            else reject(new Error("Compression failed"));
+          },
+          "image/jpeg",
+          0.85
+        );
+      };
+      img.onerror = () => {
+        URL.revokeObjectURL(objectUrl);
+        reject(new Error("Failed to load image for compression"));
+      };
+      img.src = objectUrl;
+    });
+  }
+
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
+
+    // Reject HEIC — Canvas API cannot decode it in-browser
+    if (
+      file.type === "image/heic" ||
+      file.name.toLowerCase().endsWith(".heic")
+    ) {
+      setErrorMsg(
+        "In your iPhone Camera settings, set format to 'Most Compatible' and try again."
+      );
+      setPhase("error");
+      return;
+    }
 
     const url = URL.createObjectURL(file);
     setPreviewUrl(url);
     setPhase("loading");
 
+    let imageBlob: Blob;
+    try {
+      imageBlob = await compressImage(file);
+    } catch {
+      imageBlob = file;
+    }
+
     const formData = new FormData();
-    formData.append("image", file);
+    formData.append("image", imageBlob, "photo.jpg");
     if (userPrompt.trim()) formData.append("prompt", userPrompt.trim());
 
     try {
@@ -72,10 +131,19 @@ export default function FoodPhotoAnalyzer() {
         method: "POST",
         body: formData,
       });
-      const data = await res.json();
-      if (!res.ok || data.error) throw new Error(data.error ?? "Analysis failed");
-      setReview(data as ReviewState);
-      setPhase("review");
+      const contentType = res.headers.get("content-type") ?? "";
+      if (contentType.includes("application/json")) {
+        const data = await res.json();
+        if (!res.ok || data.error) throw new Error(data.error ?? "Analysis failed");
+        setReview(data as ReviewState);
+        setPhase("review");
+      } else {
+        const text = await res.text();
+        if (res.status === 413 || text.includes("Entity Too Large")) {
+          throw new Error("Image is too large to upload. Please try a smaller photo.");
+        }
+        throw new Error("Analysis failed");
+      }
     } catch (err) {
       setErrorMsg(err instanceof Error ? err.message : "Analysis failed");
       setPhase("error");

--- a/web/src/app/api/meals/analyze-photo/route.ts
+++ b/web/src/app/api/meals/analyze-photo/route.ts
@@ -49,10 +49,19 @@ export async function POST(req: Request) {
     return Response.json({ error: "File must be an image" }, { status: 400 });
   }
 
-  // Limit to 10 MB to avoid excessive token costs
-  const MAX_SIZE = 10 * 1024 * 1024;
+  // Reject unsupported formats (e.g. HEIC) that Claude cannot process
+  const SUPPORTED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+  if (!SUPPORTED_TYPES.includes(imageFile.type)) {
+    return Response.json(
+      { error: `Unsupported format: ${imageFile.type}. Use JPEG, PNG, or WebP.` },
+      { status: 415 }
+    );
+  }
+
+  // 4 MB backstop — Vercel's hard limit is 4.5 MB; client compresses first
+  const MAX_SIZE = 4 * 1024 * 1024;
   if (imageFile.size > MAX_SIZE) {
-    return Response.json({ error: "Image must be under 10 MB" }, { status: 400 });
+    return Response.json({ error: "Image must be under 4 MB" }, { status: 413 });
   }
 
   // Read into memory — never stored, analyzed in-transit only


### PR DESCRIPTION
## Summary

- **Client-side compression** — Canvas API compresses to max 1920px longest edge, JPEG at 0.85 quality before upload; keeps payloads well under Vercel's 4.5 MB hard limit
- **HEIC early rejection (client)** — detects `image/heic` type or `.heic` filename and shows a clear message ("In your iPhone Camera settings, set format to 'Most Compatible'") before any upload attempt
- **Safe JSON parsing** — `handleFileChange` checks `content-type` before calling `.json()`; non-JSON 413 responses are detected from body text and surface a human-readable error
- **Server size guard lowered to 4 MB** — `MAX_SIZE` in `analyze-photo/route.ts` dropped from 10 MB to 4 MB so the in-code guard fires as a backstop before Vercel's limit; returns `413`
- **HEIC server-side rejection** — `SUPPORTED_TYPES` check added after file-type validation; unsupported formats return `415 Unsupported Media Type`

## Test plan

- [ ] Upload a large JPEG (>2 MB) from mobile — should compress and succeed
- [ ] Upload a HEIC file — should show the Camera settings error message immediately, no network request
- [ ] Upload a file that exceeds 4 MB after compression (edge case) — should show "Image is too large to upload" error
- [ ] Upload a valid JPEG/PNG/WebP — normal happy path unchanged
- [ ] Verify server returns 413 JSON for oversized uploads, 415 for HEIC bypass attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)