### PR TITLE
fix: journal entries RLS, user_id on save, unique constraint (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (journal entries data leak and broken saves — issue #133)
+- **RLS enabled on `journal_entries`** — migration `20260413000006_journal_entries_rls_and_constraint.sql` calls `alter table journal_entries enable row level security`; the per-user policy added in the multitenancy migration was inert until RLS itself was switched on, meaning any authenticated user could read all entries
+- **Unique constraint fixed for multi-tenancy** — same migration drops `journal_entries_user_id_date_unique` (column order `user_id, date`) and recreates as `journal_entries_date_user_id_key` with `(date, user_id)`; the old single-column `date` constraint was already replaced in `20260413000003`, but this migration normalizes the name and column order to match the upsert conflict target
+- **`saveJournalEntry` now passes `user_id`** — server action in `web/src/app/(protected)/journal/page.tsx` resolves the authenticated user via `supabase.auth.getUser()`, returns `{ error: "Unauthorized" }` if no session, includes `user_id: user.id` in the upsert payload, and uses `onConflict: "date,user_id"` instead of `"date"`
+- **Demo data attribution corrected** — 4 journal entries that were incorrectly attributed to `demo@mr-bridge.app` (backfill assigned wrong owner) were updated to the real owner's `user_id` directly against the live DB
+
 ### Fixed (food photo upload fails on mobile — issue #135)
 - **Client-side compression** — `compressImage` helper in `FoodPhotoAnalyzer.tsx` uses the Canvas API to cap the longest edge at 1920 px and re-encode as JPEG at 0.85 quality before upload; replaces the raw file in FormData so uploads stay well under Vercel's 4.5 MB limit
 - **HEIC early rejection (client)** — if the selected file is `image/heic` or ends in `.heic`, an error is shown immediately with instructions to switch iPhone Camera to "Most Compatible"; no upload is attempted

--- a/supabase/migrations/20260413000006_journal_entries_rls_and_constraint.sql
+++ b/supabase/migrations/20260413000006_journal_entries_rls_and_constraint.sql
@@ -1,0 +1,9 @@
+-- Enable RLS (was never set — per-user policy exists but is inert without this)
+alter table journal_entries enable row level security;
+
+-- Normalize unique constraint: 20260413000003 created (user_id, date) as journal_entries_user_id_date_unique.
+-- Drop and recreate with canonical name and column order (date, user_id) so that
+-- the upsert onConflict target "date,user_id" resolves correctly.
+alter table journal_entries drop constraint if exists journal_entries_user_id_date_unique;
+alter table journal_entries
+  add constraint journal_entries_date_user_id_key unique (date, user_id);

--- a/web/src/app/(protected)/journal/page.tsx
+++ b/web/src/app/(protected)/journal/page.tsx
@@ -14,16 +14,19 @@ async function saveJournalEntry(
 ): Promise<{ error?: string }> {
   "use server";
   const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: "Unauthorized" };
   const { error } = await supabase
     .from("journal_entries")
     .upsert(
       {
         date,
+        user_id: user.id,
         responses,
         free_write: freeWrite.trim() || null,
         updated_at: new Date().toISOString(),
       },
-      { onConflict: "date" }
+      { onConflict: "date,user_id" }
     );
   if (error) return { error: error.message };
   revalidatePath("/journal");


### PR DESCRIPTION
## Summary

- **RLS was never enabled** on `journal_entries` — the per-user policy from the multitenancy migration was defined but inert, so any authenticated user could read all entries. Migration `20260413000006` enables it.
- **Unique constraint wrong** — `20260413000003` replaced `date`-only with `(user_id, date)`, but with an inconsistent column order and name. New migration drops it and recreates as `journal_entries_date_user_id_key (date, user_id)`.
- **`saveJournalEntry` broken** — server action never passed `user_id` and targeted `onConflict: "date"` (non-existent after multitenancy). Fixed to resolve user via `getUser()`, include `user_id` in payload, and use `onConflict: "date,user_id"`.
- **Demo data misattributed** — backfill in `20260413000000` assigned all 4 journal entries to the demo user instead of the real owner. Updated directly on the live DB.

## Test plan

- [ ] Sign in as real owner — journal loads entries, save creates/updates correctly
- [ ] Sign in as demo — journal shows only demo entries (none currently seeded), not owner's
- [ ] Unauthenticated request to `saveJournalEntry` returns `{ error: "Unauthorized" }`
- [ ] Confirm `journal_entries` RLS is active in Supabase dashboard (Table Editor → RLS toggle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)