### PR TITLE
feat: mobile newline input, paginated chat load more (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (mobile newline input + paginated chat load more — issue #149)
+- **Mobile Enter = newline** — `chat-interface.tsx` detects touch devices via `window.matchMedia("(pointer: coarse)")` on mount; on mobile, `Enter` always inserts a newline (no submit); on desktop, plain `Enter` submits and `Shift+Enter` inserts a newline; `enterKeyHint` on the textarea is `"enter"` on mobile and `"send"` on desktop
+- **Cursor-based pagination in GET `/api/chat/sessions/[id]`** — query now accepts `before` (position cursor) and `limit` (max 50, default 20) params; fetches newest-first, reverses for display, returns `{ messages, hasMore, oldestPosition }`; initial load is capped at 20 messages
+- **"Load older messages" button** — `chat-page-client.tsx` tracks `hasMore`, `oldestPosition`, `loadingMore`; clicking the button prepends older messages while preserving scroll position via `scrollHeight` diff; button shows a `Loader2` spinner while fetching
+
 ### Added (subtasks + grocery list UI — issue #144)
 - **`parent_id` column on `tasks`** — migration `20260413000008_tasks_parent_id.sql` adds `parent_id uuid references tasks(id) on delete cascade` and a supporting index; applied to live DB
 - **`Subtask` type** added to `web/src/lib/types.ts`; `Task` extended with `parent_id: string | null` and optional `subtasks?: Subtask[]`

--- a/web/src/app/api/chat/sessions/[id]/route.ts
+++ b/web/src/app/api/chat/sessions/[id]/route.ts
@@ -2,7 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
 
 export async function GET(
-  _req: Request,
+  req: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
@@ -13,15 +13,29 @@ export async function GET(
   } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const { data: msgs, error } = await supabase
+  const url = new URL(req.url);
+  const before = url.searchParams.get("before"); // position cursor
+  const limit = Math.min(parseInt(url.searchParams.get("limit") ?? "20"), 50);
+
+  let query = supabase
     .from("chat_messages")
-    .select("id, role, content, created_at")
+    .select("id, role, content, created_at, position")
     .eq("session_id", id)
     .in("role", ["user", "assistant"])
-    .order("position", { ascending: true, nullsFirst: false })
-    .limit(50);
+    .order("position", { ascending: false }) // newest first
+    .limit(limit);
 
+  if (before) query = query.lt("position", parseInt(before));
+
+  const { data: msgs, error } = await query;
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  return NextResponse.json({ messages: msgs ?? [] });
+  // Reverse so the slice displays oldest→newest
+  const ordered = (msgs ?? []).reverse();
+
+  return NextResponse.json({
+    messages: ordered,
+    hasMore: (msgs ?? []).length === limit,
+    oldestPosition: ordered[0]?.position ?? null,
+  });
 }

--- a/web/src/components/chat/chat-interface.tsx
+++ b/web/src/components/chat/chat-interface.tsx
@@ -2,7 +2,7 @@
 
 import { useChat } from "ai/react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Send } from "lucide-react";
+import { Loader2, Send } from "lucide-react";
 import MessageBubble from "./message-bubble";
 import ToolStatusBar from "./tool-status-bar";
 import SlashCommandMenu, { SLASH_COMMANDS, type SlashCommand } from "./slash-command-menu";
@@ -12,6 +12,9 @@ interface Props {
   sessionId: string;
   initialMessages: Message[];
   onMessageSent?: () => void;
+  hasMore?: boolean;
+  loadingMore?: boolean;
+  onLoadMore?: () => void;
 }
 
 // Returns the slash token the cursor is currently inside, or null.
@@ -25,9 +28,15 @@ function getSlashToken(value: string, cursorPos: number): { start: number; query
   return { start, query: match[1].slice(1).toLowerCase() };
 }
 
-export default function ChatInterface({ sessionId, initialMessages, onMessageSent }: Props) {
+export default function ChatInterface({ sessionId, initialMessages, onMessageSent, hasMore, loadingMore, onLoadMore }: Props) {
   const bottomRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  const [isTouchDevice, setIsTouchDevice] = useState(false);
+  useEffect(() => {
+    setIsTouchDevice(window.matchMedia("(pointer: coarse)").matches);
+  }, []);
 
   const { messages, input, handleInputChange, handleSubmit, isLoading, error, reload, setInput } = useChat({
     api: "/api/chat",
@@ -96,7 +105,8 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
           setActiveIndex((i) => (i - 1 + menuCommands.length) % menuCommands.length);
           break;
         case "Enter":
-          if (e.shiftKey) return; // allow default newline in textarea
+          if (isTouchDevice) return; // mobile: Enter always inserts newline
+          if (e.shiftKey) return; // desktop: Shift+Enter inserts newline
           if (menuCommands.length > 0) {
             e.preventDefault();
             applyCommand(menuCommands[activeIndex]);
@@ -117,26 +127,54 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
           break;
       }
     },
-    [menuCommands, activeIndex, applyCommand, handleSubmit]
+    [isTouchDevice, menuCommands, activeIndex, applyCommand, handleSubmit]
   );
 
-  // ── Scroll to bottom on new messages ─────────────────────────────────
+  // ── Scroll to bottom on new messages (not when prepending older ones) ─
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages]);
+    if (!loadingMore) {
+      bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [messages, loadingMore]);
 
   // ── Auto-resize textarea ──────────────────────────────────────────────
   useEffect(() => {
     const el = inputRef.current;
     if (!el) return;
     el.style.height = "auto";
-    el.style.height = `${el.scrollHeight}px`;
+    el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
   }, [input]);
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
       {/* Message list */}
-      <div className="flex-1 overflow-y-auto space-y-3 py-4 min-h-0">
+      <div ref={scrollContainerRef} className="flex-1 overflow-y-auto space-y-3 py-4 min-h-0">
+        {hasMore && (
+          <div className="flex justify-center py-3">
+            <button
+              onClick={() => {
+                const el = scrollContainerRef.current;
+                const prevHeight = el?.scrollHeight ?? 0;
+                onLoadMore?.();
+                requestAnimationFrame(() => {
+                  if (el) el.scrollTop += el.scrollHeight - prevHeight;
+                });
+              }}
+              disabled={loadingMore}
+              className="flex items-center gap-2 px-4 py-1.5 rounded-lg text-xs transition-opacity"
+              style={{
+                background: "var(--color-surface)",
+                border: "1px solid var(--color-border)",
+                color: "var(--color-text-muted)",
+              }}
+            >
+              {loadingMore
+                ? <Loader2 size={12} className="animate-spin" />
+                : "Load older messages"
+              }
+            </button>
+          </div>
+        )}
         {messages.length === 0 && (
           <p className="text-center mt-8" style={{ fontSize: 14, color: "var(--color-text-muted)" }}>
             Ask Mr. Bridge anything.
@@ -241,6 +279,7 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
             onChange={handleChange}
             onKeyDown={handleKeyDown}
             placeholder="Ask Mr. Bridge..."
+            enterKeyHint={isTouchDevice ? "enter" : "send"}
             disabled={isLoading}
             autoComplete="off"
             aria-autocomplete="list"

--- a/web/src/components/chat/chat-page-client.tsx
+++ b/web/src/components/chat/chat-page-client.tsx
@@ -22,6 +22,9 @@ export default function ChatPageClient({ initialSessionId, initialMessages }: Pr
     initialSessionId ?? newSessionId()
   );
   const [activeMessages, setActiveMessages] = useState<Message[]>(initialMessages);
+  const [hasMore, setHasMore] = useState(false);
+  const [oldestPosition, setOldestPosition] = useState<number | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
 
   // Desktop sidebar state — persisted in localStorage
   const [historyOpen, setHistoryOpen] = useState(false);
@@ -83,12 +86,40 @@ export default function ChatPageClient({ initialSessionId, initialMessages }: Pr
       }));
       setActiveSessionId(sessionId);
       setActiveMessages(msgs);
+      setHasMore(data.hasMore ?? false);
+      setOldestPosition(data.oldestPosition ?? null);
     } catch {
       // non-fatal
     } finally {
       setLoadingSession(false);
     }
   };
