### PR TITLE
fix: standardize fitness chart date format and fix mobile tick density (#150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - **Dashboard tasks query** and **tasks page active query** both filter `parent_id IS NULL` so subtasks never appear as standalone items
 - **`add_task` chat tool** accepts optional `parent_id`; system prompt updated to instruct the model to call `get_tasks` first when adding list items, then `add_task` with `parent_id`
 
+### Fixed (fitness chart date format and mobile tick density — issue #150)
+- **`web/src/lib/chart-utils.ts`** — new shared utility with `formatDate` (YYYY-MM-DD → "Apr 11"), `computeDailyTicks` (filters dates to a readable subset based on window key), `computeWeeklyTicks` (filters weekly labels based on week count), and `daysToWindowKey` (inverse of WINDOW_DAYS)
+- **Date format standardized** — all five fitness charts now use `formatDate` ("Apr 11") instead of the previous mix of `date.slice(5)` ("04-11") on body-comp/weight-goal/body-fat-goal and `toLocaleDateString` on workout-freq/active-cal-goal; the local `dayLabel` helpers in those charts were removed in favor of the shared import
+- **Mobile tick density fixed** — removed `interval={0}` from all five `<XAxis>` elements; replaced with explicit `ticks` arrays computed by `computeDailyTicks`/`computeWeeklyTicks`; density rules: 7d → all, 14d/30d → Mondays only, 90d/1yr → every 14th date; weekly mode: ≤8 weeks → all, 9–26 weeks → every 2nd, >26 weeks → every 4th
+- **`windowKey` prop added** to `BodyCompDualChart`, `WeightGoalChart`, and `BodyFatGoalChart`; `fitness/page.tsx` passes `windowKey` from `getWindow()` to all three; `WorkoutFreqChart` and `ActiveCalGoalChart` derive window key from their existing `days` prop via `daysToWindowKey`
+
 ### Added (daily/weekly toggle on fitness charts — issue #145)
 - **`GranularityToggle` component** — `web/src/components/ui/granularity-toggle.tsx`; `Daily | Weekly` pill toggle matching window-selector style; greyed out with tooltip when `disabled`
 - **`WorkoutFreqChart`** — prop changed from `weekCount` to `days: number`; `granularity` state (`daily`/`weekly`); auto-forces weekly + disables toggle when `days > 90`; daily mode plots one slot per calendar day (green `#10B981` with goal, indigo `#6366F1` without, rest day `#1E2130`); weekly mode retains existing ISO-week bucketing; x-axis shows only Monday ticks at >14d, all days at ≤14d

--- a/web/src/app/(protected)/fitness/page.tsx
+++ b/web/src/app/(protected)/fitness/page.tsx
@@ -89,7 +89,7 @@ export default async function FitnessPage() {
       </div>
 
       {/* Body composition trend */}
-      <BodyCompDualChart data={fitnessData} windowLabel={windowKey.toUpperCase()} />
+      <BodyCompDualChart data={fitnessData} windowLabel={windowKey.toUpperCase()} windowKey={windowKey} />
 
       {/* Weekly frequency + active cal vs goals */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
@@ -131,11 +131,13 @@ export default async function FitnessPage() {
           data={fitnessData}
           goal={weightGoal}
           windowLabel={windowKey.toUpperCase()}
+          windowKey={windowKey}
         />
         <BodyFatGoalChart
           data={fitnessData}
           goal={bodyFatGoal}
           windowLabel={windowKey.toUpperCase()}
+          windowKey={windowKey}
         />
       </div>
 

--- a/web/src/components/fitness/active-cal-goal-chart.tsx
+++ b/web/src/components/fitness/active-cal-goal-chart.tsx
@@ -8,6 +8,7 @@ import {
 } from "recharts";
 import Link from "next/link";
 import { GranularityToggle } from "@/components/ui/granularity-toggle";
+import { formatDate, computeDailyTicks, computeWeeklyTicks, daysToWindowKey } from "@/lib/chart-utils";
 
 interface DataPoint {
   date: string;
@@ -42,10 +43,6 @@ function getISOWeekKey(dateStr: string): string {
   const monday = new Date(d);
   monday.setDate(d.getDate() + diff);
   return monday.toISOString().slice(0, 10);
-}
-
-function dayLabel(dateStr: string): string {
-  return new Date(dateStr + "T00:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
 
 function dayOfWeek(dateStr: string): number {
@@ -101,7 +98,7 @@ export function ActiveCalGoalChart({ data, goal, days }: Props) {
       const dateStr = d.toISOString().slice(0, 10);
       daySlots.push({
         key: dateStr,
-        label: dayLabel(dateStr),
+        label: formatDate(dateStr),
         total: null,
         isMonday: dayOfWeek(dateStr) === 1,
       });
@@ -113,7 +110,11 @@ export function ActiveCalGoalChart({ data, goal, days }: Props) {
     });
   }
 
-  const showMonday = days > 14;
+  const ticks =
+    granularity === "weekly"
+      ? computeWeeklyTicks(weekSlots.map((s) => s.label), weekCount)
+      : computeDailyTicks(daySlots.map((s) => s.key), daysToWindowKey(days));
+
   const chartData = granularity === "weekly" ? weekSlots : daySlots;
   const dailyGoal = hasGoal ? Math.round(goal! / 7) : null;
 
@@ -166,13 +167,7 @@ export function ActiveCalGoalChart({ data, goal, days }: Props) {
             tick={{ fill: "#64748B", fontSize: 10 }}
             tickLine={false}
             axisLine={false}
-            interval={0}
-            tickFormatter={(label, index) => {
-              if (granularity === "daily" && showMonday) {
-                return daySlots[index]?.isMonday ? label : "";
-              }
-              return label;
-            }}
+            ticks={ticks}
           />
           <YAxis
             stroke="#334155"

--- a/web/src/components/fitness/body-comp-dual-chart.tsx
+++ b/web/src/components/fitness/body-comp-dual-chart.tsx
@@ -12,10 +12,13 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import type { FitnessLog } from "@/lib/types";
+import type { WindowKey } from "@/lib/window";
+import { formatDate, computeDailyTicks } from "@/lib/chart-utils";
 
 interface Props {
   data: FitnessLog[];
   windowLabel?: string;
+  windowKey: WindowKey;
 }
 
 const TOOLTIP_STYLE = {
@@ -24,7 +27,7 @@ const TOOLTIP_STYLE = {
   itemStyle: { color: "#64748B", fontSize: 12 },
 };
 
-export function BodyCompDualChart({ data, windowLabel = "90D" }: Props) {
+export function BodyCompDualChart({ data, windowLabel = "90D", windowKey }: Props) {
   const [animate, setAnimate] = useState(true);
 
   useEffect(() => {
@@ -33,10 +36,11 @@ export function BodyCompDualChart({ data, windowLabel = "90D" }: Props) {
   }, []);
 
   const chartData = data.map((d) => ({
-    date: d.date.slice(5),
+    date: formatDate(d.date),
     weight: d.weight_lb,
     bodyFat: d.body_fat_pct,
   }));
+  const ticks = computeDailyTicks(data.map((d) => d.date), windowKey);
 
   if (chartData.length === 0) {
     return (
@@ -71,7 +75,7 @@ export function BodyCompDualChart({ data, windowLabel = "90D" }: Props) {
             tick={{ fill: "#64748B", fontSize: 11 }}
             tickLine={false}
             axisLine={false}
-            interval="preserveStartEnd"
+            ticks={ticks}
           />
           <YAxis
             yAxisId="weight"

--- a/web/src/components/fitness/body-fat-goal-chart.tsx
+++ b/web/src/components/fitness/body-fat-goal-chart.tsx
@@ -7,12 +7,15 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import type { FitnessLog } from "@/lib/types";
+import type { WindowKey } from "@/lib/window";
+import { formatDate, computeDailyTicks } from "@/lib/chart-utils";
 import Link from "next/link";
 
 interface Props {
   data: FitnessLog[];
   goal?: number | null;
   windowLabel?: string;
+  windowKey: WindowKey;
 }
 
 const TOOLTIP_STYLE = {
@@ -21,7 +24,7 @@ const TOOLTIP_STYLE = {
   itemStyle: { color: "#64748B", fontSize: 12 },
 };
 
-export function BodyFatGoalChart({ data, goal, windowLabel = "90D" }: Props) {
+export function BodyFatGoalChart({ data, goal, windowLabel = "90D", windowKey }: Props) {
   const [animate, setAnimate] = useState(true);
 
   useEffect(() => {
@@ -29,9 +32,9 @@ export function BodyFatGoalChart({ data, goal, windowLabel = "90D" }: Props) {
     setAnimate(!mq.matches);
   }, []);
 
-  const chartData = data
-    .filter((d) => d.body_fat_pct != null)
-    .map((d) => ({ date: d.date.slice(5), bf: d.body_fat_pct }));
+  const filtered = data.filter((d) => d.body_fat_pct != null);
+  const chartData = filtered.map((d) => ({ date: formatDate(d.date), bf: d.body_fat_pct }));
+  const ticks = computeDailyTicks(filtered.map((d) => d.date), windowKey);
 
   const latest = chartData[chartData.length - 1]?.bf ?? null;
   const hasGoal = goal != null && goal > 0;
@@ -90,7 +93,7 @@ export function BodyFatGoalChart({ data, goal, windowLabel = "90D" }: Props) {
               tick={{ fill: "#64748B", fontSize: 11 }}
               tickLine={false}
               axisLine={false}
-              interval="preserveStartEnd"
+              ticks={ticks}
             />
             <YAxis
               stroke="#334155"

--- a/web/src/components/fitness/weight-goal-chart.tsx
+++ b/web/src/components/fitness/weight-goal-chart.tsx
@@ -7,12 +7,15 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import type { FitnessLog } from "@/lib/types";
+import type { WindowKey } from "@/lib/window";
+import { formatDate, computeDailyTicks } from "@/lib/chart-utils";
 import Link from "next/link";
 
 interface Props {
   data: FitnessLog[];
   goal?: number | null;
   windowLabel?: string;
+  windowKey: WindowKey;
 }
 
 const TOOLTIP_STYLE = {
@@ -21,7 +24,7 @@ const TOOLTIP_STYLE = {
   itemStyle: { color: "#64748B", fontSize: 12 },
 };
 
-export function WeightGoalChart({ data, goal, windowLabel = "90D" }: Props) {
+export function WeightGoalChart({ data, goal, windowLabel = "90D", windowKey }: Props) {
   const [animate, setAnimate] = useState(true);
 
   useEffect(() => {
@@ -29,9 +32,9 @@ export function WeightGoalChart({ data, goal, windowLabel = "90D" }: Props) {
     setAnimate(!mq.matches);
   }, []);
 
-  const chartData = data
-    .filter((d) => d.weight_lb != null)
-    .map((d) => ({ date: d.date.slice(5), weight: d.weight_lb }));
+  const filtered = data.filter((d) => d.weight_lb != null);
+  const chartData = filtered.map((d) => ({ date: formatDate(d.date), weight: d.weight_lb }));
+  const ticks = computeDailyTicks(filtered.map((d) => d.date), windowKey);
 
   const latest = chartData[chartData.length - 1]?.weight ?? null;
   const hasGoal = goal != null && goal > 0;
@@ -90,7 +93,7 @@ export function WeightGoalChart({ data, goal, windowLabel = "90D" }: Props) {
               tick={{ fill: "#64748B", fontSize: 11 }}
               tickLine={false}
               axisLine={false}
-              interval="preserveStartEnd"
+              ticks={ticks}
             />
             <YAxis
               stroke="#334155"

--- a/web/src/components/fitness/workout-freq-chart.tsx
+++ b/web/src/components/fitness/workout-freq-chart.tsx
@@ -9,6 +9,7 @@ import {
 import type { WorkoutSession } from "@/lib/types";
 import Link from "next/link";
 import { GranularityToggle } from "@/components/ui/granularity-toggle";
+import { formatDate, computeDailyTicks, computeWeeklyTicks, daysToWindowKey } from "@/lib/chart-utils";
 
 interface Props {
   sessions: WorkoutSession[];
@@ -44,10 +45,6 @@ function barColor(count: number, goal: number): string {
   if (count >= goal)      return "#10B981"; // green
   if (count === goal - 1) return "#F59E0B"; // amber
   return "#EF4444";                         // red
-}
-
-function dayLabel(dateStr: string): string {
-  return new Date(dateStr + "T00:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
 
 function dayOfWeek(dateStr: string): number {
@@ -103,7 +100,7 @@ export function WorkoutFreqChart({ sessions, days, goal }: Props) {
       const dateStr = d.toISOString().slice(0, 10);
       daySlots.push({
         key: dateStr,
-        label: dayLabel(dateStr),
+        label: formatDate(dateStr),
         count: 0,
         isMonday: dayOfWeek(dateStr) === 1,
       });
@@ -114,7 +111,10 @@ export function WorkoutFreqChart({ sessions, days, goal }: Props) {
     });
   }
 
-  const showMonday = days > 14; // sparse ticks at >14 days
+  const ticks =
+    granularity === "weekly"
+      ? computeWeeklyTicks(weekSlots.map((s) => s.label), weekCount)
+      : computeDailyTicks(daySlots.map((s) => s.key), daysToWindowKey(days));
 
   const chartData = granularity === "weekly" ? weekSlots : daySlots;
 
@@ -164,13 +164,7 @@ export function WorkoutFreqChart({ sessions, days, goal }: Props) {
             tick={{ fill: "#64748B", fontSize: 10 }}
             tickLine={false}
             axisLine={false}
-            interval={0}
-            tickFormatter={(label, index) => {
-              if (granularity === "daily" && showMonday) {
-                return daySlots[index]?.isMonday ? label : "";
-              }
-              return label;
-            }}
+            ticks={ticks}
           />
           <YAxis
             stroke="#334155"

--- a/web/src/lib/chart-utils.ts
+++ b/web/src/lib/chart-utils.ts
@@ -1,0 +1,59 @@
+import type { WindowKey } from "@/lib/window";
+
+/** Format a YYYY-MM-DD string as "Apr 11" */
+export function formatDate(dateStr: string): string {
+  return new Date(dateStr + "T00:00:00").toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/** Derive the WindowKey from a days count (inverse of WINDOW_DAYS). */
+export function daysToWindowKey(days: number): WindowKey {
+  if (days <= 7)  return "7d";
+  if (days <= 14) return "14d";
+  if (days <= 30) return "30d";
+  if (days <= 90) return "90d";
+  return "1yr";
+}
+
+/**
+ * Given the full array of YYYY-MM-DD date strings and the active window key,
+ * returns a subset of dates formatted as "Apr 11" to use as XAxis ticks.
+ *
+ * Density rules:
+ *   7d       → all ticks
+ *   14d/30d  → Mondays only
+ *   90d/1yr  → every 14th date starting from index 0
+ */
+export function computeDailyTicks(dates: string[], windowKey: WindowKey): string[] {
+  if (dates.length === 0) return [];
+
+  if (windowKey === "7d") {
+    return dates.map(formatDate);
+  }
+
+  if (windowKey === "14d" || windowKey === "30d") {
+    return dates
+      .filter((d) => new Date(d + "T00:00:00").getDay() === 1)
+      .map(formatDate);
+  }
+
+  // 90d or 1yr: every 14th index starting from the first
+  return dates.filter((_, i) => i % 14 === 0).map(formatDate);
+}
+
+/**
+ * Given the full array of week label strings and the week count,
+ * returns a subset of labels to use as XAxis ticks.
+ *
+ * Density rules:
+ *   ≤8 weeks  → all
+ *   9–26 weeks → every 2nd
+ *   >26 weeks  → every 4th
+ */
+export function computeWeeklyTicks(labels: string[], weekCount: number): string[] {
+  if (weekCount <= 8)  return [...labels];
+  if (weekCount <= 26) return labels.filter((_, i) => i % 2 === 0);
+  return labels.filter((_, i) => i % 4 === 0);
+}


### PR DESCRIPTION
## Summary

- Standardized all five fitness charts to "Apr 11" date format via a shared `formatDate` helper in `web/src/lib/chart-utils.ts`; removes the inconsistency between `date.slice(5)` ("04-11") used in body-comp/weight-goal/body-fat-goal and `toLocaleDateString` used in workout-freq/active-cal-goal
- Replaced `interval={0}` on all `<XAxis>` elements with explicit `ticks` arrays computed from window size, keeping labels readable at all zoom levels on mobile; density rules: 7d → all ticks, 14d/30d → Mondays only, 90d/1yr → every 14th date; weekly mode: ≤8 weeks → all, 9–26 weeks → every 2nd, >26 weeks → every 4th
- Added `windowKey: WindowKey` prop to `BodyCompDualChart`, `WeightGoalChart`, and `BodyFatGoalChart`; `WorkoutFreqChart` and `ActiveCalGoalChart` derive window key from their existing `days` prop via `daysToWindowKey`

## Files changed

- `web/src/lib/chart-utils.ts` — new shared utility (formatDate, computeDailyTicks, computeWeeklyTicks, daysToWindowKey)
- `web/src/components/fitness/body-comp-dual-chart.tsx`
- `web/src/components/fitness/weight-goal-chart.tsx`
- `web/src/components/fitness/body-fat-goal-chart.tsx`
- `web/src/components/fitness/workout-freq-chart.tsx`
- `web/src/components/fitness/active-cal-goal-chart.tsx`
- `web/src/app/(protected)/fitness/page.tsx`
- `CHANGELOG.md`

## Test plan

- [ ] Load fitness page at each window (7d, 14d, 30d, 90d) and confirm X-axis labels show "Apr 11" format on all charts
- [ ] Confirm tick density thins out at 14d/30d (Mondays only) and 90d (every 14th)
- [ ] Switch workout-freq and active-cal charts to weekly mode; confirm ≤8 weeks shows all labels, wider windows thin out
- [ ] Check on a narrow mobile viewport that labels no longer overlap at 30d and 90d windows
- [ ] `cd web && npx tsc --noEmit` passes (verified clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)