### PR TITLE
feat: subtasks, daily/weekly charts, mobile weather fix (#144 #145 #147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (subtasks + grocery list UI — issue #144)
+- **`parent_id` column on `tasks`** — migration `20260413000008_tasks_parent_id.sql` adds `parent_id uuid references tasks(id) on delete cascade` and a supporting index; applied to live DB
+- **`Subtask` type** added to `web/src/lib/types.ts`; `Task` extended with `parent_id: string | null` and optional `subtasks?: Subtask[]`
+- **Three new server actions** in `tasks/page.tsx`: `addSubtask` (inserts with `parent_id`), `completeSubtask` (completes sibling-check → auto-completes parent when all done), `deleteSubtask` (hard delete)
+- **`completeTask` now cascades** — after completing the parent, also marks all active subtasks completed
+- **`TaskItem` extended** — progress indicator (`X / Y`) in parent title row (green when all done); chevron expand/collapse (default: expanded ≤3, collapsed >3); inline subtask list with checkbox, editable title, delete button; always-visible "Add item…" input at bottom of expanded list; Enter submits and keeps focus for rapid grocery entry
+- **Dashboard tasks query** and **tasks page active query** both filter `parent_id IS NULL` so subtasks never appear as standalone items
+- **`add_task` chat tool** accepts optional `parent_id`; system prompt updated to instruct the model to call `get_tasks` first when adding list items, then `add_task` with `parent_id`
+
+### Added (daily/weekly toggle on fitness charts — issue #145)
+- **`GranularityToggle` component** — `web/src/components/ui/granularity-toggle.tsx`; `Daily | Weekly` pill toggle matching window-selector style; greyed out with tooltip when `disabled`
+- **`WorkoutFreqChart`** — prop changed from `weekCount` to `days: number`; `granularity` state (`daily`/`weekly`); auto-forces weekly + disables toggle when `days > 90`; daily mode plots one slot per calendar day (green `#10B981` with goal, indigo `#6366F1` without, rest day `#1E2130`); weekly mode retains existing ISO-week bucketing; x-axis shows only Monday ticks at >14d, all days at ≤14d
+- **`ActiveCalGoalChart`** — same prop rename and granularity state; daily mode plots raw `active_cal` values with daily target reference line (`Math.round(goal / 7)`); weekly mode retains week-sum logic; same tick density logic
+- **Fitness page** — replaced hardcoded `weekCount={8}` on both charts with `days={days}` from the window selector cookie
+
+### Fixed (mobile weather H/L wrapping — issue #147)
+- **`DashboardHeader`** — `whiteSpace: "nowrap"` on the H/L `<span>` prevents the string from breaking mid-value; `flex-wrap` + `gap-x-1.5 gap-y-0` on the weather `<p>` allows a clean break after the condition text on very narrow screens
+
 ### Added (notification history center — issue #99)
 - **`notifications` table** — new Supabase table (`id`, `user_id`, `type`, `title`, `body`, `sent_at`, `read_at`) with RLS, per-user composite index on `(user_id, sent_at desc)`, and a partial index for unread rows; migration `20260413000007_notifications.sql` applied to live DB
 - **`log_notification` helper** in `scripts/_supabase.py` — inserts a row after each successful push notification; non-fatal (errors go to stderr only)

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ flowchart LR
 - **Dashboard** — Personalized briefing with live weather, Google Calendar schedule, Gmail highlights, habit check-in, active tasks, and Oura recovery scores in one view
 - **Chat** — Conversational interface to Mr. Bridge; streams Claude responses with 15 built-in tools (tasks, habits, fitness, profile, Gmail, Calendar read/create/update/delete, recipes, meals); conflict detection and deduplication pre-flight before every calendar create; slash command autocomplete
 - **Habits** — Daily toggle check-in with streaks, 90-day heatmap, streak bar chart, weekly radial completion chart
-- **Tasks** — Inline editing, priority, relative due dates, completed-tasks accordion
-- **Fitness** — Body composition charts (weight + BF%), weekly workout frequency, active calorie chart, full workout history table (start/end time, HR zones, source badge, activity filter); goal progress overlays
+- **Tasks** — Inline editing, priority, relative due dates, completed-tasks accordion; subtask/list hierarchy with progress indicator, expand/collapse, rapid "Add item…" entry optimised for grocery lists; completing a parent cascades to all subtasks
+- **Fitness** — Body composition charts (weight + BF%), workout frequency + active calorie charts with daily/weekly granularity toggle (auto-weekly at >90d), full workout history table (start/end time, HR zones, source badge, activity filter); goal progress overlays; window selector wired through to all charts
 - **Journal** — Guided 5-prompt daily reflection + free-write tab; auto-save; collapsible history
 - **Weekly Review** — Last 7 days at a glance: habit scores, task completion, workout summary, recovery averages, body comp delta, journal count
 - **Meals** — Daily macro summary vs goals; food photo analyzer (photo → client-side compression → Claude vision → macro estimate → log); HEIC detection with user-friendly guidance; 7-day meal history

--- a/supabase/migrations/20260413000008_tasks_parent_id.sql
+++ b/supabase/migrations/20260413000008_tasks_parent_id.sql
@@ -1,0 +1,4 @@
+alter table tasks
+  add column if not exists parent_id uuid references tasks(id) on delete cascade;
+
+create index if not exists tasks_parent_id_idx on tasks (parent_id);

--- a/web/src/app/(protected)/dashboard/page.tsx
+++ b/web/src/app/(protected)/dashboard/page.tsx
@@ -85,6 +85,7 @@ export default async function DashboardPage() {
     supabase
       .from("tasks")
       .select("*")
+      .is("parent_id", null)
       .eq("status", "active")
       .order("created_at", { ascending: false }),
   ]);

