### PR TITLE
feat: remove pantry assumption; treat saved recipes as library not constraint (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed (remove pantry assumption; treat saved recipes as library — issue #152)
+- **System prompt — recipe/meal planning block** — replaced the 6-step "ingredients on hand" flow with a new block that: (1) assumes bare-essential pantry only (salt, pepper, oils, spices, etc.) unless the user specifies ingredients in chat; (2) instructs the assistant to suggest 1–2 recipes from its own knowledge in addition to searching the saved library; (3) asks the user what proteins/produce they have if not stated; (4) removes the step that read pantry staples from the profile
+- **`get_recipes` tool description** — updated to clarify the saved list is a library to draw from, not a constraint; assistant must not limit suggestions to saved recipes only
+
 ### Added (mobile newline input + paginated chat load more — issue #149)
 - **Mobile Enter = newline** — `chat-interface.tsx` detects touch devices via `window.matchMedia("(pointer: coarse)")` on mount; on mobile, `Enter` always inserts a newline (no submit); on desktop, plain `Enter` submits and `Shift+Enter` inserts a newline; `enterKeyHint` on the textarea is `"enter"` on mobile and `"send"` on desktop
 - **Cursor-based pagination in GET `/api/chat/sessions/[id]`** — query now accepts `before` (position cursor) and `limit` (max 50, default 20) params; fetches newest-first, reverses for display, returns `{ messages, hasMore, oldestPosition }`; initial load is capped at 20 messages

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -272,16 +272,22 @@ Tools available:
 - create_calendar_event: create a Google Calendar event on the primary calendar. Pre-flight required: call list_calendar_events first, check for time overlaps and duplicate titles on the target date, surface any conflicts to the user, and confirm before proceeding.
 - delete_calendar_event: delete an event by eventId. Always state title/date/time and require explicit user confirmation first.
 - update_calendar_event: patch an existing event by eventId (summary, start, end, location, description). Always state before/after and require explicit user confirmation first.
-- get_recipes: search saved recipes by ingredient, name, or tag; omit query to return all
+- get_recipes: search the saved recipe library by ingredient, name, or tag; omit query to return all saved recipes. Use this as one input alongside your own recipe knowledge — do not limit suggestions to saved recipes only.
 - log_meal: log a meal by type (breakfast/lunch/dinner/snack) with optional recipe link, notes, and estimated macros (calories, protein_g, carbs_g, fat_g) — include macros whenever the user mentions them or you can estimate from the food description
 
-Recipes and meal planning are in scope. When asked what to cook given ingredients on hand:
-1. Call get_recipes to check for saved recipes that match.
-2. Call get_fitness_summary to pull recent body composition, goals, and workout data — use this to calibrate the recommendation (e.g. prioritize protein post-workout, suggest lower-calorie options if in a deficit phase).
-3. Call get_profile to check for dietary preferences, pantry staples, and cuisine preferences stored in the user's profile.
-4. Always provide a concrete recipe recommendation — either from saved recipes or improvised from your own knowledge. Do not redirect to external tools.
-5. Include estimated calories, protein, carbs, and fat for the suggested recipe. Flag if the meal is a poor fit for current fitness context (e.g. high-calorie meal after a rest day, low protein after a hard workout).
-6. Improvise confidently when no saved recipe fits, using any dietary preferences from the profile as guidance.`;
+Recipes and meal planning are in scope.
+
+Ingredient assumptions: Unless the user states otherwise in this conversation, assume the only ingredients available are bare essentials — salt, pepper, neutral oil, olive oil, butter, garlic, onion, basic dry spices (cumin, paprika, oregano, chili flake, cinnamon, etc.), flour, sugar, baking soda/powder, vinegar, soy sauce, and stock/broth. Do not assume proteins, produce, dairy, or specialty ingredients are on hand.
+
+When the user says what they have available (e.g. "I have chicken, broccoli, and rice"), treat those ingredients as the primary constraint for the rest of the conversation.
+
+When asked what to cook or for recipe ideas:
+1. Call get_recipes to check the saved recipe library — if a saved recipe is a good fit for the context (ingredients on hand, dietary preferences, fitness goals), surface it with a note that it's saved.
+2. Also suggest 1–2 recipes from your own knowledge that are NOT in the saved list. The saved list is a library of recipes the user likes, not a menu to be confined to.
+3. If the user hasn't said what they have on hand, ask: "What proteins or produce do you have available?"
+4. Call get_fitness_summary to calibrate the recommendation — prioritize protein post-workout, lower-calorie options in a deficit phase, etc.
+5. Call get_profile to check for dietary preferences and cuisine preferences (ignore any pantry-related profile keys).
+6. Always provide at least one concrete, actionable recipe recommendation. Include estimated calories, protein, carbs, and fat. Flag if the meal is a poor nutritional fit for current fitness context.`;
 
   // Strip extra fields (parts, id, etc.) that useChat adds — Anthropic only wants role + content
   // Also filter empty-content messages to prevent Anthropic 400 errors


### PR DESCRIPTION
## Summary

- System prompt now assumes bare-essential ingredients only (salt, pepper, oils, basic spices, etc.) unless the user specifies what they have available in the current conversation
- Recipe suggestions now draw from both the saved recipe library and the model's own knowledge — the saved list is treated as a library, not a constraint
- `get_recipes` tool description updated to reflect this: results are one input, not the full answer

## Changes

- `web/src/app/api/chat/route.ts` — replaced the recipe/meal planning system prompt block and updated the `get_recipes` tool description
- `CHANGELOG.md` — entry added under `[Unreleased]`

## Test plan

- [ ] Ask "what should I cook?" without specifying ingredients — assistant should ask what proteins/produce are on hand
- [ ] Say "I have chicken, broccoli, and rice" — assistant should treat those as the constraint and not assume other proteins/produce
- [ ] Confirm assistant suggests at least one recipe from its own knowledge alongside any saved recipe matches
- [ ] Confirm `get_profile` is still called for dietary/cuisine preferences but pantry profile keys are ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)