### PR TITLE
fix: chat textarea with shift+enter + auto-expand, mobile bottom spacing (#134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (chat textarea with shift+enter + auto-expand, mobile bottom spacing — issue #134)
+- **`<input>` replaced with auto-expanding `<textarea>`** — `chat-interface.tsx` now uses a `<textarea rows={1}>` with an auto-resize effect that sets height from `scrollHeight` on every input change; capped at `max-height: 200px` with `overflow-y: auto` so the field scrolls internally rather than growing unbounded
+- **Shift+Enter inserts newlines** — `handleKeyDown` now passes through `Enter` when `shiftKey` is held, allowing multi-line input; plain Enter submits (or applies a slash command if the menu is open)
+- **Mobile bottom spacing fixed** — replaced `height: calc(100dvh - 8rem)` hardcoded on `ChatInterface` with a flex-fill chain: `chat/page.tsx` wraps in `h-full flex flex-col`; `chat-page-client.tsx` root div and content row use `flex flex-col flex-1 min-h-0`; `ChatInterface` root div uses `flex flex-col flex-1 min-h-0` — the chat fills available layout height without dead space below the input bar on mobile
+
 ### Fixed (journal entries data leak and broken saves — issue #133)
 - **RLS enabled on `journal_entries`** — migration `20260413000006_journal_entries_rls_and_constraint.sql` calls `alter table journal_entries enable row level security`; the per-user policy added in the multitenancy migration was inert until RLS itself was switched on, meaning any authenticated user could read all entries
 - **Unique constraint fixed for multi-tenancy** — same migration drops `journal_entries_user_id_date_unique` (column order `user_id, date`) and recreates as `journal_entries_date_user_id_key` with `(date, user_id)`; the old single-column `date` constraint was already replaced in `20260413000003`, but this migration normalizes the name and column order to match the upsert conflict target

--- a/web/src/app/(protected)/chat/page.tsx
+++ b/web/src/app/(protected)/chat/page.tsx
@@ -38,9 +38,11 @@ export default async function ChatPage() {
   }
 
   return (
-    <ChatPageClient
-      initialSessionId={(session as ChatSession | null)?.id ?? null}
-      initialMessages={initialMessages}
-    />
+    <div className="h-full flex flex-col">
+      <ChatPageClient
+        initialSessionId={(session as ChatSession | null)?.id ?? null}
+        initialMessages={initialMessages}
+      />
+    </div>
   );
 }

--- a/web/src/components/chat/chat-interface.tsx
+++ b/web/src/components/chat/chat-interface.tsx
@@ -27,7 +27,7 @@ function getSlashToken(value: string, cursorPos: number): { start: number; query
 
 export default function ChatInterface({ sessionId, initialMessages, onMessageSent }: Props) {
   const bottomRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
 
   const { messages, input, handleInputChange, handleSubmit, isLoading, error, reload, setInput } = useChat({
     api: "/api/chat",
@@ -54,8 +54,8 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
   }, []);
 
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      handleInputChange(e);
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      handleInputChange(e as unknown as React.ChangeEvent<HTMLInputElement>);
       updateMenu(e.target.value, e.target.selectionStart ?? e.target.value.length);
     },
     [handleInputChange, updateMenu]
@@ -83,32 +83,41 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
   );
 
   const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (menuCommands.length === 0) return;
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       switch (e.key) {
         case "ArrowDown":
+          if (menuCommands.length === 0) return;
           e.preventDefault();
           setActiveIndex((i) => (i + 1) % menuCommands.length);
           break;
         case "ArrowUp":
+          if (menuCommands.length === 0) return;
           e.preventDefault();
           setActiveIndex((i) => (i - 1 + menuCommands.length) % menuCommands.length);
           break;
         case "Enter":
-          e.preventDefault();
-          applyCommand(menuCommands[activeIndex]);
+          if (e.shiftKey) return; // allow default newline in textarea
+          if (menuCommands.length > 0) {
+            e.preventDefault();
+            applyCommand(menuCommands[activeIndex]);
+          } else {
+            e.preventDefault();
+            handleSubmit(e as unknown as React.FormEvent);
+          }
           break;
         case "Escape":
+          if (menuCommands.length === 0) return;
           e.preventDefault();
           setMenuCommands([]);
           break;
         case "Tab":
+          if (menuCommands.length === 0) return;
           e.preventDefault();
           applyCommand(menuCommands[activeIndex]);
           break;
       }
     },
