### PR TITLE
fix: enable RLS and fix unique constraint on journal_entries (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ---
 
+## [Unreleased]
+
+### Fixed (journal data leak and sync failure — issue #133)
+- **`supabase/migrations/20260413000006_journal_entries_rls_and_constraint.sql`** — `journal_entries` had RLS policies from the multitenancy migration but `ENABLE ROW LEVEL SECURITY` was never called, so all queries returned every user's rows; migration enables RLS so the existing per-user policies take effect
+- **`supabase/migrations/20260413000006_journal_entries_rls_and_constraint.sql`** — unique constraint was `(user_id, date)` (migration 003) but `saveJournalEntry` targeted `onConflict: "date,user_id"`; the column-order mismatch caused upserts to fail when another user had a row for the same date; constraint dropped and recreated as `journal_entries_date_user_id_key UNIQUE (date, user_id)` matching the upsert target
+- **`web/src/app/(protected)/journal/page.tsx`** — no code changes needed; queries use `createClient()` (user-scoped) and `saveJournalEntry` already includes `user_id: user.id`; both work correctly once RLS is active
+
+---
+
 ## [1.0.0] — 2026-04-13
 
 ### Fixed (pre-1.0 audit — security and server action correctness)


### PR DESCRIPTION
## Summary

- **Data leak fixed**: `journal_entries` had per-user RLS policies (from the multitenancy migration) but `ENABLE ROW LEVEL SECURITY` was never called — all queries returned every user's rows. Migration `20260413000006` enables RLS so the policies take effect.
- **Sync failure fixed**: Unique constraint was `(user_id, date)` but `saveJournalEntry` targeted `onConflict: "date,user_id"`. Column-order mismatch caused upserts to fail when another user had a row for the same date. Constraint recreated as `journal_entries_date_user_id_key UNIQUE (date, user_id)`.
- **No page.tsx changes needed**: `JournalPage` uses `createClient()` (user-scoped) for reads and `saveJournalEntry` already includes `user_id: user.id` — both work correctly once RLS is active.

## Migration

`supabase/migrations/20260413000006_journal_entries_rls_and_constraint.sql` — already applied to remote DB (`npx supabase db push` confirmed "Remote database is up to date").

## Test plan

- [ ] Log in as a real user — journal shows only their entries (not demo entries)
- [ ] Save a journal entry — upsert succeeds without error
- [ ] Log in as demo account — demo entries visible only to demo user
- [ ] `cd web && npx tsc --noEmit` — zero errors (confirmed)

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)