### PR TITLE
feat: notification history center — log + web UI + nav badge (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (notification history center — issue #99)
+- **`notifications` table** — new Supabase table (`id`, `user_id`, `type`, `title`, `body`, `sent_at`, `read_at`) with RLS, per-user composite index on `(user_id, sent_at desc)`, and a partial index for unread rows; migration `20260413000007_notifications.sql` applied to live DB
+- **`log_notification` helper** in `scripts/_supabase.py` — inserts a row after each successful push notification; non-fatal (errors go to stderr only)
+- **HRV, weather, task, and birthday scripts updated** — `check_hrv_alert.py`, `check_weather_alert.py`, `check_daily_alerts.py`, `check_birthday_notif.py` all call `log_notification` with `type`, `title`, and `body` after a confirmed `subprocess.run` success; `check_birthday_notif.py` initializes its own Supabase client for this purpose
+- **30-day TTL cleanup** wired into `api/cron/sync/route.ts` (runs daily at 6 AM PST) — deletes rows where `sent_at < now() - 30 days` before syncs run; time-based rather than count-based so recent unread notifications are never silently dropped
+- **`/notifications` page** — server component at `web/src/app/(protected)/notifications/page.tsx`; fetches last 50 notifications within the 30-day window; marks all unread as read on page load via a single `UPDATE` before rendering; passes `isUnread` flag per row to the client component
+- **`NotificationList` client component** — `web/src/components/notifications/notification-list.tsx`; type filter pills (All / HRV / Weather / Tasks / Birthday); per-row icon by type; relative time display (`Just now`, `2 hours ago`, `Yesterday`, weekday, or `Apr 3`); left-border accent + bold title for unread rows at fetch time; "No notifications yet" empty state
+- **`/api/notifications/unread-count` route** — returns `{ count: number }` for unread rows within the 30-day window; called by Nav on mount and on route change
+- **Notifications nav item** — `Bell` icon added to `NAV_ITEMS` between Chat and Settings; appears in desktop sidebar and in the More bottom sheet on mobile; red dot/count badge rendered on the Bell icon when `unreadCount > 0`; badge refreshes on every route change via `useEffect([pathname])`
+
 ### Fixed (chat textarea with shift+enter + auto-expand, mobile bottom spacing — issue #134)
 - **`<input>` replaced with auto-expanding `<textarea>`** — `chat-interface.tsx` now uses a `<textarea rows={1}>` with an auto-resize effect that sets height from `scrollHeight` on every input change; capped at `max-height: 200px` with `overflow-y: auto` so the field scrolls internally rather than growing unbounded
 - **Shift+Enter inserts newlines** — `handleKeyDown` now passes through `Enter` when `shiftKey` is held, allowing multi-line input; plain Enter submits (or applies a slash command if the menu is open)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ flowchart LR
 - **Journal** — Guided 5-prompt daily reflection + free-write tab; auto-save; collapsible history
 - **Weekly Review** — Last 7 days at a glance: habit scores, task completion, workout summary, recovery averages, body comp delta, journal count
 - **Meals** — Daily macro summary vs goals; food photo analyzer (photo → client-side compression → Claude vision → macro estimate → log); HEIC detection with user-friendly guidance; 7-day meal history
+- **Notifications** — In-app notification center (`/notifications`) showing last 30 days of push notification history; type filter pills (HRV / Weather / Tasks / Birthday); unread indicator (left-border accent + bold title); red badge on the Bell nav icon; auto-marked read on page visit; 30-day TTL auto-cleanup via daily cron
 - **Push notifications** — HRV drop alerts, task due-date reminders, weather warnings, birthday reminders, weekly review nudge via ntfy.sh (Android/iOS/macOS)
 
 ---

--- a/scripts/_supabase.py
+++ b/scripts/_supabase.py
@@ -1,12 +1,13 @@
 """
 Shared Supabase client helper for sync scripts.
 Uses SUPABASE_SERVICE_ROLE_KEY (bypasses RLS).
-Import as: from _supabase import get_client, get_owner_user_id, log_sync, urlopen_with_retry
+Import as: from _supabase import get_client, get_owner_user_id, log_sync, log_notification, urlopen_with_retry
 """
 from __future__ import annotations
 
 import json
 import os
+import sys
 import time
 import urllib.error
 import urllib.request
@@ -66,6 +67,19 @@ def upsert(client, table: str, rows: list[dict], conflict: str | None = None) ->
     kwargs = {"on_conflict": conflict} if conflict else {}
     resp = client.table(table).upsert(rows, **kwargs).execute()
     return len(resp.data)
+
+
+def log_notification(client, user_id: str, type_: str, title: str, body: str | None = None) -> None:
+    """Insert a row into the notifications table. Non-fatal — errors are printed to stderr."""
+    try:
+        client.table("notifications").insert({
+            "user_id": user_id,
+            "type": type_,
+            "title": title,
+            "body": body,
+        }).execute()
+    except Exception as e:
+        print(f"[notify] Failed to log notification: {e}", file=sys.stderr)
 
 
 def log_sync(client, source: str, status: str, records_written: int = 0, error_message: str | None = None):

--- a/scripts/check_birthday_notif.py
+++ b/scripts/check_birthday_notif.py
@@ -22,7 +22,10 @@ from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 
 ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
 load_dotenv(ROOT / ".env")
+from _supabase import get_client, get_owner_user_id, log_notification  # noqa: E402
+
 NOTIFY_SCRIPT = ROOT / "scripts" / "notify.sh"
 CLICK_PATH = "/dashboard"
 
@@ -97,13 +100,24 @@ def main() -> None:
             if is_birthday_event(title, cal_name):
                 birthdays_today.append(person_name(title))
 
+    try:
+        sb_client = get_client()
+        user_id: str | None = get_owner_user_id()
+    except Exception:
+        sb_client = None
+        user_id = None
+
     app_url = os.environ.get("APP_URL", "").rstrip("/")
     for name in birthdays_today:
-        cmd = ["bash", str(NOTIFY_SCRIPT), "--title", "Birthday Today", "--message", f"It's {name}'s birthday today."]
+        title = "Birthday Today"
+        body = f"It's {name}'s birthday today."
+        cmd = ["bash", str(NOTIFY_SCRIPT), "--title", title, "--message", body]
         if app_url:
             cmd += ["--click-url", f"{app_url}{CLICK_PATH}"]
         try:
             subprocess.run(cmd, check=True)
+            if sb_client and user_id:
+                log_notification(sb_client, user_id, "birthday", title, body)
         except Exception as e:
             print(f"[check_birthday_notif] notify error for {name}: {e}", file=sys.stderr)
 

--- a/scripts/check_daily_alerts.py
+++ b/scripts/check_daily_alerts.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(ROOT / "scripts"))
-from _supabase import get_client
+from _supabase import get_client, get_owner_user_id, log_notification
 
 NOTIFY_SCRIPT = ROOT / "scripts" / "notify.sh"
 CLICK_PATH = "/tasks"
@@ -75,6 +75,11 @@ def main() -> None:
         set_profile_value(client, "task_alerts_last_notified", today_str)
         return
 
+    try:
+        user_id: str | None = get_owner_user_id()
+    except EnvironmentError:
+        user_id = None
+
     fired = 0
     for task in rows:
         due = task.get("due_date", "")
@@ -89,6 +94,8 @@ def main() -> None:
         try:
             subprocess.run(cmd, check=True)
             fired += 1
+            if user_id:
+                log_notification(client, user_id, "task_due", title, message)
         except Exception as e:
             print(f"[check_daily_alerts] notify error for task '{name}': {e}", file=sys.stderr)
 

--- a/scripts/check_hrv_alert.py
+++ b/scripts/check_hrv_alert.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(ROOT / "scripts"))
-from _supabase import get_client
+from _supabase import get_client, get_owner_user_id, log_notification
 
 NOTIFY_SCRIPT = ROOT / "scripts" / "notify.sh"
 CLICK_PATH = "/dashboard"
