### PR TITLE
feat: add sign out button to desktop sidebar and mobile More sheet (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (sign out button — issue #156)
+- **`web/src/components/ui/sign-out-button.tsx`** — new client component; calls `supabase.auth.signOut()` and redirects to `/login`
+- **`web/src/components/nav.tsx`** — desktop sidebar: sign-out section with top border below demo banner; mobile More sheet: Sign Out button as last grid item, inlines sign-out logic to avoid redundant imports
+
 ### Fixed (journal data leak and sync failure — issue #133)
 - **`supabase/migrations/20260413000006_journal_entries_rls_and_constraint.sql`** — `journal_entries` had RLS policies from the multitenancy migration but `ENABLE ROW LEVEL SECURITY` was never called, so all queries returned every user's rows; migration enables RLS so the existing per-user policies take effect
 - **`supabase/migrations/20260413000006_journal_entries_rls_and_constraint.sql`** — unique constraint was `(user_id, date)` (migration 003) but `saveJournalEntry` targeted `onConflict: "date,user_id"`; the column-order mismatch caused upserts to fail when another user had a row for the same date; constraint dropped and recreated as `journal_entries_date_user_id_key UNIQUE (date, user_id)` matching the upsert target

--- a/web/src/components/nav.tsx
+++ b/web/src/components/nav.tsx
@@ -16,8 +16,10 @@ import {
   Bell,
   MoreHorizontal,
   X,
+  LogOut,
 } from "lucide-react";
 import Logo from "@/components/ui/logo";
+import SignOutButton from "@/components/ui/sign-out-button";
 import { createClient } from "@/lib/supabase/client";
 
 const NAV_ITEMS = [
@@ -142,6 +144,11 @@ export default function Nav() {
             Demo account — changes reset nightly
           </div>
         )}
+
+        {/* Sign out — desktop */}
+        <div className="px-3 pb-4 mt-auto" style={{ borderTop: "1px solid var(--color-border)" }}>
+          <SignOutButton />
+        </div>
       </nav>
 
       {/* Demo banner — mobile (above tab bar) */}
@@ -271,6 +278,26 @@ export default function Nav() {
                   </Link>
                 );
               })}
+
+              {/* Sign out — mobile More sheet */}
+              <button
+                onClick={async () => {
+                  setShowMore(false);
+                  const supabase = createClient();
+                  await supabase.auth.signOut();
+                  window.location.href = "/login";
+                }}
+                className="flex items-center gap-3 px-4 py-3 rounded-xl transition-colors duration-150"
+                style={{
+                  background: "var(--color-surface-raised)",
+                  color: "var(--color-text-muted)",
+                  border: "none",
+                  cursor: "pointer",
+                }}
+              >
+                <LogOut size={18} strokeWidth={1.5} style={{ flexShrink: 0 }} />
+                <span className="text-sm font-medium">Sign out</span>
+              </button>
             </div>
           </div>
         </>

--- a/web/src/components/ui/sign-out-button.tsx
+++ b/web/src/components/ui/sign-out-button.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { LogOut } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+import { useRouter } from "next/navigation";
+
+export default function SignOutButton() {
+  const router = useRouter();
+  async function handleSignOut() {
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    router.push("/login");
+  }
+  return (
+    <button
+      onClick={handleSignOut}
+      className="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium w-full transition-colors duration-150"
+      style={{ color: "var(--color-text-muted)", background: "transparent", border: "none", cursor: "pointer" }}
+      onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = "var(--color-text)"; }}
+      onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = "var(--color-text-muted)"; }}
+    >
+      <LogOut size={18} strokeWidth={1.5} style={{ flexShrink: 0 }} />
+      Sign out
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `SignOutButton` client component (`web/src/components/ui/sign-out-button.tsx`) — calls `supabase.auth.signOut()` and redirects to `/login`
- Desktop sidebar: sign-out section with top border, always visible below the demo banner
- Mobile More sheet: Sign Out as the last item in the 2-column grid, always visible

Closes #156

## Test plan
- [ ] Desktop: Sign Out button visible at bottom of sidebar; click redirects to `/login`
- [ ] Mobile: Sign Out appears as last item in More sheet; click redirects to `/login`
- [ ] Works for both demo and regular accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)