+
+  const handleLoadMore = useCallback(async () => {
+    if (!oldestPosition || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const res = await fetch(
+        `/api/chat/sessions/${activeSessionId}?before=${oldestPosition}&limit=20`
+      );
+      const data = await res.json();
+      const older: Message[] = (
+        data.messages as { id: string; role: string; content: string; created_at: string }[]
+      ).map((m) => ({
+        id: m.id,
+        role: m.role as "user" | "assistant",
+        content: m.content,
+        createdAt: new Date(m.created_at),
+      }));
+      setActiveMessages((prev) => [...older, ...prev]);
+      setHasMore(data.hasMore ?? false);
+      setOldestPosition(data.oldestPosition ?? null);
+    } catch {
+      // non-fatal
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [activeSessionId, oldestPosition, loadingMore]);
 
   // Refresh session list after a message exchange completes (so preview updates)
   const handleMessageSent = useCallback(() => {
@@ -204,6 +235,9 @@ export default function ChatPageClient({ initialSessionId, initialMessages }: Pr
               sessionId={activeSessionId}
               initialMessages={activeMessages}
               onMessageSent={handleMessageSent}
+              hasMore={hasMore}
+              loadingMore={loadingMore}
+              onLoadMore={handleLoadMore}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
- **Mobile newline**: touch devices detected via `window.matchMedia("(pointer: coarse)")`; `Enter` inserts newline on mobile, submits on desktop; `Shift+Enter` still inserts newline on desktop; `enterKeyHint` set to `"enter"` / `"send"` accordingly
- **Cursor-based pagination**: `GET /api/chat/sessions/[id]` now accepts `?before=<position>&limit=<n>` (max 50, default 20); returns `{ messages, hasMore, oldestPosition }` — initial load is capped at 20 messages
- **Load older messages button**: appears at top of message list when `hasMore` is true; prepends older messages and preserves scroll position via `scrollHeight` diff; shows `Loader2` spinner while fetching; auto-scroll to bottom is suppressed while loading older messages

## Dependencies
- #132 (`position` column) — merged ✓
- #134 (textarea conversion) — merged ✓

## Test plan
- [ ] Desktop: Enter submits, Shift+Enter inserts newline
- [ ] Mobile (or DevTools touch emulation): Enter inserts newline, submit requires tapping the Send button; mobile keyboard shows "return" not "send"
- [ ] Open a session with >20 messages — "Load older messages" button appears at top
- [ ] Click "Load older messages" — older messages prepend, scroll position holds, button disappears when all loaded
- [ ] New chat session — no "Load older messages" button, auto-scroll to bottom works normally
- [ ] Streaming response — auto-scrolls to bottom as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)