@@ -113,6 +113,8 @@ def main() -> None:
         subprocess.run(cmd, check=True)
         set_profile_value(client, "hrv_alert_last_notified", today_str)
         print(f"[check_hrv_alert] Alert fired: {message}")
+        user_id = get_owner_user_id()
+        log_notification(client, user_id, "hrv_alert", title, message)
     except Exception as e:
         print(f"[check_hrv_alert] notify error: {e}", file=sys.stderr)
 

--- a/scripts/check_weather_alert.py
+++ b/scripts/check_weather_alert.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(ROOT / "scripts"))
-from _supabase import get_client
+from _supabase import get_client, get_owner_user_id, log_notification
 from fetch_weather import fetch_weather
 
 NOTIFY_SCRIPT    = ROOT / "scripts" / "notify.sh"
@@ -51,7 +51,7 @@ def set_profile_value(client, key: str, value: str) -> None:
     client.table("profile").upsert({"key": key, "value": value}, on_conflict="key").execute()
 
 
-def _fire(title: str, message: str) -> bool:
+def _fire(title: str, message: str, client=None, user_id: str | None = None) -> bool:
     app_url = os.environ.get("APP_URL", "").rstrip("/")
     cmd = ["bash", str(NOTIFY_SCRIPT), "--title", title, "--message", message]
     if app_url:
