### PR TITLE
release: v1.0.0 pre-release audit — security, multitenancy, correctness

### DIFF
--- a/.claude/rules/mr-bridge-rules.md
+++ b/.claude/rules/mr-bridge-rules.md
@@ -13,9 +13,10 @@ After reading the briefing output, check the PROFILE section for a `name` key.
   python3 - <<'EOF'
   import sys
   sys.path.insert(0, "scripts")
-  from _supabase import get_client
+  from _supabase import get_client, get_owner_user_id
   client = get_client()
-  client.table("profile").upsert({"key": "name", "value": "<name>"}, on_conflict="key").execute()
+  uid = get_owner_user_id()
+  client.table("profile").upsert({"user_id": uid, "key": "name", "value": "<name>"}, on_conflict="user_id,key").execute()
   print("Name saved.")
   EOF
   ```
@@ -145,9 +146,10 @@ When the user says anything like "change my location to X", "set weather to X", 
 python3 - <<'EOF'
 import sys
 sys.path.insert(0, "scripts")
-from _supabase import get_client
+from _supabase import get_client, get_owner_user_id
 client = get_client()
-client.table("profile").upsert({"key": "location_city", "value": "<CITY>"}, on_conflict="key").execute()
+uid = get_owner_user_id()
+client.table("profile").upsert({"user_id": uid, "key": "location_city", "value": "<CITY>"}, on_conflict="user_id,key").execute()
 print("Location updated.")
 EOF
 ```
@@ -161,9 +163,10 @@ When the user says "reset my location", "back home", "use my home location", or 
 python3 - <<'EOF'
 import sys
 sys.path.insert(0, "scripts")
-from _supabase import get_client
+from _supabase import get_client, get_owner_user_id
 client = get_client()
-client.table("profile").delete().eq("key", "location_city").execute()
+uid = get_owner_user_id()
+client.table("profile").delete().eq("user_id", uid).eq("key", "location_city").execute()
 print("Location reset.")
 EOF
 ```
@@ -198,7 +201,7 @@ All live data is stored in Supabase. Local markdown files are archived originals
 | `tasks` + `study_log` | Manual logging | (future command) |
 | `profile` | Migrated from `profile.md` | (edit via Supabase or future command) |
 | `recipes` + `meal_log` | Migrated from `meal_log.md` | `get_recipes` / `log_meal` tools (web chat) |
-| `chat_sessions` + `chat_messages` | Web interface | (future — issue #10) |
+| `chat_sessions` + `chat_messages` | Web interface | Chat API (`/api/chat`) |
 | `timer_state` | Study timer | `study-timer` agent |
 
 ## Reference Index

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 .env
+.env.local
+.env.*.local
 node_modules/
 __pycache__/
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,29 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ---
 
-## [Unreleased]
+## [1.0.0] — 2026-04-13
+
+### Fixed (pre-1.0 audit — security and server action correctness)
+- **`web/src/app/api/google/calendar/route.ts`, `gmail/route.ts`, `calendar/upcoming-birthday/route.ts`** — missing auth guard: unauthenticated callers fell through to real Google Calendar/Gmail API and received owner's live data; added `if (!user) return 401` before the demo-user check
+- **`web/src/app/api/meals/analyze-photo/route.ts`, `meals/estimate-macros/route.ts`** — no auth check at all; unauthenticated callers could trigger Anthropic API calls; added auth guard
+- **`web/src/app/api/weather/route.ts`** — no auth check; switched from `createServiceClient` (reads all users' profile rows) to `createClient` with user-scoped `.eq("user_id", user.id)` filter; added `if (!user) return 401`
+- **`web/src/app/api/chat/route.ts`** — unauthenticated callers could reach the Anthropic stream; added `if (!user) return 401`; `userId` is now non-nullable after the guard so all downstream `.eq("user_id", userId)` filters are unconditionally applied
+- **`.gitignore`** — added `.env.local` and `.env.*.local` rules; previously only `.env` was ignored, leaving `web/.env.local` unprotected from accidental `git add`
+- **`web/src/app/(protected)/dashboard/page.tsx`** — `toggleHabit` server action upserted habits without `user_id`; new entries would fail `NOT NULL` constraint; added `getUser()` guard and `user_id: user.id` in upsert payload
+- **`web/src/app/(protected)/habits/page.tsx`** — `toggleHabit` and `addHabit` server actions missing `user_id`; fixed with `getUser()` guard and `user_id: user.id` on all writes
+- **`web/src/app/(protected)/tasks/page.tsx`** — `addTask` and `addSubtask` used `user?.id` (nullable); if auth ever fails these would insert `undefined` into `user_id NOT NULL`; strengthened to `if (!user) return { error: "Unauthorized" }` with non-nullable `user.id`
+
+### Fixed (pre-1.0 audit — multitenancy correctness)
+- **`scripts/check_hrv_alert.py`, `check_weather_alert.py`, `check_task_due_alerts.py`, `check_daily_alerts.py`** — `set_profile_value` / `get_profile_value` helpers updated to pass `user_id` (NOT NULL violation after multitenancy migration) and fix `on_conflict="key"` → `on_conflict="user_id,key"`; all task/recovery queries now filter by `owner_user_id`
+- **`check_daily_alerts.py`** — tasks query used nonexistent `name` column; corrected to `title`
+- **`scripts/fetch_weather.py`** — profile select without user_id filter now scopes to `owner_user_id` when available; docstring example snippet updated with correct upsert pattern
+- **`web/src/lib/sync/oura.ts`, `fitbit.ts`, `googlefit.ts`** — `syncOura`, `syncFitbit`, `syncGoogleFit` functions now require a `userId` string parameter; all DB queries and inserts include `user_id`; `onConflict` strings updated to include `user_id` (e.g. `date` → `user_id,date`); fixes NOT NULL violation on all sync table inserts post-multitenancy migration
+- **`web/src/app/api/sync/{oura,fitbit,googlefit}/route.ts`** — pass `user.id` to sync functions (previously passed none)
+- **`web/src/app/api/cron/sync/route.ts`** — read `OWNER_USER_ID` from env and pass to all sync functions; return 500 if not configured
+- **`web/src/app/(protected)/settings/page.tsx`** — `updateProfile` and `deleteProfile` server actions now fetch the authenticated user and include `user_id` in all profile writes; `onConflict` fixed to `user_id,key`
+- **`web/.env.local.example`** — added `OWNER_USER_ID` variable with setup instructions; Fitbit token bootstrap snippet updated with correct `user_id,key` upsert pattern
+- **`README.md`** — table counts updated (14 → 16); migration list updated to include all 20260413 migrations; `web/.env.local` table gains `OWNER_USER_ID` row; Fitbit token snippet corrected; tool count updated (13 → 16)
+- **`.claude/rules/mr-bridge-rules.md`** — location set/reset code snippets updated to include `user_id` and correct `on_conflict`; name storage snippet updated; Data Sources table updated (`chat_sessions/chat_messages` now points to Chat API, no longer "future"); `chat_sessions` + `chat_messages` table entry updated to reflect shipped state
 
 ### Changed (remove pantry assumption; treat saved recipes as library — issue #152)
 - **System prompt — recipe/meal planning block** — replaced the 6-step "ingredients on hand" flow with a new block that: (1) assumes bare-essential pantry only (salt, pepper, oils, spices, etc.) unless the user specifies ingredients in chat; (2) instructs the assistant to suggest 1–2 recipes from its own knowledge in addition to searching the saved library; (3) asks the user what proteins/produce they have if not stated; (4) removes the step that read pantry staples from the profile

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ flowchart LR
         sg["sync-googlefit"]
     end
 
-    db[("Supabase\n14 tables")]
+    db[("Supabase\n16 tables")]
 
     subgraph web["Next.js · Vercel"]
         cron["cron/sync\ndaily 6am PST"]
@@ -133,7 +133,7 @@ supabase link --project-ref <your-project-ref>   # ref is the part of the URL af
 supabase db push
 ```
 