-    [menuCommands, activeIndex, applyCommand]
+    [menuCommands, activeIndex, applyCommand, handleSubmit]
   );
 
   // ── Scroll to bottom on new messages ─────────────────────────────────
@@ -116,8 +125,16 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
+  // ── Auto-resize textarea ──────────────────────────────────────────────
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [input]);
+
   return (
-    <div className="flex flex-col" style={{ height: "calc(100dvh - 8rem)" }}>
+    <div className="flex flex-col flex-1 min-h-0">
       {/* Message list */}
       <div className="flex-1 overflow-y-auto space-y-3 py-4 min-h-0">
         {messages.length === 0 && (
@@ -217,8 +234,9 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
               onHover={setActiveIndex}
             />
           )}
-          <input
+          <textarea
             ref={inputRef}
+            rows={1}
             value={input}
             onChange={handleChange}
             onKeyDown={handleKeyDown}
@@ -229,6 +247,10 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
             aria-expanded={menuCommands.length > 0}
             className="w-full rounded-xl px-4 py-2.5 text-sm transition-colors duration-150 focus:outline-none"
             style={{
+              resize: "none",
+              overflow: "hidden",
+              maxHeight: 200,
+              overflowY: "auto",
               background: "var(--color-surface)",
               border: "1px solid var(--color-border)",
               color: "var(--color-text)",

--- a/web/src/components/chat/chat-page-client.tsx
+++ b/web/src/components/chat/chat-page-client.tsx
@@ -96,7 +96,7 @@ export default function ChatPageClient({ initialSessionId, initialMessages }: Pr
   }, [fetchSessions]);
 
   return (
-    <div>
+    <div className="flex flex-col flex-1 min-h-0">
       {/* Page header */}
       <div className="flex items-center justify-between mb-5">
         <div className="flex items-center gap-2">
@@ -176,7 +176,7 @@ export default function ChatPageClient({ initialSessionId, initialMessages }: Pr
       </div>
 
       {/* Content row: sidebar + chat */}
-      <div className="flex gap-4 items-start">
+      <div className="flex gap-4 items-stretch flex-1 min-h-0">
         {/* Desktop history sidebar */}
         {historyOpen && (
           <div className="hidden lg:block">
@@ -190,11 +190,11 @@ export default function ChatPageClient({ initialSessionId, initialMessages }: Pr
         )}
 
         {/* Chat interface */}
-        <div className="flex-1 min-w-0">
+        <div className="flex flex-col flex-1 min-w-0 min-h-0">
           {loadingSession ? (
             <div
-              className="flex items-center justify-center"
-              style={{ height: "calc(100dvh - 8rem)", color: "var(--color-text-muted)", fontSize: 14 }}
+              className="flex flex-1 items-center justify-center"
+              style={{ color: "var(--color-text-muted)", fontSize: 14 }}
             >
               Loading conversation&hellip;
             </div>


### PR DESCRIPTION
## Summary

- **Textarea auto-expand** — `<input>` in `chat-interface.tsx` replaced with `<textarea rows={1}>` that auto-resizes via a `scrollHeight` effect on every keystroke, capped at 200 px with internal scroll beyond that
- **Shift+Enter newlines** — `handleKeyDown` passes through `Enter` when `shiftKey` is held; plain `Enter` submits (or applies the active slash command)
- **Mobile bottom spacing** — replaced the hardcoded `height: calc(100dvh - 8rem)` with a flex-fill chain: `chat/page.tsx` → `h-full flex flex-col` wrapper; `chat-page-client.tsx` root + content-row divs → `flex flex-col flex-1 min-h-0`; `ChatInterface` root → `flex flex-col flex-1 min-h-0`; input bar now sits flush above the browser nav with no dead space

## Test plan

- [ ] Desktop: type a long message — textarea expands line by line, stops at ~200 px and scrolls internally
- [ ] Desktop: Shift+Enter inserts a newline; Enter submits
- [ ] Desktop: slash command menu — Enter applies command, Shift+Enter still inserts newline
- [ ] Mobile (375 px): input bar sits flush above browser nav bar, no dead space below it
- [ ] Desktop: overall chat layout unchanged — no regression in sidebar or session switching

🤖 Generated with [Claude Code](https://claude.ai/claude-code)