@@ -59,6 +59,8 @@ def _fire(title: str, message: str) -> bool:
     try:
         subprocess.run(cmd, check=True)
         print(f"[check_weather_alert] Alert fired: {message}")
+        if client and user_id:
+            log_notification(client, user_id, "weather", title, message)
         return True
     except Exception as e:
         print(f"[check_weather_alert] notify error: {e}", file=sys.stderr)
@@ -87,12 +89,18 @@ def main() -> None:
         print(f"[check_weather_alert] Weather fetch error: {e}", file=sys.stderr)
         return
 
+    try:
+        user_id: str | None = get_owner_user_id()
+    except EnvironmentError:
+        user_id = None
+
     # Thunderstorm
     wmo = w.get("wmo_code")
     if wmo is not None and wmo in THUNDER_CODES:
         _fire(
             "Severe Weather Alert",
             f"Thunderstorm forecast today (WMO {wmo}). Check conditions before heading out.",
+            client, user_id,
         )
 
     # Heavy precipitation
@@ -101,6 +109,7 @@ def main() -> None:
         _fire(
             "Rain Alert",
             f'{precip:.1f}" of precipitation forecast today. Plan accordingly.',
+            client, user_id,
         )
 
     # Extreme heat
@@ -109,6 +118,7 @@ def main() -> None:
         _fire(
             "Heat Alert",
             f"High of {high:.0f}°F forecast today. Stay hydrated.",
+            client, user_id,
         )
 
     # Freeze warning
@@ -117,6 +127,7 @@ def main() -> None:
         _fire(
             "Freeze Warning",
             f"Low of {low:.0f}°F tonight. Dress warm.",
+            client, user_id,
         )
 
     # High wind
@@ -125,6 +136,7 @@ def main() -> None:
         _fire(
             "Wind Alert",
             f"Wind speeds of {wind:.0f} mph forecast today.",
+            client, user_id,
         )
 
     set_profile_value(client, "weather_alert_last_notified", today_str)

--- a/supabase/migrations/20260413000007_notifications.sql
+++ b/supabase/migrations/20260413000007_notifications.sql
@@ -1,0 +1,18 @@
+create table notifications (
+  id        uuid primary key default gen_random_uuid(),
+  user_id   uuid not null references auth.users(id) on delete cascade,
+  type      text not null,   -- 'hrv_alert' | 'weather' | 'task_due' | 'journal_reminder' | 'birthday'
+  title     text not null,
+  body      text,
+  sent_at   timestamptz not null default now(),
+  read_at   timestamptz         -- null = unread
+);
+
+alter table notifications enable row level security;
+create policy "users access own data" on notifications
+  for all to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create index notifications_user_sent_idx on notifications (user_id, sent_at desc);
+create index notifications_unread_idx    on notifications (user_id, read_at) where read_at is null;