--- a/web/src/app/(protected)/fitness/page.tsx
+++ b/web/src/app/(protected)/fitness/page.tsx
@@ -15,7 +15,7 @@ import type { FitnessLog, WorkoutSession, RecoveryMetrics } from "@/lib/types";
 export default async function FitnessPage() {
   const supabase = await createClient();
   const { key: windowKey, days } = await getWindow();
-  const weekCount = Math.max(8, Math.ceil(days / 7));
+  const weekCount = Math.ceil(days / 7);
 
   const [fitnessRes, workoutsRes, recoveryRes, profileRes] = await Promise.all([
     supabase
@@ -96,7 +96,7 @@ export default async function FitnessPage() {
         <div className="flex flex-col gap-2">
           <WorkoutFreqChart
             sessions={workouts}
-            weekCount={8}
+            days={days}
             goal={weeklyWorkoutGoal}
           />
           {walkCount > 0 && (
@@ -121,7 +121,7 @@ export default async function FitnessPage() {
         <ActiveCalGoalChart
           data={recoveryData}
           goal={weeklyActiveCalGoal}
-          weekCount={8}
+          days={days}
         />
       </div>
 

--- a/web/src/app/(protected)/tasks/page.tsx
+++ b/web/src/app/(protected)/tasks/page.tsx
@@ -11,7 +11,9 @@ async function addTask(title: string, priority: string, dueDate: string): Promis
   "use server";
   try {
     const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
     const { error } = await supabase.from("tasks").insert({
+      user_id: user?.id,
       title,
       priority: priority || "medium",
       status: "active",
@@ -35,6 +37,12 @@ async function completeTask(taskId: string): Promise<{ error?: string }> {
       .update({ status: "completed", completed_at: new Date().toISOString() })
       .eq("id", taskId);
     if (error) return { error: error.message };
+    // Also complete any active subtasks
+    await supabase
+      .from("tasks")
+      .update({ status: "completed", completed_at: new Date().toISOString() })
+      .eq("parent_id", taskId)
+      .eq("status", "active");
     revalidatePath("/tasks");
     revalidatePath("/dashboard");
     return {};
@@ -70,16 +78,93 @@ async function updateTask(taskId: string, title: string): Promise<{ error?: stri
   }
 }
 
+async function addSubtask(parentId: string, title: string): Promise<{ error?: string }> {
+  "use server";
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    const { error } = await supabase.from("tasks").insert({
+      user_id: user?.id,
+      title,
+      parent_id: parentId,
+      status: "active",
+      priority: null,
+      due_date: null,
+    });
+    if (error) return { error: error.message };
+    revalidatePath("/tasks");
+    return {};
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Failed to add subtask" };
+  }
+}
+
+async function completeSubtask(id: string): Promise<{ error?: string }> {
+  "use server";
+  try {
+    const supabase = await createClient();
+    // Get parent_id before completing
+    const { data: subtask } = await supabase
+      .from("tasks")
+      .select("parent_id")
+      .eq("id", id)
+      .single();
+    const { error } = await supabase
+      .from("tasks")
+      .update({ status: "completed", completed_at: new Date().toISOString() })
+      .eq("id", id);
+    if (error) return { error: error.message };
+    // Check if all siblings are now completed — if so, complete parent
+    if (subtask?.parent_id) {
+      const { data: siblings } = await supabase
+        .from("tasks")
+        .select("status")
+        .eq("parent_id", subtask.parent_id);
+      const allDone = (siblings ?? []).every((s) => s.status === "completed");
+      if (allDone) {
+        await supabase
+          .from("tasks")
+          .update({ status: "completed", completed_at: new Date().toISOString() })
+          .eq("id", subtask.parent_id);
+      }
+    }
+    revalidatePath("/tasks");
+    revalidatePath("/dashboard");
+    return {};
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Failed to complete subtask" };
+  }
+}
+
+async function deleteSubtask(id: string): Promise<{ error?: string }> {
+  "use server";
+  try {
+    const supabase = await createClient();
+    const { error } = await supabase.from("tasks").delete().eq("id", id);
+    if (error) return { error: error.message };
+    revalidatePath("/tasks");
+    return {};
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Failed to delete subtask" };
+  }
+}
+
 const priorityOrder = { high: 0, medium: 1, low: 2 };
 
 export default async function TasksPage() {
   const supabase = await createClient();
 
   const [activeResult, completedResult] = await Promise.all([
-    supabase.from("tasks").select("*").eq("status", "active").order("created_at", { ascending: false }),
+    supabase
+      .from("tasks")
+      .select("*, subtasks:tasks!tasks_parent_id_fkey(id, title, status, created_at)")
+      .is("parent_id", null)
+      .eq("status", "active")
+      .order("created_at", { ascending: false }),
     supabase
       .from("tasks")
       .select("*")
+      .is("parent_id", null)
       .eq("status", "completed")
       .order("completed_at", { ascending: false })
       .limit(10),
@@ -139,6 +224,9 @@ export default async function TasksPage() {
                         completeAction={completeTask}
                         archiveAction={archiveTask}
                         updateAction={updateTask}
+                        addSubtaskAction={addSubtask}
+                        completeSubtaskAction={completeSubtask}
+                        deleteSubtaskAction={deleteSubtask}
                       />
                     </div>
                   ))}

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -259,7 +259,7 @@ You have access to the user's Supabase data, Gmail, and Google Calendar via tool
 
 Tools available:
 - get_tasks: active/completed/archived tasks
-- add_task: create a new task
+- add_task: create a new task or subtask (use parent_id to add items to a list — call get_tasks first to find the parent task ID)
 - complete_task: mark a task done by ID
 - get_habits_today: all active habits + today's completion status
 - log_habit: mark a habit complete for a given date
@@ -319,12 +319,13 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
     }),
 
     add_task: tool({
-      description: "Add a new task to the tasks table.",
+      description: "Add a new task or subtask to the tasks table. To add an item to a list (e.g. shopping list, grocery list), first call get_tasks to find the parent task ID, then call add_task with parent_id set.",
       parameters: jsonSchema<{
         title: string;
         priority?: "high" | "medium" | "low";
         category?: string;
         due_date?: string;
+        parent_id?: string;
       }>({
         type: "object",
         required: ["title"],
@@ -333,20 +334,29 @@ Recipes and meal planning are in scope. When asked what to cook given ingredient
           priority: {
             type: "string",
             enum: ["high", "medium", "low"],
-            description: "Task priority.",
+            description: "Task priority. Omit for subtasks.",
           },
           category: { type: "string", description: "Task category." },
-          due_date: { type: "string", description: "Due date in YYYY-MM-DD format." },
+          due_date: { type: "string", description: "Due date in YYYY-MM-DD format. Omit for subtasks." },
+          parent_id: { type: "string", description: "Parent task UUID. Set this to add a subtask/list item under an existing task." },
         },
       }),
-      execute: async ({ title, priority, category, due_date }) => {
+      execute: async ({ title, priority, category, due_date, parent_id }) => {
         if (due_date && !/^\d{4}-\d{2}-\d{2}$/.test(due_date)) {
           return { error: `due_date must be YYYY-MM-DD format, got: "${due_date}"` };
         }
         const { data, error } = await supabase
           .from("tasks")
-          .insert({ user_id: userId, title, priority: priority ?? null, category: category ?? null, due_date: due_date ?? null, status: "active" })
-          .select("id, title, priority, status, due_date, category, created_at")
+          .insert({
+            user_id: userId,
+            title,
+            priority: parent_id ? null : (priority ?? null),
+            category: category ?? null,
+            due_date: parent_id ? null : (due_date ?? null),
+            status: "active",
+            parent_id: parent_id ?? null,
+          })
+          .select("id, title, priority, status, due_date, category, parent_id, created_at")
           .single();
         if (error) return { error: error.message };
         return data;

--- a/web/src/components/dashboard/dashboard-header.tsx
+++ b/web/src/components/dashboard/dashboard-header.tsx
@@ -45,14 +45,14 @@ export default function DashboardHeader({ greeting, dateStr, windowKey }: Props)
           {dateStr}
         </p>
         {weather && (
-          <p className="mt-0.5 flex items-center gap-1.5" style={{ fontSize: 13, color: "var(--color-text-muted)" }}>
+          <p className="mt-0.5 flex flex-wrap items-center gap-x-1.5 gap-y-0" style={{ fontSize: 13, color: "var(--color-text-muted)" }}>
             {emoji && <span style={{ fontSize: 14, lineHeight: 1 }}>{emoji}</span>}
             {weather.temp != null && (
               <span style={{ color: "var(--color-text)" }}>{Math.round(weather.temp)}°</span>
             )}
             <span>{weather.condition}</span>
             {(weather.high != null || weather.low != null) && (
-              <span style={{ color: "var(--color-text-faint)" }}>
+              <span style={{ color: "var(--color-text-faint)", whiteSpace: "nowrap" }}>
                 · H {weather.high != null ? `${Math.round(weather.high)}°` : "—"} L {weather.low != null ? `${Math.round(weather.low)}°` : "—"}
               </span>
             )}

--- a/web/src/components/fitness/active-cal-goal-chart.tsx
+++ b/web/src/components/fitness/active-cal-goal-chart.tsx
@@ -7,6 +7,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import Link from "next/link";
+import { GranularityToggle } from "@/components/ui/granularity-toggle";
 
 interface DataPoint {
   date: string;
@@ -16,7 +17,7 @@ interface DataPoint {
 interface Props {
   data: DataPoint[];
   goal?: number | null;
-  weekCount?: number;
+  days: number;
 }
 
 const TOOLTIP_STYLE = {
@@ -43,35 +44,78 @@ function getISOWeekKey(dateStr: string): string {
   return monday.toISOString().slice(0, 10);
 }
 
-export function ActiveCalGoalChart({ data, goal, weekCount = 8 }: Props) {
+function dayLabel(dateStr: string): string {
+  return new Date(dateStr + "T00:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function dayOfWeek(dateStr: string): number {
+  return new Date(dateStr + "T00:00:00").getDay();
+}
+
+export function ActiveCalGoalChart({ data, goal, days }: Props) {
   const [animate, setAnimate] = useState(true);
+  const weekCount = Math.ceil(days / 7);
+  const forceWeekly = days > 90;
+  const [granularity, setGranularity] = useState<"daily" | "weekly">(
+    forceWeekly ? "weekly" : "daily"
+  );
+
+  useEffect(() => {
+    if (forceWeekly) setGranularity("weekly");
+  }, [forceWeekly]);
 
   useEffect(() => {
     const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
     setAnimate(!mq.matches);
   }, []);
 
-  // Build 8-week slots
   const now = new Date();
-  const weeks: { key: string; label: string; total: number }[] = [];
-  for (let i = weekCount - 1; i >= 0; i--) {
-    const d = new Date(now);
-    d.setDate(d.getDate() - i * 7);
-    const dateStr = d.toISOString().slice(0, 10);
-    const key = getISOWeekKey(dateStr);
-    if (!weeks.find((w) => w.key === key)) {
-      weeks.push({ key, label: getISOWeekLabel(dateStr), total: 0 });
+  const hasGoal = goal != null && goal > 0;
+
+  // ── Weekly mode ──────────────────────────────────────────────────────────
+  const weekSlots: { key: string; label: string; total: number }[] = [];
+  if (granularity === "weekly") {
+    for (let i = weekCount - 1; i >= 0; i--) {
+      const d = new Date(now);
+      d.setDate(d.getDate() - i * 7);
+      const dateStr = d.toISOString().slice(0, 10);
+      const key = getISOWeekKey(dateStr);
+      if (!weekSlots.find((w) => w.key === key)) {
+        weekSlots.push({ key, label: getISOWeekLabel(dateStr), total: 0 });
+      }
     }
+    data.forEach((d) => {
+      if (d.active_cal == null) return;
+      const key = getISOWeekKey(d.date);
+      const slot = weekSlots.find((w) => w.key === key);
+      if (slot) slot.total += d.active_cal;
+    });
   }
 
-  data.forEach((d) => {
-    if (d.active_cal == null) return;
-    const key = getISOWeekKey(d.date);
-    const slot = weeks.find((w) => w.key === key);
-    if (slot) slot.total += d.active_cal;
-  });
+  // ── Daily mode ───────────────────────────────────────────────────────────
+  const daySlots: { key: string; label: string; total: number | null; isMonday: boolean }[] = [];
+  if (granularity === "daily") {
+    for (let i = days - 1; i >= 0; i--) {
+      const d = new Date(now);
+      d.setDate(d.getDate() - i);
+      const dateStr = d.toISOString().slice(0, 10);
+      daySlots.push({
+        key: dateStr,
+        label: dayLabel(dateStr),
+        total: null,
+        isMonday: dayOfWeek(dateStr) === 1,
+      });
+    }
+    const calMap = new Map(data.filter((d) => d.active_cal != null).map((d) => [d.date, d.active_cal!]));
+    daySlots.forEach((slot) => {
+      const v = calMap.get(slot.key);
+      if (v != null) slot.total = v;
+    });
+  }
 
-  const hasGoal = goal != null && goal > 0;
+  const showMonday = days > 14;
+  const chartData = granularity === "weekly" ? weekSlots : daySlots;
+  const dailyGoal = hasGoal ? Math.round(goal! / 7) : null;
 
   return (
     <div
@@ -80,13 +124,22 @@ export function ActiveCalGoalChart({ data, goal, weekCount = 8 }: Props) {
     >
       <div className="flex items-center justify-between mb-4">
         <p className="text-xs uppercase tracking-widest" style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}>
-          Active Calories — {weekCount} Weeks
+          Active Calories — {granularity === "daily" ? "Daily" : "Weekly"}
         </p>
-        {hasGoal && (
-          <span className="text-xs tabular-nums" style={{ color: "var(--color-text-faint)" }}>
-            Goal: {goal!.toLocaleString()} kcal/wk
-          </span>
-        )}
+        <div className="flex items-center gap-2">
+          {hasGoal && (
+            <span className="text-xs tabular-nums" style={{ color: "var(--color-text-faint)" }}>
+              {granularity === "daily"
+                ? `Target: ${dailyGoal!.toLocaleString()} kcal/day`
+                : `Goal: ${goal!.toLocaleString()} kcal/wk`}
+            </span>
+          )}
+          <GranularityToggle
+            value={granularity}
+            onChange={setGranularity}
+            disabled={forceWeekly}
+          />
+        </div>
       </div>
 
       {!hasGoal && (
@@ -99,7 +152,7 @@ export function ActiveCalGoalChart({ data, goal, weekCount = 8 }: Props) {
       )}
 
       <ResponsiveContainer width="100%" height={200}>
-        <AreaChart data={weeks} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+        <AreaChart data={chartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
           <defs>
             <linearGradient id="acal-goal-grad" x1="0" y1="0" x2="0" y2="1">
               <stop offset="0%"   stopColor="#F59E0B" stopOpacity={0.3} />
@@ -113,7 +166,9 @@ export function ActiveCalGoalChart({ data, goal, weekCount = 8 }: Props) {
             tick={{ fill: "#64748B", fontSize: 10 }}
             tickLine={false}
             axisLine={false}
-            interval={0}
+            interval={granularity === "daily" && showMonday
+              ? (_, index) => !(daySlots[index]?.isMonday)
+              : 0}
           />
           <YAxis
             stroke="#334155"
@@ -124,14 +179,27 @@ export function ActiveCalGoalChart({ data, goal, weekCount = 8 }: Props) {
           />
           <Tooltip
             {...TOOLTIP_STYLE}
-            formatter={(v: number) => [`${Math.round(v).toLocaleString()} kcal`, "Active Cal"]}
+            formatter={(v: number) => [
+              `${Math.round(v).toLocaleString()} kcal`,
+              granularity === "daily" ? "Active Cal" : "Active Cal",
+            ]}
+            labelFormatter={(label) => granularity === "daily" ? label : label}
           />
-          {hasGoal && (
+          {hasGoal && granularity === "weekly" && (
             <ReferenceLine
               y={goal}
               stroke="#64748B"
               strokeDasharray="4 3"
               strokeWidth={1.5}
+            />
+          )}
+          {hasGoal && granularity === "daily" && dailyGoal != null && (
+            <ReferenceLine
+              y={dailyGoal}
+              stroke="#64748B"
+              strokeDasharray="4 3"
+              strokeWidth={1.5}
+              label={{ value: "Daily target", fill: "#64748B", fontSize: 10, position: "insideTopRight" }}
             />
           )}
           <Area
@@ -144,6 +212,7 @@ export function ActiveCalGoalChart({ data, goal, weekCount = 8 }: Props) {
             activeDot={{ r: 4, fill: "#F59E0B", strokeWidth: 0 }}
             isAnimationActive={animate}
             animationDuration={300}
+            connectNulls={false}
           />
         </AreaChart>
       </ResponsiveContainer>

--- a/web/src/components/fitness/active-cal-goal-chart.tsx
+++ b/web/src/components/fitness/active-cal-goal-chart.tsx
@@ -166,9 +166,13 @@ export function ActiveCalGoalChart({ data, goal, days }: Props) {
             tick={{ fill: "#64748B", fontSize: 10 }}
             tickLine={false}
             axisLine={false}
-            interval={granularity === "daily" && showMonday
-              ? (_, index) => !(daySlots[index]?.isMonday)
-              : 0}
+            interval={0}
+            tickFormatter={(label, index) => {
+              if (granularity === "daily" && showMonday) {
+                return daySlots[index]?.isMonday ? label : "";
+              }
+              return label;
+            }}
           />
           <YAxis
             stroke="#334155"

--- a/web/src/components/fitness/workout-freq-chart.tsx
+++ b/web/src/components/fitness/workout-freq-chart.tsx
@@ -8,10 +8,11 @@ import {
 } from "recharts";
 import type { WorkoutSession } from "@/lib/types";
 import Link from "next/link";
+import { GranularityToggle } from "@/components/ui/granularity-toggle";
 
 interface Props {
   sessions: WorkoutSession[];
-  weekCount?: number;
+  days: number;
   goal?: number | null;
 }
 
@@ -40,13 +41,31 @@ function getISOWeekKey(dateStr: string): string {
 }
 
 function barColor(count: number, goal: number): string {
-  if (count >= goal)          return "#10B981"; // green
-  if (count === goal - 1)     return "#F59E0B"; // amber
-  return "#EF4444";                             // red
+  if (count >= goal)      return "#10B981"; // green
+  if (count === goal - 1) return "#F59E0B"; // amber
+  return "#EF4444";                         // red
 }
 
-export function WorkoutFreqChart({ sessions, weekCount = 8, goal }: Props) {
+function dayLabel(dateStr: string): string {
+  return new Date(dateStr + "T00:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function dayOfWeek(dateStr: string): number {
+  return new Date(dateStr + "T00:00:00").getDay(); // 0 = Sunday, 1 = Monday
+}
+
+export function WorkoutFreqChart({ sessions, days, goal }: Props) {
   const [animate, setAnimate] = useState(true);
+  const weekCount = Math.ceil(days / 7);
+  const forceWeekly = days > 90;
+  const [granularity, setGranularity] = useState<"daily" | "weekly">(
+    forceWeekly ? "weekly" : "daily"
+  );
+
+  // When days changes and > 90, force back to weekly
+  useEffect(() => {
+    if (forceWeekly) setGranularity("weekly");
+  }, [forceWeekly]);
 
   useEffect(() => {
     const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
@@ -54,24 +73,50 @@ export function WorkoutFreqChart({ sessions, weekCount = 8, goal }: Props) {
   }, []);
 
   const now = new Date();
-  const weeks: { key: string; label: string; count: number }[] = [];
-  for (let i = weekCount - 1; i >= 0; i--) {
-    const d = new Date(now);
-    d.setDate(d.getDate() - i * 7);
-    const dateStr = d.toISOString().slice(0, 10);
-    const key = getISOWeekKey(dateStr);
-    if (!weeks.find((w) => w.key === key)) {
-      weeks.push({ key, label: getISOWeekLabel(dateStr), count: 0 });
+  const hasGoal = goal != null && goal > 0;
+
+  // ── Weekly mode ──────────────────────────────────────────────────────────
+  const weekSlots: { key: string; label: string; count: number }[] = [];
+  if (granularity === "weekly") {
+    for (let i = weekCount - 1; i >= 0; i--) {
+      const d = new Date(now);
+      d.setDate(d.getDate() - i * 7);
+      const dateStr = d.toISOString().slice(0, 10);
+      const key = getISOWeekKey(dateStr);
+      if (!weekSlots.find((w) => w.key === key)) {
+        weekSlots.push({ key, label: getISOWeekLabel(dateStr), count: 0 });
+      }
     }
+    sessions.forEach((s) => {
+      const key = getISOWeekKey(s.date);
+      const slot = weekSlots.find((w) => w.key === key);
+      if (slot) slot.count++;
+    });
   }
 
-  sessions.forEach((s) => {
-    const key = getISOWeekKey(s.date);
-    const slot = weeks.find((w) => w.key === key);
-    if (slot) slot.count++;
-  });
+  // ── Daily mode ───────────────────────────────────────────────────────────
+  const daySlots: { key: string; label: string; count: number; isMonday: boolean }[] = [];
+  if (granularity === "daily") {
+    for (let i = days - 1; i >= 0; i--) {
+      const d = new Date(now);
+      d.setDate(d.getDate() - i);
+      const dateStr = d.toISOString().slice(0, 10);
+      daySlots.push({
+        key: dateStr,
+        label: dayLabel(dateStr),
+        count: 0,
+        isMonday: dayOfWeek(dateStr) === 1,
+      });
+    }
+    const sessionSet = new Set(sessions.map((s) => s.date));
+    daySlots.forEach((slot) => {
+      if (sessionSet.has(slot.key)) slot.count = 1;
+    });
+  }
 
-  const hasGoal = goal != null && goal > 0;
+  const showMonday = days > 14; // sparse ticks at >14 days
+
+  const chartData = granularity === "weekly" ? weekSlots : daySlots;
 
   return (
     <div
@@ -80,13 +125,25 @@ export function WorkoutFreqChart({ sessions, weekCount = 8, goal }: Props) {
     >
       <div className="flex items-center justify-between mb-4">
         <p className="text-xs uppercase tracking-widest" style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}>
-          Workout Frequency — {weekCount} Weeks
+          Workout Frequency — {granularity === "daily" ? "Daily" : "Weekly"}
         </p>
-        {hasGoal && (
-          <span className="text-xs tabular-nums" style={{ color: "var(--color-text-faint)" }}>
-            Goal: {goal}/wk
-          </span>
-        )}
+        <div className="flex items-center gap-2">
+          {hasGoal && granularity === "weekly" && (
+            <span className="text-xs tabular-nums" style={{ color: "var(--color-text-faint)" }}>
+              Goal: {goal}/wk
+            </span>
+          )}
+          {hasGoal && granularity === "daily" && (
+            <span className="text-xs tabular-nums" style={{ color: "var(--color-text-faint)" }}>
+              Goal: {goal}/wk
+            </span>
+          )}
+          <GranularityToggle
+            value={granularity}
+            onChange={setGranularity}
+            disabled={forceWeekly}
+          />
+        </div>
       </div>
 
       {!hasGoal && (
@@ -99,7 +156,7 @@ export function WorkoutFreqChart({ sessions, weekCount = 8, goal }: Props) {
       )}
 
       <ResponsiveContainer width="100%" height={200}>
-        <BarChart data={weeks} margin={{ top: 4, right: 4, left: -24, bottom: 0 }}>
+        <BarChart data={chartData} margin={{ top: 4, right: 4, left: -24, bottom: 0 }}>
           <CartesianGrid strokeDasharray="3 3" stroke="#1E2130" vertical={false} />
           <XAxis
             dataKey="label"
@@ -107,7 +164,9 @@ export function WorkoutFreqChart({ sessions, weekCount = 8, goal }: Props) {
             tick={{ fill: "#64748B", fontSize: 10 }}
             tickLine={false}
             axisLine={false}
-            interval={0}
+            interval={granularity === "daily" && showMonday
+              ? (_, index) => !(daySlots[index]?.isMonday)
+              : 0}
           />
           <YAxis
             stroke="#334155"
@@ -116,8 +175,11 @@ export function WorkoutFreqChart({ sessions, weekCount = 8, goal }: Props) {
             axisLine={false}
             allowDecimals={false}
           />
-          <Tooltip {...TOOLTIP_STYLE} formatter={(v: number) => [v, "Sessions"]} />
-          {hasGoal && (
+          <Tooltip
+            {...TOOLTIP_STYLE}
+            formatter={(v: number) => [v, granularity === "daily" ? "Workout" : "Sessions"]}
+          />
+          {hasGoal && granularity === "weekly" && (
             <ReferenceLine
               y={goal}
               stroke="#64748B"
@@ -127,17 +189,27 @@ export function WorkoutFreqChart({ sessions, weekCount = 8, goal }: Props) {
           )}
           <Bar
             dataKey="count"
-            name="Sessions"
+            name={granularity === "daily" ? "Workout" : "Sessions"}
             radius={[3, 3, 0, 0]}
             isAnimationActive={animate}
             animationDuration={300}
           >
-            {weeks.map((entry) => (
-              <Cell
-                key={entry.key}
-                fill={hasGoal ? barColor(entry.count, goal!) : "#6366F1"}
-              />
-            ))}
+            {chartData.map((entry) => {
+              if (granularity === "daily") {
+                return (
+                  <Cell
+                    key={entry.key}
+                    fill={entry.count > 0 ? (hasGoal ? "#10B981" : "#6366F1") : "#1E2130"}
+                  />
+                );
+              }
+              return (
+                <Cell
+                  key={entry.key}
+                  fill={hasGoal ? barColor(entry.count, goal!) : "#6366F1"}
+                />
+              );
+            })}
           </Bar>
         </BarChart>
       </ResponsiveContainer>

--- a/web/src/components/fitness/workout-freq-chart.tsx
+++ b/web/src/components/fitness/workout-freq-chart.tsx
@@ -164,9 +164,13 @@ export function WorkoutFreqChart({ sessions, days, goal }: Props) {
             tick={{ fill: "#64748B", fontSize: 10 }}
             tickLine={false}
             axisLine={false}
-            interval={granularity === "daily" && showMonday
-              ? (_, index) => !(daySlots[index]?.isMonday)
-              : 0}
+            interval={0}
+            tickFormatter={(label, index) => {
+              if (granularity === "daily" && showMonday) {
+                return daySlots[index]?.isMonday ? label : "";
+              }
+              return label;
+            }}
           />
           <YAxis
             stroke="#334155"

--- a/web/src/components/tasks/task-item.tsx
+++ b/web/src/components/tasks/task-item.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState, useTransition, useRef, useEffect } from "react";
-import { Archive } from "lucide-react";
-import type { Task } from "@/lib/types";
+import { Archive, ChevronDown, ChevronRight, X } from "lucide-react";
+import type { Task, Subtask } from "@/lib/types";
 
 const PRIORITY_COLOR: Record<string, string> = {
   high:   "var(--color-danger)",
@@ -23,16 +23,139 @@ function relativeDue(dateStr: string): { label: string; urgent: boolean } {
 
 interface Props {
   task: Task;
-  completeAction: (id: string) => Promise<{ error?: string }>;
-  archiveAction:  (id: string) => Promise<{ error?: string }>;
-  updateAction:   (id: string, title: string) => Promise<{ error?: string }>;
+  completeAction:       (id: string) => Promise<{ error?: string }>;
+  archiveAction:        (id: string) => Promise<{ error?: string }>;
+  updateAction:         (id: string, title: string) => Promise<{ error?: string }>;
+  addSubtaskAction:     (parentId: string, title: string) => Promise<{ error?: string }>;
+  completeSubtaskAction:(id: string) => Promise<{ error?: string }>;
+  deleteSubtaskAction:  (id: string) => Promise<{ error?: string }>;
 }
 
-export default function TaskItem({ task, completeAction, archiveAction, updateAction }: Props) {
+function SubtaskRow({
+  subtask,
+  completeSubtaskAction,
+  deleteSubtaskAction,
+  updateAction,
+}: {
+  subtask: Subtask;
+  completeSubtaskAction: (id: string) => Promise<{ error?: string }>;
+  deleteSubtaskAction:   (id: string) => Promise<{ error?: string }>;
+  updateAction:          (id: string, title: string) => Promise<{ error?: string }>;
+}) {
+  const [isPending, startTransition] = useTransition();
+  const [editing, setEditing]       = useState(false);
+  const [editTitle, setEditTitle]   = useState(subtask.title);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
+
+  function commitEdit() {
+    setEditing(false);
+    const trimmed = editTitle.trim();
+    if (trimmed && trimmed !== subtask.title) {
+      startTransition(async () => { await updateAction(subtask.id, trimmed); });
+    } else {
+      setEditTitle(subtask.title);
+    }
+  }
+
+  const done = subtask.status === "completed";
+
+  return (
+    <div
+      className="flex items-center gap-2 px-3 py-2"
+      style={{
+        opacity: isPending ? 0.4 : 1,
+        transition: "opacity 150ms",
+        borderLeft: "2px solid var(--color-border)",
+        marginLeft: 8,
+      }}
+    >
+      {/* Checkbox */}
+      <button
+        onClick={() => !done && startTransition(async () => { await completeSubtaskAction(subtask.id); })}
+        disabled={isPending || done}
+        className="flex-shrink-0 flex items-center justify-center transition-opacity hover:opacity-70"
+        style={{ width: 32, height: 32, margin: "-8px -4px -8px -8px" }}
+        title={done ? "Completed" : "Mark complete"}
+      >
+        <span
+          className="rounded-sm border-2 block flex items-center justify-center"
+          style={{
+            width: 15,
+            height: 15,
+            borderColor: done ? "var(--color-text-faint)" : "var(--color-border)",
+            background: done ? "var(--color-text-faint)" : "transparent",
+          }}
+        />
+      </button>
+
+      {/* Title */}
+      <div className="flex-1 min-w-0">
+        {editing ? (
+          <input
+            ref={inputRef}
+            value={editTitle}
+            onChange={(e) => setEditTitle(e.target.value)}
+            onBlur={commitEdit}
+            onKeyDown={(e) => {
+              if (e.key === "Enter")  commitEdit();
+              if (e.key === "Escape") { setEditTitle(subtask.title); setEditing(false); }
+            }}
+            className="w-full bg-transparent text-sm focus:outline-none"
+            style={{ color: "var(--color-text)" }}
+          />
+        ) : (
+          <span
+            className="text-sm cursor-text"
+            style={{
+              color: done ? "var(--color-text-faint)" : "var(--color-text)",
+              textDecoration: done ? "line-through" : "none",
+            }}
+            onClick={() => !done && setEditing(true)}
+          >
+            {subtask.title}
+          </span>
+        )}
+      </div>
+
+      {/* Delete */}
+      {!done && (
+        <button
+          onClick={() => startTransition(async () => { await deleteSubtaskAction(subtask.id); })}
+          disabled={isPending}
+          className="flex-shrink-0 p-1 rounded transition-opacity hover:opacity-70"
+          style={{ color: "var(--color-text-faint)" }}
+          title="Remove"
+        >
+          <X size={12} />
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default function TaskItem({
+  task,
+  completeAction,
+  archiveAction,
+  updateAction,
+  addSubtaskAction,
+  completeSubtaskAction,
+  deleteSubtaskAction,
+}: Props) {
   const [isPending, startTransition] = useTransition();
   const [editing, setEditing]       = useState(false);
   const [editTitle, setEditTitle]   = useState(task.title);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  const subtasks = task.subtasks ?? [];
+  const defaultExpanded = subtasks.length <= 3;
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const [addInput, setAddInput] = useState("");
+  const addInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (editing) inputRef.current?.focus();
@@ -40,6 +163,10 @@ export default function TaskItem({ task, completeAction, archiveAction, updateAc
 
   const dot = PRIORITY_COLOR[task.priority ?? "low"] ?? PRIORITY_COLOR.low;
   const due = task.due_date ? relativeDue(task.due_date) : null;
+
+  const completedCount = subtasks.filter((s) => s.status === "completed").length;
+  const totalCount = subtasks.length;
+  const allDone = totalCount > 0 && completedCount === totalCount;
 
   function handleComplete() {
     startTransition(async () => { await completeAction(task.id); });
@@ -59,82 +186,165 @@ export default function TaskItem({ task, completeAction, archiveAction, updateAc
     }
   }
 
+  function handleAddSubtask(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key !== "Enter") return;
+    const trimmed = addInput.trim();
+    if (!trimmed) return;
+    setAddInput("");
+    startTransition(async () => {
+      await addSubtaskAction(task.id, trimmed);
+    });
+    // Keep focus for rapid entry
+    setTimeout(() => addInputRef.current?.focus(), 50);
+  }
+
   return (
-    <div
-      className="flex items-center gap-3 px-4 py-3"
-      style={{ opacity: isPending ? 0.4 : 1, transition: "opacity 150ms" }}
-    >
-      {/* Completion circle — 44px touch target wrapping 18px visual */}
-      <button
-        onClick={handleComplete}
-        disabled={isPending}
-        className="flex-shrink-0 flex items-center justify-center transition-opacity hover:opacity-70"
-        style={{ width: 44, height: 44, margin: "-13px -10px -13px -13px" }}
-        title="Mark complete"
-      >
-        <span
-          className="rounded-full border-2 block"
-          style={{ width: 18, height: 18, borderColor: dot }}
-        />
-      </button>
-
-      {/* Priority dot */}
-      <span
-        className="flex-shrink-0 rounded-full"
-        style={{ width: 6, height: 6, background: dot }}
-      />
-
-      {/* Title */}
-      <div className="flex-1 min-w-0">
-        {editing ? (
-          <input
-            ref={inputRef}
-            value={editTitle}
-            onChange={(e) => setEditTitle(e.target.value)}
-            onBlur={commitEdit}
-            onKeyDown={(e) => {
-              if (e.key === "Enter")  commitEdit();
-              if (e.key === "Escape") { setEditTitle(task.title); setEditing(false); }
-            }}
-            className="w-full bg-transparent text-sm focus:outline-none"
-            style={{ color: "var(--color-text)" }}
-          />
-        ) : (
+    <div style={{ opacity: isPending ? 0.4 : 1, transition: "opacity 150ms" }}>
+      {/* Parent row */}
+      <div className="flex items-center gap-3 px-4 py-3">
+        {/* Completion circle — 44px touch target */}
+        <button
+          onClick={handleComplete}
+          disabled={isPending}
+          className="flex-shrink-0 flex items-center justify-center transition-opacity hover:opacity-70"
+          style={{ width: 44, height: 44, margin: "-13px -10px -13px -13px" }}
+          title="Mark complete"
+        >
           <span
-            className="text-sm cursor-text"
-            style={{ color: "var(--color-text)" }}
-            onClick={() => setEditing(true)}
+            className="rounded-full border-2 block"
+            style={{ width: 18, height: 18, borderColor: dot }}
+          />
+        </button>
+
+        {/* Priority dot */}
+        <span
+          className="flex-shrink-0 rounded-full"
+          style={{ width: 6, height: 6, background: dot }}
+        />
+
+        {/* Title + subtask progress */}
+        <div className="flex-1 min-w-0 flex items-center gap-2">
+          {editing ? (
+            <input
+              ref={inputRef}
+              value={editTitle}
+              onChange={(e) => setEditTitle(e.target.value)}
+              onBlur={commitEdit}
+              onKeyDown={(e) => {
+                if (e.key === "Enter")  commitEdit();
+                if (e.key === "Escape") { setEditTitle(task.title); setEditing(false); }
+              }}
+              className="flex-1 bg-transparent text-sm focus:outline-none"
+              style={{ color: "var(--color-text)" }}
+            />
+          ) : (
+            <span
+              className="text-sm cursor-text truncate"
+              style={{ color: "var(--color-text)" }}
+              onClick={() => setEditing(true)}
+            >
+              {task.title}
+            </span>
+          )}
+          {task.category && (
+            <span className="text-xs flex-shrink-0" style={{ color: "var(--color-text-faint)" }}>
+              {task.category}
+            </span>
+          )}
+          {totalCount > 0 && (
+            <span
+              className="text-xs tabular-nums flex-shrink-0 font-medium"
+              style={{ color: allDone ? "#10B981" : "var(--color-text-muted)" }}
+            >
+              {completedCount}/{totalCount}
+            </span>
+          )}
+        </div>
+
+        {/* Due date */}
+        {due && (
+          <span
+            className="flex-shrink-0 text-xs tabular-nums"
+            style={{ color: due.urgent ? "var(--color-danger)" : "var(--color-text-muted)" }}
           >
-            {task.title}
+            {due.label}
           </span>
         )}
-        {task.category && (
-          <span className="text-xs ml-1.5" style={{ color: "var(--color-text-faint)" }}>
-            {task.category}
-          </span>
+
+        {/* Expand/collapse chevron (only when subtasks exist) */}
+        {totalCount > 0 && (
+          <button
+            onClick={() => setExpanded((v) => !v)}
+            className="flex-shrink-0 p-1 rounded transition-opacity hover:opacity-70"
+            style={{ color: "var(--color-text-muted)" }}
+            title={expanded ? "Collapse" : "Expand"}
+          >
+            {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+          </button>
         )}
+
+        {/* Archive */}
+        <button
+          onClick={handleArchive}
+          disabled={isPending}
+          className="flex-shrink-0 p-1 rounded transition-opacity hover:opacity-70"
+          style={{ color: "var(--color-text-muted)" }}
+          title="Archive"
+        >
+          <Archive size={13} />
+        </button>
       </div>
 
-      {/* Due date */}
-      {due && (
-        <span
-          className="flex-shrink-0 text-xs tabular-nums"
-          style={{ color: due.urgent ? "var(--color-danger)" : "var(--color-text-muted)" }}
-        >
-          {due.label}
-        </span>
+      {/* Subtask list + add input */}
+      {expanded && (
+        <div className="pb-2 px-4 space-y-0.5">
+          {subtasks.map((sub) => (
+            <SubtaskRow
+              key={sub.id}
+              subtask={sub}
+              completeSubtaskAction={completeSubtaskAction}
+              deleteSubtaskAction={deleteSubtaskAction}
+              updateAction={updateAction}
+            />
+          ))}
+
+          {/* Add item input */}
+          <div
+            className="flex items-center gap-2 px-3 py-1.5"
+            style={{ borderLeft: "2px solid var(--color-border)", marginLeft: 8 }}
+          >
+            <input
+              ref={addInputRef}
+              value={addInput}
+              onChange={(e) => setAddInput(e.target.value)}
+              onKeyDown={handleAddSubtask}
+              placeholder="Add item…"
+              className="flex-1 bg-transparent text-sm focus:outline-none"
+              style={{ color: "var(--color-text)", caretColor: "var(--color-primary)" }}
+            />
+          </div>
+        </div>
       )}
 
-      {/* Archive */}
-      <button
-        onClick={handleArchive}
-        disabled={isPending}
-        className="flex-shrink-0 p-1 rounded transition-opacity hover:opacity-70"
-        style={{ color: "var(--color-text-muted)" }}
-        title="Archive"
-      >
-        <Archive size={13} />
-      </button>
+      {/* Show add input even when no subtasks yet (collapsed = no subtasks, so always show) */}
+      {!expanded && totalCount === 0 && (
+        <div className="pb-2 px-4">
+          <div
+            className="flex items-center gap-2 px-3 py-1.5"
+            style={{ borderLeft: "2px solid var(--color-border)", marginLeft: 8 }}
+          >
+            <input
+              ref={addInputRef}
+              value={addInput}
+              onChange={(e) => setAddInput(e.target.value)}
+              onKeyDown={handleAddSubtask}
+              placeholder="Add item…"
+              className="flex-1 bg-transparent text-sm focus:outline-none"
+              style={{ color: "var(--color-text)", caretColor: "var(--color-primary)" }}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/ui/granularity-toggle.tsx
+++ b/web/src/components/ui/granularity-toggle.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+interface Props {
+  value: "daily" | "weekly";
+  onChange: (v: "daily" | "weekly") => void;
+  disabled?: boolean;
+}
+
+export function GranularityToggle({ value, onChange, disabled }: Props) {
+  return (
+    <div
+      className="flex items-center gap-0.5 p-0.5 rounded-lg"
+      style={{
+        background: "var(--color-surface)",
+        border: "1px solid var(--color-border)",
+        opacity: disabled ? 0.45 : 1,
+      }}
+      title={disabled ? "Switch to a shorter window to view daily data" : undefined}
+    >
+      {(["daily", "weekly"] as const).map((opt) => {
+        const active = opt === value;
+        return (
+          <button
+            key={opt}
+            onClick={() => !disabled && onChange(opt)}
+            disabled={disabled}
+            className="px-2.5 py-1 rounded-md text-xs font-medium transition-all duration-150"
+            style={{
+              background: active ? "var(--color-primary)" : "transparent",
+              color: active ? "#fff" : "var(--color-text-muted)",
+              cursor: disabled ? "not-allowed" : "pointer",
+            }}
+          >
+            {opt.charAt(0).toUpperCase() + opt.slice(1)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -15,6 +15,13 @@ export interface HabitLog {
   notes: string | null;
 }
 
+export interface Subtask {
+  id: string;
+  title: string;
+  status: "active" | "completed" | "archived";
+  created_at: string;
+}
+
 export interface Task {
   id: string;
   title: string;
@@ -24,6 +31,8 @@ export interface Task {
   category: string | null;
   completed_at: string | null;
   created_at: string;
+  parent_id: string | null;
+  subtasks?: Subtask[];
 }
 
 export interface FitnessLog {


### PR DESCRIPTION
## Summary

- **#147 (fix)** — Weather H/L span gets `whiteSpace: nowrap` so the high/low string never breaks mid-value; weather `<p>` switches to `flex-wrap` + `gap-x-1.5 gap-y-0` so overflow wraps cleanly after the condition text
- **#145 (feat)** — Fitness charts now accept `days` from the window selector cookie instead of hardcoded `weekCount=8`; new `GranularityToggle` component (`Daily | Weekly` pill) added to both `WorkoutFreqChart` and `ActiveCalGoalChart`; daily mode plots per-day slots (workout = green/indigo, rest = dark); auto-forces weekly + disables toggle at >90d; Monday-only x-axis ticks at >14d
- **#144 (feat)** — Parent/child task hierarchy: `parent_id` column + index (migration `20260413000008`); `addSubtask`, `completeSubtask` (with sibling check → auto-complete parent), `deleteSubtask` server actions; `completeTask` cascades to subtasks; `TaskItem` extended with progress indicator, expand/collapse chevron, inline subtask list, always-visible "Add item…" input for rapid grocery entry; dashboard + tasks queries filter `parent_id IS NULL`; `add_task` chat tool accepts `parent_id`

## Test plan

- [ ] Mobile: weather line wraps cleanly after condition text, H/L never splits across lines
- [ ] Fitness page 7D/14D windows: charts default to daily mode, toggle works
- [ ] Fitness page 90D/1Y windows: toggle auto-switches to weekly and is greyed out
- [ ] WorkoutFreqChart daily: workout days show coloured bars, rest days dark
- [ ] ActiveCalGoalChart daily: plots raw per-day active cal values, daily target reference line visible
- [ ] Tasks: add a task, expand it, type items in "Add item…" and press Enter — items appear immediately, input stays focused
- [ ] Tasks: complete all subtasks → parent auto-completes
- [ ] Tasks: complete parent → all subtasks complete
- [ ] Dashboard tasks card: subtasks do not appear as standalone items in the count
- [ ] Chat: ask "add milk to my grocery list" → model calls `get_tasks`, finds parent, calls `add_task` with `parent_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)