-This creates all 14 tables (habits, tasks, fitness_log, recovery_metrics, workout_sessions, meal_log, recipes, profile, journal_entries, etc.).
+This creates all 16 tables (habits, tasks, fitness_log, recovery_metrics, workout_sessions, meal_log, recipes, profile, journal_entries, notifications, etc.).
 
 ### Step 3 — Get your Anthropic API key
 
@@ -203,8 +203,9 @@ python3 scripts/sync-fitbit.py --setup
 python3 -c "
 import sys, os; sys.path.insert(0, 'scripts')
 from dotenv import load_dotenv; load_dotenv(dotenv_path='.env')
-from _supabase import get_client
-get_client().table('profile').upsert({'key': 'fitbit_refresh_token', 'value': os.environ['FITBIT_REFRESH_TOKEN']}, on_conflict='key').execute()
+from _supabase import get_client, get_owner_user_id
+uid = get_owner_user_id()
+get_client().table('profile').upsert({'user_id': uid, 'key': 'fitbit_refresh_token', 'value': os.environ['FITBIT_REFRESH_TOKEN']}, on_conflict='user_id,key').execute()
 print('Done.')
 "
 ```
@@ -267,6 +268,7 @@ Fill in each file using the values collected in steps 2–6. Every variable has 
 | `FITBIT_CLIENT_SECRET` | dev.fitbit.com → Your app *(optional)* |
 | `FITBIT_WEIGHT_UNIT` | `lbs` or `kg` *(optional)* |
 | `USER_TIMEZONE` | IANA timezone, e.g. `America/Los_Angeles` |
+| `OWNER_USER_ID` | Your Supabase auth UUID — run `python3 scripts/print_owner_id.py` |
 | `CRON_SECRET` | Generate a random string, e.g. `openssl rand -hex 32` |
 | `APP_URL` | Your Vercel deployment URL *(optional — enables notification tap-to-open)* |
 
@@ -352,7 +354,16 @@ mr-bridge-assistant/
 │       ├── 20260411000000_add_journal_entries.sql
 │       ├── 20260411000001_recovery_metrics_extended.sql
 │       ├── 20260411100000_fitness_log_unique_date_source.sql
-│       └── 20260412000000_add_nutrition_to_meal_log.sql
+│       ├── 20260412000000_add_nutrition_to_meal_log.sql
+│       ├── 20260413000000_add_user_id_multitenancy.sql
+│       ├── 20260413000001_profile_composite_unique.sql
+│       ├── 20260413000002_composite_unique_constraints.sql
+│       ├── 20260413000003_journal_entries_composite_unique.sql
+│       ├── 20260413000004_workout_sessions_unique_constraint.sql
+│       ├── 20260413000005_chat_messages_position.sql
+│       ├── 20260413000006_journal_entries_rls_and_constraint.sql
+│       ├── 20260413000007_notifications.sql
+│       └── 20260413000008_tasks_parent_id.sql
 │
 ├── web/                                   # Next.js web interface (deployed on Vercel)
 │   ├── .env.local.example                 # Web app env var template
@@ -371,7 +382,7 @@ mr-bridge-assistant/
 │   │   │   │   ├── journal/page.tsx       # Daily journal — guided 5-prompt flow + free write
 │   │   │   │   └── settings/page.tsx      # Profile key-values + nutrition/fitness goal calculator
 │   │   │   ├── api/
-│   │   │   │   ├── chat/route.ts          # Claude API tool use (13 tools)
+│   │   │   │   ├── chat/route.ts          # Claude API tool use (16 tools)
 │   │   │   │   ├── sync/
 │   │   │   │   │   ├── oura/route.ts      # POST — sync last 3d Oura data → recovery_metrics
 │   │   │   │   │   ├── fitbit/route.ts    # POST — sync last 7d Fitbit body + workouts

--- a/scripts/check_daily_alerts.py
+++ b/scripts/check_daily_alerts.py
@@ -24,10 +24,11 @@ NOTIFY_SCRIPT = ROOT / "scripts" / "notify.sh"
 CLICK_PATH = "/tasks"
 
 
-def get_profile_value(client, key: str) -> str | None:
+def get_profile_value(client, owner_user_id: str, key: str) -> str | None:
     rows = (
         client.table("profile")
         .select("value")
+        .eq("user_id", owner_user_id)
         .eq("key", key)
         .limit(1)
         .execute()
@@ -36,13 +37,17 @@ def get_profile_value(client, key: str) -> str | None:
     return rows[0]["value"] if rows else None
 
 
-def set_profile_value(client, key: str, value: str) -> None:
-    client.table("profile").upsert({"key": key, "value": value}, on_conflict="key").execute()
+def set_profile_value(client, owner_user_id: str, key: str, value: str) -> None:
+    client.table("profile").upsert(
+        {"user_id": owner_user_id, "key": key, "value": value},
+        on_conflict="user_id,key",
+    ).execute()
 
 
 def main() -> None:
     try:
         client = get_client()
+        user_id = get_owner_user_id()
     except Exception as e:
         print(f"[check_daily_alerts] Supabase connection error: {e}", file=sys.stderr)
         return
@@ -50,7 +55,7 @@ def main() -> None:
     today_str = date.today().isoformat()
 
     # Once-per-day guard
-    last_notified = get_profile_value(client, "task_alerts_last_notified")
+    last_notified = get_profile_value(client, user_id, "task_alerts_last_notified")
     if last_notified == today_str:
         return
 
@@ -58,7 +63,8 @@ def main() -> None:
     try:
         rows = (
             client.table("tasks")
-            .select("id, name, due_date")
+            .select("id, title, due_date")
+            .eq("user_id", user_id)
             .eq("status", "active")
             .not_("due_date", "is", None)
             .lte("due_date", today_str)
@@ -72,18 +78,13 @@ def main() -> None:
 
     if not rows:
         # Still mark as run so we don't re-query all day
-        set_profile_value(client, "task_alerts_last_notified", today_str)
+        set_profile_value(client, user_id, "task_alerts_last_notified", today_str)
         return
-
-    try:
-        user_id: str | None = get_owner_user_id()
-    except EnvironmentError:
-        user_id = None
 
     fired = 0
     for task in rows:
         due = task.get("due_date", "")
-        name = task.get("name", "(unnamed task)")
+        name = task.get("title", "(unnamed task)")
         is_today = due == today_str
         title = "Task Due Today" if is_today else "Task Overdue"
         message = f"{name} — due {due}" if not is_today else f"{name} — due today"
@@ -94,12 +95,11 @@ def main() -> None:
         try:
             subprocess.run(cmd, check=True)
             fired += 1
-            if user_id:
-                log_notification(client, user_id, "task_due", title, message)
+            log_notification(client, user_id, "task_due", title, message)
         except Exception as e:
             print(f"[check_daily_alerts] notify error for task '{name}': {e}", file=sys.stderr)
 
-    set_profile_value(client, "task_alerts_last_notified", today_str)
+    set_profile_value(client, user_id, "task_alerts_last_notified", today_str)
     if fired:
         print(f"[check_daily_alerts] Fired {fired} task alert(s).")
 

--- a/scripts/check_hrv_alert.py
+++ b/scripts/check_hrv_alert.py
@@ -25,10 +25,11 @@ CLICK_PATH = "/dashboard"
 DEFAULT_THRESHOLD = 20  # percent
 
 
-def get_profile_value(client, key: str) -> str | None:
+def get_profile_value(client, owner_user_id: str, key: str) -> str | None:
     rows = (
         client.table("profile")
         .select("value")
+        .eq("user_id", owner_user_id)
         .eq("key", key)
         .limit(1)
         .execute()
@@ -37,25 +38,29 @@ def get_profile_value(client, key: str) -> str | None:
     return rows[0]["value"] if rows else None
 
 
-def set_profile_value(client, key: str, value: str) -> None:
-    client.table("profile").upsert({"key": key, "value": value}, on_conflict="key").execute()
+def set_profile_value(client, owner_user_id: str, key: str, value: str) -> None:
+    client.table("profile").upsert(
+        {"user_id": owner_user_id, "key": key, "value": value},
+        on_conflict="user_id,key",
+    ).execute()
 
 
 def main() -> None:
     try:
         client = get_client()
+        owner_user_id = get_owner_user_id()
     except Exception as e:
         print(f"[check_hrv_alert] Supabase connection error: {e}", file=sys.stderr)
         return
 
     # Once-per-day guard
     today_str = date.today().isoformat()
-    last_notified = get_profile_value(client, "hrv_alert_last_notified")
+    last_notified = get_profile_value(client, owner_user_id, "hrv_alert_last_notified")
     if last_notified == today_str:
         return
 
     # Read threshold from profile (default 20%)
-    threshold_raw = get_profile_value(client, "hrv_alert_threshold")
+    threshold_raw = get_profile_value(client, owner_user_id, "hrv_alert_threshold")
     try:
         threshold = float(threshold_raw) if threshold_raw else DEFAULT_THRESHOLD
     except ValueError:
@@ -66,6 +71,7 @@ def main() -> None:
     rows = (
         client.table("recovery_metrics")
         .select("date, avg_hrv")
+        .eq("user_id", owner_user_id)
         .not_("avg_hrv", "is", None)
         .gte("date", cutoff)
         .order("date", desc=True)
@@ -111,10 +117,9 @@ def main() -> None:
         cmd += ["--click-url", f"{app_url}{CLICK_PATH}"]
     try:
         subprocess.run(cmd, check=True)
-        set_profile_value(client, "hrv_alert_last_notified", today_str)
+        set_profile_value(client, owner_user_id, "hrv_alert_last_notified", today_str)
         print(f"[check_hrv_alert] Alert fired: {message}")
-        user_id = get_owner_user_id()
-        log_notification(client, user_id, "hrv_alert", title, message)
+        log_notification(client, owner_user_id, "hrv_alert", title, message)
     except Exception as e:
         print(f"[check_hrv_alert] notify error: {e}", file=sys.stderr)
 

--- a/scripts/check_task_due_alerts.py
+++ b/scripts/check_task_due_alerts.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(ROOT / "scripts"))
-from _supabase import get_client
+from _supabase import get_client, get_owner_user_id
 
 NOTIFY_SCRIPT = ROOT / "scripts" / "notify.sh"
 CACHE_KEY = "task_notif_cache"
@@ -28,10 +28,11 @@ DEDUP_HOURS = 24
 CLICK_PATH = "/tasks"
 
 
-def get_profile_value(client, key: str) -> str | None:
+def get_profile_value(client, owner_user_id: str, key: str) -> str | None:
     rows = (
         client.table("profile")
         .select("value")
+        .eq("user_id", owner_user_id)
         .eq("key", key)
         .limit(1)
         .execute()
@@ -40,13 +41,16 @@ def get_profile_value(client, key: str) -> str | None:
     return rows[0]["value"] if rows else None
 
 
-def set_profile_value(client, key: str, value: str) -> None:
-    client.table("profile").upsert({"key": key, "value": value}, on_conflict="key").execute()
+def set_profile_value(client, owner_user_id: str, key: str, value: str) -> None:
+    client.table("profile").upsert(
+        {"user_id": owner_user_id, "key": key, "value": value},
+        on_conflict="user_id,key",
+    ).execute()
 
 
-def load_notif_cache(client) -> dict[str, str]:
+def load_notif_cache(client, owner_user_id: str) -> dict[str, str]:
     """Return {task_id: iso_timestamp_last_notified} from profile."""
-    raw = get_profile_value(client, CACHE_KEY)
+    raw = get_profile_value(client, owner_user_id, CACHE_KEY)
     if not raw:
         return {}
     try:
@@ -55,8 +59,8 @@ def load_notif_cache(client) -> dict[str, str]:
         return {}
 
 
-def save_notif_cache(client, cache: dict[str, str]) -> None:
-    set_profile_value(client, CACHE_KEY, json.dumps(cache))
+def save_notif_cache(client, owner_user_id: str, cache: dict[str, str]) -> None:
+    set_profile_value(client, owner_user_id, CACHE_KEY, json.dumps(cache))
 
 
 def needs_notification(task_id: str, cache: dict[str, str]) -> bool:
@@ -85,6 +89,7 @@ def send_notify(title: str, message: str) -> None:
 def main() -> None:
     try:
         client = get_client()
+        owner_user_id = get_owner_user_id()
     except Exception as e:
         print(f"[check_task_due_alerts] Supabase connection error: {e}", file=sys.stderr)
         return
@@ -96,6 +101,7 @@ def main() -> None:
         rows = (
             client.table("tasks")
             .select("id, title, due_date")
+            .eq("user_id", owner_user_id)
             .eq("status", "active")
             .not_("due_date", "is", None)
             .lte("due_date", today_str)
@@ -110,7 +116,7 @@ def main() -> None:
     if not rows:
         return
 
-    cache = load_notif_cache(client)
+    cache = load_notif_cache(client, owner_user_id)
     now_iso = datetime.now(timezone.utc).isoformat()
 
     # Partition tasks that need notification into overdue vs due-today buckets.
@@ -165,7 +171,7 @@ def main() -> None:
             print(f"[check_task_due_alerts] notify error (due today): {e}", file=sys.stderr)
 
     if fired:
-        save_notif_cache(client, cache)
+        save_notif_cache(client, owner_user_id, cache)
         print(
             f"[check_task_due_alerts] Fired {fired} notification(s) "
             f"({len(overdue_labels)} overdue, {len(due_today_labels)} due today)."

--- a/scripts/check_weather_alert.py
+++ b/scripts/check_weather_alert.py
@@ -35,10 +35,11 @@ WIND_THRESHOLD   = 30.0   # mph
 THUNDER_CODES    = set(range(95, 100))  # WMO 95–99
 
 
-def get_profile_value(client, key: str) -> str | None:
+def get_profile_value(client, owner_user_id: str, key: str) -> str | None:
     rows = (
         client.table("profile")
         .select("value")
+        .eq("user_id", owner_user_id)
         .eq("key", key)
         .limit(1)
         .execute()
@@ -47,8 +48,11 @@ def get_profile_value(client, key: str) -> str | None:
     return rows[0]["value"] if rows else None
 
 
-def set_profile_value(client, key: str, value: str) -> None:
-    client.table("profile").upsert({"key": key, "value": value}, on_conflict="key").execute()
+def set_profile_value(client, owner_user_id: str, key: str, value: str) -> None:
+    client.table("profile").upsert(
+        {"user_id": owner_user_id, "key": key, "value": value},
+        on_conflict="user_id,key",
+    ).execute()
 
 
 def _fire(title: str, message: str, client=None, user_id: str | None = None) -> bool:
@@ -70,13 +74,14 @@ def _fire(title: str, message: str, client=None, user_id: str | None = None) -> 
 def main() -> None:
     try:
         client = get_client()
+        owner_user_id = get_owner_user_id()
     except Exception as e:
         print(f"[check_weather_alert] Supabase connection error: {e}", file=sys.stderr)
         return
 
     # Once-per-day guard
     today_str = date.today().isoformat()
-    last_notified = get_profile_value(client, "weather_alert_last_notified")
+    last_notified = get_profile_value(client, owner_user_id, "weather_alert_last_notified")
     if last_notified == today_str:
         return
 
@@ -89,10 +94,7 @@ def main() -> None:
         print(f"[check_weather_alert] Weather fetch error: {e}", file=sys.stderr)
         return
 
-    try:
-        user_id: str | None = get_owner_user_id()
-    except EnvironmentError:
-        user_id = None
+    user_id: str | None = owner_user_id
 
     # Thunderstorm
     wmo = w.get("wmo_code")
@@ -139,7 +141,7 @@ def main() -> None:
             client, user_id,
         )
 
-    set_profile_value(client, "weather_alert_last_notified", today_str)
+    set_profile_value(client, owner_user_id, "weather_alert_last_notified", today_str)
 
 
 if __name__ == "__main__":

--- a/scripts/fetch_weather.py
+++ b/scripts/fetch_weather.py
@@ -9,9 +9,9 @@ Location is resolved in order:
 
 To set a custom location:
   python3 -c "
-  import sys; sys.path.insert(0,'scripts')
-  from _supabase import get_client; c = get_client()
-  c.table('profile').upsert({'key':'location_city','value':'Seattle, WA'}, on_conflict='key').execute()
+  import sys, os; sys.path.insert(0,'scripts')
+  from _supabase import get_client, get_owner_user_id; c = get_client(); uid = get_owner_user_id()
+  c.table('profile').upsert({'user_id':uid,'key':'location_city','value':'Seattle, WA'}, on_conflict='user_id,key').execute()
   "
 
 Reusable by both fetch_briefing_data.py and check_weather_alert.py.
@@ -28,7 +28,7 @@ from typing import Any
 
 ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(ROOT / "scripts"))
-from _supabase import get_client, urlopen_with_retry
+from _supabase import get_client, get_owner_user_id, urlopen_with_retry
 
 # WMO Weather Interpretation Code → human-readable condition
 WMO_CONDITIONS: dict[int, str] = {
@@ -119,6 +119,7 @@ def fetch_weather(
     lat: float | None = None,
     lon: float | None = None,
     profile: dict[str, str] | None = None,
+    owner_user_id: str | None = None,
 ) -> dict[str, Any]:
     """
     Fetch weather data and return a structured dict.
@@ -150,7 +151,15 @@ def fetch_weather(
         if profile is None:
             if client is None:
                 client = get_client()
-            rows = client.table("profile").select("key,value").execute().data
+            if owner_user_id is None:
+                try:
+                    owner_user_id = get_owner_user_id()
+                except EnvironmentError:
+                    owner_user_id = None
+            q = client.table("profile").select("key,value")
+            if owner_user_id:
+                q = q.eq("user_id", owner_user_id)
+            rows = q.execute().data
             profile = {r["key"]: r["value"] for r in rows}
 
         raw_lat = profile.get("location_lat")

--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -34,14 +34,20 @@ FITBIT_WEIGHT_UNIT=lbs  # lbs or kg — must match your Fitbit profile unit sett
 #   python3 -c "
 #   import sys, os; sys.path.insert(0, 'scripts')
 #   from dotenv import load_dotenv; load_dotenv(dotenv_path='.env')
-#   from _supabase import get_client
-#   get_client().table('profile').upsert({'key': 'fitbit_refresh_token', 'value': os.environ['FITBIT_REFRESH_TOKEN']}, on_conflict='key').execute()
+#   from _supabase import get_client, get_owner_user_id
+#   uid = get_owner_user_id()
+#   get_client().table('profile').upsert({'user_id': uid, 'key': 'fitbit_refresh_token', 'value': os.environ['FITBIT_REFRESH_TOKEN']}, on_conflict='user_id,key').execute()
 #   print('Done.')
 #   "
 
 # ── User preferences ──────────────────────────────────────────────────────────
 # IANA timezone string — used for calendar event creation and date calculations
 USER_TIMEZONE=America/Los_Angeles
+
+# ── Owner user ID ─────────────────────────────────────────────────────────────
+# Your Supabase auth UID — required for cron sync to write to the correct user.
+# Run: python3 scripts/print_owner_id.py to get your UID.
+OWNER_USER_ID=<your-supabase-auth-uid>
 
 # ── Vercel cron authentication ────────────────────────────────────────────────
 # Required for the /api/cron/sync route; must match what you set in Vercel env vars

--- a/web/src/app/(protected)/dashboard/page.tsx
+++ b/web/src/app/(protected)/dashboard/page.tsx
@@ -18,9 +18,11 @@ import type { HabitLog, HabitRegistry, FitnessLog, RecoveryMetrics, Task } from 
 async function toggleHabit(habitId: string, date: string, completed: boolean) {
   "use server";
   const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return;
   await supabase
     .from("habits")
-    .upsert({ habit_id: habitId, date, completed }, { onConflict: "habit_id,date" });
+    .upsert({ user_id: user.id, habit_id: habitId, date, completed }, { onConflict: "habit_id,date" });
   revalidatePath("/dashboard");
 }
 

--- a/web/src/app/(protected)/habits/page.tsx
+++ b/web/src/app/(protected)/habits/page.tsx
@@ -16,10 +16,12 @@ import { getWindow } from "@/lib/window";
 async function toggleHabit(habitId: string, date: string, completed: boolean) {
   "use server";
   const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return;
   if (completed) {
     await supabase
       .from("habits")
-      .upsert({ habit_id: habitId, date, completed: true }, { onConflict: "habit_id,date" });
+      .upsert({ user_id: user.id, habit_id: habitId, date, completed: true }, { onConflict: "habit_id,date" });
   } else {
     await supabase
       .from("habits")
@@ -34,7 +36,10 @@ async function toggleHabit(habitId: string, date: string, completed: boolean) {
 async function addHabit(name: string, emoji: string, category: string) {
   "use server";
   const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return;
   await supabase.from("habit_registry").insert({
+    user_id: user.id,
     name: name.trim(),
     emoji: emoji.trim() || null,
     category: category.trim() || null,

--- a/web/src/app/(protected)/settings/page.tsx
+++ b/web/src/app/(protected)/settings/page.tsx
@@ -7,9 +7,11 @@ import { ProfileForm } from "@/components/settings/profile-form";
 async function updateProfile(key: string, value: string) {
   "use server";
   const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return;
   await supabase
     .from("profile")
-    .upsert({ key, value }, { onConflict: "key" });
+    .upsert({ user_id: user.id, key, value }, { onConflict: "user_id,key" });
   revalidatePath("/settings");
   revalidatePath("/dashboard");
 }
@@ -17,7 +19,9 @@ async function updateProfile(key: string, value: string) {
 async function deleteProfile(key: string) {
   "use server";
   const supabase = await createClient();
-  await supabase.from("profile").delete().eq("key", key);
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return;
+  await supabase.from("profile").delete().eq("user_id", user.id).eq("key", key);
   revalidatePath("/settings");
   revalidatePath("/dashboard");
 }

--- a/web/src/app/(protected)/tasks/page.tsx
+++ b/web/src/app/(protected)/tasks/page.tsx
@@ -12,8 +12,9 @@ async function addTask(title: string, priority: string, dueDate: string): Promis
   try {
     const supabase = await createClient();
     const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return { error: "Unauthorized" };
     const { error } = await supabase.from("tasks").insert({
-      user_id: user?.id,
+      user_id: user.id,
       title,
       priority: priority || "medium",
       status: "active",
@@ -83,8 +84,9 @@ async function addSubtask(parentId: string, title: string): Promise<{ error?: st
   try {
     const supabase = await createClient();
     const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return { error: "Unauthorized" };
     const { error } = await supabase.from("tasks").insert({
-      user_id: user?.id,
+      user_id: user.id,
       title,
       parent_id: parentId,
       status: "active",

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -126,9 +126,12 @@ export async function POST(req: Request) {
   // Resolve the authenticated user (needed for per-user data scoping)
   const serverClient = await createClient();
   const { data: { user } } = await serverClient.auth.getUser();
-  const userId = user?.id ?? null;
+  if (!user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+  }
+  const userId = user.id;
   const demoUserId = process.env.DEMO_USER_ID ?? null;
-  const isDemo = !!(userId && demoUserId && userId === demoUserId);
+  const isDemo = !!(demoUserId && userId === demoUserId);
 
   const supabase = createServiceClient();
 

--- a/web/src/app/api/cron/sync/route.ts
+++ b/web/src/app/api/cron/sync/route.ts
@@ -14,6 +14,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const ownerUserId = process.env.OWNER_USER_ID;
+  if (!ownerUserId) {
+    return NextResponse.json({ error: "OWNER_USER_ID not configured" }, { status: 500 });
+  }
+
   const db = createServiceClient();
   const results: Record<string, unknown> = {};
 
@@ -34,7 +39,7 @@ export async function GET(request: NextRequest) {
 
   if (ouraAge === null || ouraAge >= SKIP_WINDOW_SECS) {
     tasks.push(
-      syncOura(db)
+      syncOura(db, ownerUserId)
         .then((r) => { results.oura = r; })
         .catch((e) => { results.oura = { error: (e as Error).message }; }),
     );
@@ -44,7 +49,7 @@ export async function GET(request: NextRequest) {
 
   if (fitbitAge === null || fitbitAge >= SKIP_WINDOW_SECS) {
     tasks.push(
-      syncFitbit(db)
+      syncFitbit(db, ownerUserId)
         .then((r) => { results.fitbit = r; })
         .catch((e) => { results.fitbit = { error: (e as Error).message }; }),
     );
@@ -54,7 +59,7 @@ export async function GET(request: NextRequest) {
 
   if (googleFitAge === null || googleFitAge >= SKIP_WINDOW_SECS) {
     tasks.push(
-      syncGoogleFit(db)
+      syncGoogleFit(db, ownerUserId)
         .then((r) => { results.googleFit = r; })
         .catch((e) => { results.googleFit = { error: (e as Error).message }; }),
     );

--- a/web/src/app/api/google/calendar/route.ts
+++ b/web/src/app/api/google/calendar/route.ts
@@ -36,10 +36,13 @@ const DEMO_EVENTS: CalendarEvent[] = [
 void today;
 
 export async function GET() {
-  // Return mock data for demo user
   const serverClient = await createClient();
   const { data: { user } } = await serverClient.auth.getUser();
-  if (user?.id && user.id === process.env.DEMO_USER_ID) {
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  // Return mock data for demo user
+  if (user.id === process.env.DEMO_USER_ID) {
     return NextResponse.json({ events: DEMO_EVENTS });
   }
 

--- a/web/src/app/api/google/calendar/upcoming-birthday/route.ts
+++ b/web/src/app/api/google/calendar/upcoming-birthday/route.ts
@@ -2,6 +2,7 @@ import { google } from "googleapis";
 import { NextResponse } from "next/server";
 import { getGoogleAuthClient } from "@/lib/google-auth";
 import { todayString, USER_TZ } from "@/lib/timezone";
+import { createClient } from "@/lib/supabase/server";
 
 export interface UpcomingBirthday {
   name: string;
@@ -37,6 +38,12 @@ function parseEventDate(event: { start?: { date?: string | null; dateTime?: stri
 }
 
 export async function GET() {
+  const serverClient = await createClient();
+  const { data: { user } } = await serverClient.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   try {
     const auth = getGoogleAuthClient();
     const calendar = google.calendar({ version: "v3", auth });

--- a/web/src/app/api/google/gmail/route.ts
+++ b/web/src/app/api/google/gmail/route.ts
@@ -30,10 +30,13 @@ const DEMO_EMAILS: EmailSummary[] = [
 ];
 
 export async function GET() {
-  // Return mock data for demo user
   const serverClient = await createClient();
   const { data: { user } } = await serverClient.auth.getUser();
-  if (user?.id && user.id === process.env.DEMO_USER_ID) {
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  // Return mock data for demo user
+  if (user.id === process.env.DEMO_USER_ID) {
     return NextResponse.json({ emails: DEMO_EMAILS });
   }
 

--- a/web/src/app/api/meals/analyze-photo/route.ts
+++ b/web/src/app/api/meals/analyze-photo/route.ts
@@ -1,6 +1,7 @@
 import { anthropic } from "@ai-sdk/anthropic";
 import { generateObject } from "ai";
 import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
 
 export const maxDuration = 30;
 
@@ -29,6 +30,12 @@ const FoodAnalysisSchema = z.object({
 export type FoodAnalysis = z.infer<typeof FoodAnalysisSchema>;
 
 export async function POST(req: Request) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   let formData: FormData;
   try {
     formData = await req.formData();

--- a/web/src/app/api/meals/estimate-macros/route.ts
+++ b/web/src/app/api/meals/estimate-macros/route.ts
@@ -1,6 +1,7 @@
 import { anthropic } from "@ai-sdk/anthropic";
 import { generateObject } from "ai";
 import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
 
 export const maxDuration = 20;
 
@@ -22,6 +23,12 @@ const MacroEstimateSchema = z.object({
 export type MacroEstimate = z.infer<typeof MacroEstimateSchema>;
 
 export async function POST(req: Request) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   let body: { ingredients: string };
   try {
     body = await req.json();

--- a/web/src/app/api/sync/fitbit/route.ts
+++ b/web/src/app/api/sync/fitbit/route.ts
@@ -16,7 +16,7 @@ export async function POST() {
 
   try {
     const db = createServiceClient();
-    const result = await syncFitbit(db);
+    const result = await syncFitbit(db, user.id);
     return NextResponse.json({ success: true, ...result });
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Sync failed";

--- a/web/src/app/api/sync/googlefit/route.ts
+++ b/web/src/app/api/sync/googlefit/route.ts
@@ -21,7 +21,7 @@ export async function POST() {
 
   try {
     const db = createServiceClient();
-    const result = await syncGoogleFit(db);
+    const result = await syncGoogleFit(db, user.id);
     return NextResponse.json({ success: true, ...result });
   } catch (err) {
     console.error("[/api/sync/googlefit]", err);

--- a/web/src/app/api/sync/oura/route.ts
+++ b/web/src/app/api/sync/oura/route.ts
@@ -16,7 +16,7 @@ export async function POST() {
 
   try {
     const db = createServiceClient();
-    const result = await syncOura(db);
+    const result = await syncOura(db, user.id);
     return NextResponse.json({ success: true, ...result });
   } catch (err) {
     console.error("[/api/sync/oura]", err);

--- a/web/src/app/api/weather/route.ts
+++ b/web/src/app/api/weather/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { createServiceClient } from "@/lib/supabase/service";
+import { createClient } from "@/lib/supabase/server";
 
 export interface WeatherData {
   temp: number | null;
@@ -47,9 +47,14 @@ async function geocode(query: string): Promise<{ lat: number; lon: number; label
 }
 
 export async function GET() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   try {
-    const supabase = createServiceClient();
-    const { data: profileRows } = await supabase.from("profile").select("key,value");
+    const { data: profileRows } = await supabase.from("profile").select("key,value").eq("user_id", user.id);
     const profile: Record<string, string> = {};
     for (const row of profileRows ?? []) profile[row.key] = row.value;
 

--- a/web/src/components/chat/chat-interface.tsx
+++ b/web/src/components/chat/chat-interface.tsx
@@ -130,9 +130,16 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
     [isTouchDevice, menuCommands, activeIndex, applyCommand, handleSubmit]
   );
 
-  // ── Scroll to bottom on new messages (not when prepending older ones) ─
+  // ── Scroll to bottom ─────────────────────────────────────────────────
+  // On mount: snap instantly so the chat opens at the most recent message.
+  // On new messages during the session: smooth scroll.
+  const hasInitialScrolled = useRef(false);
   useEffect(() => {
-    if (!loadingMore) {
+    if (loadingMore) return; // don't jump when prepending older messages
+    if (!hasInitialScrolled.current) {
+      bottomRef.current?.scrollIntoView({ behavior: "instant" });
+      hasInitialScrolled.current = true;
+    } else {
       bottomRef.current?.scrollIntoView({ behavior: "smooth" });
     }
   }, [messages, loadingMore]);

--- a/web/src/lib/sync/fitbit.ts
+++ b/web/src/lib/sync/fitbit.ts
@@ -14,6 +14,7 @@ async function refreshFitbitToken(
   clientId: string,
   clientSecret: string,
   refreshToken: string,
+  userId: string,
 ): Promise<string> {
   const credentials = btoa(`${clientId}:${clientSecret}`);
   const res = await fetch(FITBIT_TOKEN_URL, {
@@ -34,10 +35,13 @@ async function refreshFitbitToken(
   const data = await res.json();
 
   // Save rotated refresh token back to profile table
-  if (data.refresh_token && data.refresh_token !== refreshToken) {
+  if (data.refresh_token && data.refresh_token !== refreshToken && userId) {
     await db
       .from("profile")
-      .upsert({ key: "fitbit_refresh_token", value: data.refresh_token }, { onConflict: "key" });
+      .upsert(
+        { user_id: userId, key: "fitbit_refresh_token", value: data.refresh_token },
+        { onConflict: "user_id,key" },
+      );
   }
 
   return data.access_token as string;
@@ -113,7 +117,7 @@ export interface FitbitSyncResult {
   workoutsWritten: number;
 }
 
-export async function syncFitbit(db: SupabaseClient): Promise<FitbitSyncResult> {
+export async function syncFitbit(db: SupabaseClient, userId: string): Promise<FitbitSyncResult> {
   const clientId = process.env.FITBIT_CLIENT_ID;
   const clientSecret = process.env.FITBIT_CLIENT_SECRET;
   if (!clientId || !clientSecret) {
@@ -124,13 +128,14 @@ export async function syncFitbit(db: SupabaseClient): Promise<FitbitSyncResult> 
   const { data: tokenRow } = await db
     .from("profile")
     .select("value")
+    .eq("user_id", userId)
     .eq("key", "fitbit_refresh_token")
     .maybeSingle();
 
   const refreshToken = tokenRow?.value as string | undefined;
   if (!refreshToken) throw new Error("fitbit_refresh_token not found in profile table");
 
-  const accessToken = await refreshFitbitToken(db, clientId, clientSecret, refreshToken);
+  const accessToken = await refreshFitbitToken(db, clientId, clientSecret, refreshToken, userId);
 
   const now = new Date();
   const past = new Date(now);
@@ -174,10 +179,12 @@ export async function syncFitbit(db: SupabaseClient): Promise<FitbitSyncResult> 
     const { data: existingRich } = await db
       .from("fitness_log")
       .select("date")
+      .eq("user_id", userId)
       .not("body_fat_pct", "is", null);
     const { data: existingFitbit } = await db
       .from("fitness_log")
       .select("date")
+      .eq("user_id", userId)
       .eq("source", "fitbit_body");
 
     const skip = new Set([
@@ -185,7 +192,9 @@ export async function syncFitbit(db: SupabaseClient): Promise<FitbitSyncResult> 
       ...((existingFitbit ?? []) as { date: string }[]).map((r) => r.date),
     ]);
 
-    const newRows = bodyRows.filter((r) => !skip.has(r.date as string));
+    const newRows = bodyRows
+      .filter((r) => !skip.has(r.date as string))
+      .map((r) => ({ ...r, user_id: userId }));
     if (newRows.length) {
       const { error } = await db.from("fitness_log").insert(newRows);
       if (error) throw new Error(`fitness_log insert: ${error.message}`);
@@ -228,6 +237,7 @@ export async function syncFitbit(db: SupabaseClient): Promise<FitbitSyncResult> 
     const { data: existingWorkouts } = await db
       .from("workout_sessions")
       .select("id,date,start_time,activity,avg_hr,duration_mins")
+      .eq("user_id", userId)
       .eq("source", "fitbit");
 
     const existingList = (existingWorkouts ?? []) as {
@@ -276,7 +286,7 @@ export async function syncFitbit(db: SupabaseClient): Promise<FitbitSyncResult> 
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const newWorkouts = toInsert.map(({ _key, ...rest }) => rest);
+    const newWorkouts = toInsert.map(({ _key, ...rest }) => ({ ...rest, user_id: userId }));
     if (newWorkouts.length) {
       const { error } = await db.from("workout_sessions").insert(newWorkouts);
       if (error) throw new Error(`workout_sessions insert: ${error.message}`);

--- a/web/src/lib/sync/googlefit.ts
+++ b/web/src/lib/sync/googlefit.ts
@@ -96,7 +96,7 @@ export interface GoogleFitSyncResult {
   written: number;
 }
 
-export async function syncGoogleFit(db: SupabaseClient): Promise<GoogleFitSyncResult> {
+export async function syncGoogleFit(db: SupabaseClient, userId: string): Promise<GoogleFitSyncResult> {
   const accessToken = await getGoogleAccessToken();
 
   // Discover available body datasources
@@ -187,10 +187,12 @@ export async function syncGoogleFit(db: SupabaseClient): Promise<GoogleFitSyncRe
   const { data: existingRich } = await db
     .from("fitness_log")
     .select("date")
+    .eq("user_id", userId)
     .not("body_fat_pct", "is", null);
   const { data: existingGfit } = await db
     .from("fitness_log")
     .select("date")
+    .eq("user_id", userId)
     .eq("source", "google_fit");
 
   const skip = new Set([
@@ -200,7 +202,7 @@ export async function syncGoogleFit(db: SupabaseClient): Promise<GoogleFitSyncRe
 
   const newRows = rows
     .filter((r) => !skip.has(r.date as string))
-    .map((r) => ({ ...r, source: "google_fit" }));
+    .map((r) => ({ ...r, user_id: userId, source: "google_fit" }));
 
   if (!newRows.length) return { written: 0 };
 

--- a/web/src/lib/sync/oura.ts
+++ b/web/src/lib/sync/oura.ts
@@ -49,7 +49,7 @@ export interface OuraSyncResult {
   updated: number;
 }
 
-export async function syncOura(db: SupabaseClient, days = 3): Promise<OuraSyncResult> {
+export async function syncOura(db: SupabaseClient, userId: string, days = 3): Promise<OuraSyncResult> {
   const token = process.env.OURA_ACCESS_TOKEN;
   if (!token) throw new Error("OURA_ACCESS_TOKEN not configured");
 
@@ -182,6 +182,7 @@ export async function syncOura(db: SupabaseClient, days = 3): Promise<OuraSyncRe
     if (vo2[d] != null) meta.vo2_max = vo2[d];
 
     return {
+      user_id: userId,
       date: d,
       bedtime: sd.bedtime ?? null,
       total_sleep_hrs: sd.total_sleep_hrs ?? null,
@@ -202,7 +203,7 @@ export async function syncOura(db: SupabaseClient, days = 3): Promise<OuraSyncRe
     };
   });
 
-  const { error } = await db.from("recovery_metrics").upsert(rows, { onConflict: "date" });
+  const { error } = await db.from("recovery_metrics").upsert(rows, { onConflict: "user_id,date" });
   if (error) throw new Error(error.message);
 
   await logSync(db, "oura", "ok", rows.length);


### PR DESCRIPTION
## Summary

Full pre-1.0 release audit across all layers of the app. Two categories of fixes:

**Security (auth bypass)**
- `/api/google/calendar`, `/gmail`, `/calendar/upcoming-birthday` — unauthenticated callers fell through to real Google APIs and received owner's live calendar/email data
- `/api/meals/analyze-photo`, `/estimate-macros` — no auth; anyone could trigger Anthropic API calls
- `/api/weather` — no auth; switched from service client (all users) to per-user scoped reads
- `/api/chat` — unauthenticated callers could reach the Anthropic stream
- All 7 routes now return `401 Unauthorized` when no session is present

**Multitenancy correctness (NOT NULL user_id)**
- Python alert scripts (`check_hrv_alert`, `check_weather_alert`, `check_task_due_alerts`, `check_daily_alerts`): profile helpers now include `user_id`, `on_conflict` fixed to `user_id,key`
- `check_daily_alerts`: tasks query used nonexistent `name` column (correct: `title`)
- `fetch_weather.py`: profile select scoped to `owner_user_id`
- Web sync libs (oura/fitbit/googlefit): all writes include `user_id`; `onConflict` strings updated
- `cron/sync`: passes `OWNER_USER_ID` env var to all three sync functions
- Settings page: profile `upsert`/`delete` scoped to authenticated user

**Server action correctness**
- `dashboard/page.tsx` `toggleHabit`: missing `user_id` in habit upsert
- `habits/page.tsx` `toggleHabit`/`addHabit`: same issue + `habit_registry` insert
- `tasks/page.tsx` `addTask`/`addSubtask`: nullable `user?.id` → non-nullable with early 401 guard

**Other**
- `.gitignore`: added `.env.local` and `.env.*.local` (previously only `.env` was ignored)
- `chat-interface.tsx`: instant scroll to bottom on mount; smooth scroll on new messages

## Test plan

- [ ] Log in as real user — calendar, gmail, weather all load
- [ ] Load `/api/google/calendar` without a session (curl) — expect 401
- [ ] Toggle a habit and add a new habit — verify rows in Supabase with correct `user_id`
- [ ] Add and complete a task — verify `user_id` in Supabase
- [ ] Trigger `/api/cron/sync` with correct `CRON_SECRET` — all three syncs run
- [ ] Demo user still gets mock data for calendar/gmail/chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)