--- a/web/src/app/(protected)/notifications/page.tsx
+++ b/web/src/app/(protected)/notifications/page.tsx
@@ -1,0 +1,61 @@
+export const dynamic = "force-dynamic";
+
+import { createClient } from "@/lib/supabase/server";
+import NotificationList from "@/components/notifications/notification-list";
+
+export interface Notification {
+  id: string;
+  type: string;
+  title: string;
+  body: string | null;
+  sent_at: string;
+  read_at: string | null;
+  isUnread: boolean;
+}
+
+export default async function NotificationsPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) return null;
+
+  const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+  // Fetch up to 50 notifications within the 30-day TTL window
+  const { data: rows } = await supabase
+    .from("notifications")
+    .select("id, type, title, body, sent_at, read_at")
+    .gte("sent_at", cutoff)
+    .order("sent_at", { ascending: false })
+    .limit(50);
+
+  const notifications: Notification[] = (rows ?? []).map((n) => ({
+    ...n,
+    isUnread: n.read_at === null,
+  }));
+
+  // Mark all fetched unread notifications as read in a single update
+  const unreadIds = notifications.filter((n) => n.isUnread).map((n) => n.id);
+  if (unreadIds.length > 0) {
+    await supabase
+      .from("notifications")
+      .update({ read_at: new Date().toISOString() })
+      .eq("user_id", user.id)
+      .is("read_at", null);
+  }
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <div>
+        <h1 className="font-heading font-semibold" style={{ fontSize: 24, color: "var(--color-text)" }}>
+          Notifications
+        </h1>
+        <p className="mt-1" style={{ fontSize: 14, color: "var(--color-text-muted)" }}>
+          Last 30 days
+        </p>
+      </div>
+
+      <NotificationList notifications={notifications} />
+    </div>
+  );
+}

--- a/web/src/app/api/cron/sync/route.ts
+++ b/web/src/app/api/cron/sync/route.ts
@@ -17,6 +17,12 @@ export async function GET(request: NextRequest) {
   const db = createServiceClient();
   const results: Record<string, unknown> = {};
 
+  // Purge notifications older than 30 days (TTL cleanup — runs once daily)
+  await db
+    .from("notifications")
+    .delete()
+    .lt("sent_at", new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString());
+
   // Run all three syncs in parallel, skipping any synced within the last 30 minutes
   const [ouraAge, fitbitAge, googleFitAge] = await Promise.all([
     lastSyncAgeSecs(db, "oura"),

--- a/web/src/app/api/notifications/unread-count/route.ts
+++ b/web/src/app/api/notifications/unread-count/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export async function GET() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ count: 0 }, { status: 401 });
+  }
+
+  const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+  const { count } = await supabase
+    .from("notifications")
+    .select("*", { count: "exact", head: true })
+    .eq("user_id", user.id)
+    .is("read_at", null)
+    .gte("sent_at", cutoff);
+
+  return NextResponse.json({ count: count ?? 0 });
+}

--- a/web/src/components/nav.tsx
+++ b/web/src/components/nav.tsx
@@ -13,6 +13,7 @@ import {
   ListTodo,
   BookOpen,
   BarChart2,
+  Bell,
   MoreHorizontal,
   X,
 } from "lucide-react";
@@ -20,15 +21,16 @@ import Logo from "@/components/ui/logo";
 import { createClient } from "@/lib/supabase/client";
 
 const NAV_ITEMS = [
-  { href: "/dashboard", label: "Dashboard",  icon: LayoutDashboard },
-  { href: "/fitness",   label: "Fitness",    icon: Activity },
-  { href: "/habits",    label: "Habits",     icon: CheckSquare },
-  { href: "/tasks",     label: "Tasks",      icon: ListTodo },
-  { href: "/weekly",    label: "Weekly",     icon: BarChart2 },
-  { href: "/journal",   label: "Journal",    icon: BookOpen },
-  { href: "/meals",     label: "Meals",      icon: UtensilsCrossed },
-  { href: "/chat",      label: "Chat",       icon: MessageSquare },
-  { href: "/settings",  label: "Settings",   icon: Settings },
+  { href: "/dashboard",     label: "Dashboard",     icon: LayoutDashboard },
+  { href: "/fitness",       label: "Fitness",       icon: Activity },
+  { href: "/habits",        label: "Habits",        icon: CheckSquare },
+  { href: "/tasks",         label: "Tasks",         icon: ListTodo },
+  { href: "/weekly",        label: "Weekly",        icon: BarChart2 },
+  { href: "/journal",       label: "Journal",       icon: BookOpen },
+  { href: "/meals",         label: "Meals",         icon: UtensilsCrossed },
+  { href: "/chat",          label: "Chat",          icon: MessageSquare },
+  { href: "/notifications", label: "Notifications", icon: Bell },
+  { href: "/settings",      label: "Settings",      icon: Settings },
 ];
 
 // 4 primary tabs always visible; the rest live in the More sheet
@@ -45,6 +47,7 @@ export default function Nav() {
   const pathname = usePathname();
   const [showMore, setShowMore] = useState(false);
   const [isDemo, setIsDemo] = useState(false);
+  const [unreadCount, setUnreadCount] = useState(0);
 
   useEffect(() => {
     const demoEmail = process.env.NEXT_PUBLIC_DEMO_EMAIL;
@@ -54,6 +57,13 @@ export default function Nav() {
       setIsDemo(user?.email === demoEmail);
     });
   }, []);
+
+  useEffect(() => {
+    fetch("/api/notifications/unread-count")
+      .then((r) => r.ok ? r.json() : { count: 0 })
+      .then((d) => setUnreadCount(d.count ?? 0))
+      .catch(() => {});
+  }, [pathname]);
 
   // Is the current page one of the "More" pages? If so, highlight the More button.
   const moreIsActive = MOBILE_MORE.some((item) => isActive(pathname, item.href));
@@ -83,6 +93,7 @@ export default function Nav() {
         <div className="flex flex-col gap-0.5 px-3 overflow-y-auto flex-1">
           {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
             const active = isActive(pathname, href);
+            const showBadge = href === "/notifications" && unreadCount > 0;
             return (
               <Link
                 key={href}
@@ -93,11 +104,29 @@ export default function Nav() {
                   color: active ? "var(--color-primary)" : "var(--color-text-muted)",
                 }}
               >
-                <Icon
-                  size={18}
-                  strokeWidth={active ? 2 : 1.5}
-                  style={{ color: active ? "var(--color-primary)" : "var(--color-text-muted)", flexShrink: 0 }}
-                />
+                <span className="relative" style={{ flexShrink: 0 }}>
+                  <Icon
+                    size={18}
+                    strokeWidth={active ? 2 : 1.5}
+                    style={{ color: active ? "var(--color-primary)" : "var(--color-text-muted)" }}
+                  />
+                  {showBadge && (
+                    <span
+                      className="absolute -top-1 -right-1 flex items-center justify-center rounded-full text-white"
+                      style={{
+                        background: "#EF4444",
+                        minWidth: 14,
+                        height: 14,
+                        fontSize: 9,
+                        fontWeight: 700,
+                        padding: "0 3px",
+                        lineHeight: 1,
+                      }}
+                    >
+                      {unreadCount > 9 ? "9+" : unreadCount}
+                    </span>
+                  )}
+                </span>
                 {label}
               </Link>
             );
@@ -203,6 +232,7 @@ export default function Nav() {
             <div className="px-3 pb-4 grid grid-cols-2 gap-1">
               {MOBILE_MORE.map(({ href, label, icon: Icon }) => {
                 const active = isActive(pathname, href);
+                const showBadge = href === "/notifications" && unreadCount > 0;
                 return (
                   <Link
                     key={href}
@@ -214,11 +244,29 @@ export default function Nav() {
                       color: active ? "var(--color-primary)" : "var(--color-text-muted)",
                     }}
                   >
-                    <Icon
-                      size={18}
-                      strokeWidth={active ? 2 : 1.5}
-                      style={{ color: active ? "var(--color-primary)" : "var(--color-text-muted)", flexShrink: 0 }}
-                    />
+                    <span className="relative" style={{ flexShrink: 0 }}>
+                      <Icon
+                        size={18}
+                        strokeWidth={active ? 2 : 1.5}
+                        style={{ color: active ? "var(--color-primary)" : "var(--color-text-muted)" }}
+                      />
+                      {showBadge && (
+                        <span
+                          className="absolute -top-1 -right-1 flex items-center justify-center rounded-full text-white"
+                          style={{
+                            background: "#EF4444",
+                            minWidth: 14,
+                            height: 14,
+                            fontSize: 9,
+                            fontWeight: 700,
+                            padding: "0 3px",
+                            lineHeight: 1,
+                          }}
+                        >
+                          {unreadCount > 9 ? "9+" : unreadCount}
+                        </span>
+                      )}
+                    </span>
                     <span className="text-sm font-medium">{label}</span>
                   </Link>
                 );

--- a/web/src/components/notifications/notification-list.tsx
+++ b/web/src/components/notifications/notification-list.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState } from "react";
+import { Activity, CloudRain, CheckSquare, Cake, Bell } from "lucide-react";
+import type { Notification } from "@/app/(protected)/notifications/page";
+
+const TYPE_FILTERS = [
+  { key: "all",       label: "All" },
+  { key: "hrv_alert", label: "HRV" },
+  { key: "weather",   label: "Weather" },
+  { key: "task_due",  label: "Tasks" },
+  { key: "birthday",  label: "Birthday" },
+] as const;
+
+type FilterKey = (typeof TYPE_FILTERS)[number]["key"];
+
+function typeIcon(type: string) {
+  switch (type) {
+    case "hrv_alert": return <Activity size={16} style={{ color: "var(--color-primary)", flexShrink: 0 }} />;
+    case "weather":   return <CloudRain size={16} style={{ color: "#38BDF8", flexShrink: 0 }} />;
+    case "task_due":  return <CheckSquare size={16} style={{ color: "#10B981", flexShrink: 0 }} />;
+    case "birthday":  return <Cake size={16} style={{ color: "#F59E0B", flexShrink: 0 }} />;
+    default:          return <Bell size={16} style={{ color: "var(--color-text-muted)", flexShrink: 0 }} />;
+  }
+}
+
+function relativeTime(isoString: string): string {
+  const date = new Date(isoString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffMins < 60) return diffMins <= 1 ? "Just now" : `${diffMins} minutes ago`;
+  if (diffHours < 24) return diffHours === 1 ? "1 hour ago" : `${diffHours} hours ago`;
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return date.toLocaleDateString("en-US", { weekday: "short" });
+
+  const sameYear = date.getFullYear() === now.getFullYear();
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    ...(sameYear ? {} : { year: "numeric" }),
+  });
+}
+
+interface Props {
+  notifications: Notification[];
+}
+
+export default function NotificationList({ notifications }: Props) {
+  const [filter, setFilter] = useState<FilterKey>("all");
+
+  const visible = filter === "all"
+    ? notifications
+    : notifications.filter((n) => n.type === filter);
+
+  return (
+    <div className="space-y-4">
+      {/* Filter pills */}
+      <div className="flex gap-2 flex-wrap">
+        {TYPE_FILTERS.map(({ key, label }) => {
+          const active = filter === key;
+          return (
+            <button
+              key={key}
+              onClick={() => setFilter(key)}
+              className="px-3 py-1 rounded-full text-xs font-medium transition-colors duration-150 cursor-pointer"
+              style={{
+                background: active ? "var(--color-primary)" : "var(--color-surface)",
+                color: active ? "white" : "var(--color-text-muted)",
+                border: active ? "1px solid var(--color-primary)" : "1px solid var(--color-border)",
+              }}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Notification rows */}
+      {visible.length === 0 ? (
+        <p style={{ fontSize: 14, color: "var(--color-text-faint)" }}>No notifications yet</p>
+      ) : (
+        <div
+          className="rounded-xl overflow-hidden"
+          style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+        >
+          {visible.map((n, i) => (
+            <div
+              key={n.id}
+              className="flex items-start gap-3 px-4 py-3"
+              style={{
+                borderTop: i > 0 ? "1px solid var(--color-border)" : "none",
+                borderLeft: n.isUnread ? "3px solid var(--color-primary)" : "3px solid transparent",
+              }}
+            >
+              <div style={{ marginTop: 2 }}>{typeIcon(n.type)}</div>
+              <div className="flex-1 min-w-0">
+                <p
+                  style={{
+                    fontSize: 13,
+                    fontWeight: n.isUnread ? 600 : 400,
+                    color: "var(--color-text)",
+                    lineHeight: 1.4,
+                  }}
+                >
+                  {n.title}
+                </p>
+                {n.body && (
+                  <p
+                    style={{
+                      fontSize: 12,
+                      color: "var(--color-text-muted)",
+                      marginTop: 2,
+                      lineHeight: 1.4,
+                    }}
+                  >
+                    {n.body}
+                  </p>
+                )}
+              </div>
+              <span
+                style={{
+                  fontSize: 11,
+                  color: "var(--color-text-faint)",
+                  whiteSpace: "nowrap",
+                  flexShrink: 0,
+                  marginTop: 2,
+                }}
+              >
+                {relativeTime(n.sent_at)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **DB**: `notifications` table with RLS, `sent_at`/`read_at` columns, partial unread index; migration `20260413000007_notifications.sql` applied to live Supabase
- **Scripts**: `log_notification()` helper added to `scripts/_supabase.py`; all four alert scripts (HRV, weather, task, birthday) call it after a confirmed send
- **TTL**: 30-day `DELETE` wired into `api/cron/sync/route.ts` — runs daily at 6 AM PST, time-based so recent unread rows are never silently dropped
- **Web page**: `/notifications` (server component) — fetches last 50 within TTL window; marks all unread as read on load via single `UPDATE`; passes `isUnread` per row
- **Client component**: `NotificationList` — type filter pills (All / HRV / Weather / Tasks / Birthday); icon per type; relative time (`Just now`, `2 hours ago`, `Yesterday`, weekday, `Apr 3`); left-border accent + bold title for unread; empty state
- **API route**: `GET /api/notifications/unread-count` → `{ count: number }`
- **Nav**: `Bell` icon + Notifications item in desktop sidebar and mobile More sheet; red count badge on Bell; badge re-fetches on every route change via `useEffect([pathname])`

## Test plan

- [ ] Run any alert script locally (`python3 scripts/check_hrv_alert.py`) and verify a row appears in `notifications` table in Supabase dashboard
- [ ] Visit `/notifications` — page loads, shows notifications with correct icons and relative times
- [ ] Unread rows show left-border accent and bold title on first visit; revisiting clears the styling (read_at set)
- [ ] Type filter pills correctly filter the list; "No notifications yet" shows when empty
- [ ] Bell icon in sidebar/More sheet shows red badge when unread count > 0; badge clears after visiting `/notifications`
- [ ] Cron route (`GET /api/cron/sync`) deletes rows older than 30 days without touching recent ones
- [ ] Demo account: notifications page loads without error (empty state expected)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)