### PR TITLE
fix: Fitbit token rotation divergence and sync error display

### DIFF
--- a/scripts/sync-fitbit.py
+++ b/scripts/sync-fitbit.py
@@ -120,6 +120,7 @@ def exchange_code(code, verifier, client_id, client_secret):
 
 
 def refresh_access_token(client_id, client_secret, refresh_token):
+    """Returns (access_token, new_refresh_token_or_none)."""
     credentials = base64.b64encode(f"{client_id}:{client_secret}".encode()).decode()
     body = urllib.parse.urlencode({
         "grant_type": "refresh_token",
@@ -132,9 +133,11 @@ def refresh_access_token(client_id, client_secret, refresh_token):
     try:
         with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
             data = json.loads(resp.read())
-            if data.get("refresh_token") != refresh_token:
-                update_env_token(data["refresh_token"])
-            return data["access_token"]
+            new_token = data.get("refresh_token")
+            if new_token and new_token != refresh_token:
+                update_env_token(new_token)
+                return data["access_token"], new_token
+            return data["access_token"], None
     except urllib.error.HTTPError as e:
         print(f"[error] Token refresh failed {e.code}: {e.read().decode()}")
         print("Run: python3 scripts/sync-fitbit.py --setup  to re-authenticate")
@@ -436,7 +439,7 @@ def main():
         print("Run: python3 scripts/sync-fitbit.py --setup")
         sys.exit(1)
 
-    access_token = refresh_access_token(client_id, client_secret, refresh_token)
+    access_token, rotated_token = refresh_access_token(client_id, client_secret, refresh_token)
 
     end = datetime.now()
     start = end - timedelta(days=args.days)
@@ -458,6 +461,13 @@ def main():
 
     client = get_client()
     owner_user_id = get_owner_user_id()
+
+    # Keep Supabase profile table in sync with the rotated token so the web app stays valid
+    if rotated_token:
+        client.table("profile").upsert(
+            {"user_id": owner_user_id, "key": "fitbit_refresh_token", "value": rotated_token},
+            on_conflict="user_id,key",
+        ).execute()
 
     # Write body composition
     existing_body = existing_body_dates(client, owner_user_id)

--- a/web/src/components/dashboard/sync-button.tsx
+++ b/web/src/components/dashboard/sync-button.tsx
@@ -5,22 +5,45 @@ import { useRouter } from "next/navigation";
 
 type SyncState = "idle" | "syncing" | "done" | "error";
 
+const SOURCES = ["oura", "fitbit", "googlefit"] as const;
+type Source = (typeof SOURCES)[number];
+
 export default function SyncButton() {
   const router = useRouter();
   const [state, setState] = useState<SyncState>("idle");
   const [syncedAt, setSyncedAt] = useState<string | null>(null);
+  const [errors, setErrors] = useState<Partial<Record<Source, string>>>({});
 
   async function handleSync() {
     setState("syncing");
+    setErrors({});
     try {
-      // All three sources in parallel
       const results = await Promise.allSettled([
-        fetch("/api/sync/oura", { method: "POST" }),
-        fetch("/api/sync/fitbit", { method: "POST" }),
+        fetch("/api/sync/oura",      { method: "POST" }),
+        fetch("/api/sync/fitbit",    { method: "POST" }),
         fetch("/api/sync/googlefit", { method: "POST" }),
       ]);
 
-      const anyFailed = results.some((r) => r.status === "rejected" || (r.status === "fulfilled" && !r.value.ok));
+      const newErrors: Partial<Record<Source, string>> = {};
+      for (let i = 0; i < results.length; i++) {
+        const source = SOURCES[i] as Source;
+        const result = results[i];
+        if (result.status === "rejected") {
+          newErrors[source] = "Network error";
+          continue;
+        }
+        if (!result.value.ok) {
+          try {
+            const body = await result.value.json();
+            newErrors[source] = body.error ?? "Sync failed";
+          } catch {
+            newErrors[source] = "Sync failed";
+          }
+        }
+      }
+
+      const anyFailed = Object.keys(newErrors).length > 0;
+      setErrors(newErrors);
       setState(anyFailed ? "error" : "done");
       if (!anyFailed) {
         setSyncedAt(
@@ -30,46 +53,58 @@ export default function SyncButton() {
       router.refresh();
     } catch {
       setState("error");
+      setErrors({ oura: "Unexpected error" });
     }
   }
 
-  return (
-    <button
-      onClick={handleSync}
-      disabled={state === "syncing"}
-      title={syncedAt ? `Last synced ${syncedAt}` : "Sync all data sources"}
-      className="flex items-center gap-1.5 text-xs disabled:opacity-40 transition-colors"
-      style={{ color: "var(--color-text-faint)" }}
-      onMouseEnter={(e) => (e.currentTarget.style.color = "var(--color-text-muted)")}
-      onMouseLeave={(e) => (e.currentTarget.style.color = "var(--color-text-faint)")}
+  const errorSummary = Object.entries(errors)
+    .map(([src, msg]) => `${src}: ${msg}`)
+    .join(" · ");
 
-    >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="12"
-        height="12"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className={state === "syncing" ? "animate-spin" : ""}
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <button
+        onClick={handleSync}
+        disabled={state === "syncing"}
+        title={syncedAt ? `Last synced ${syncedAt}` : "Sync all data sources"}
+        className="flex items-center gap-1.5 text-xs disabled:opacity-40 transition-colors"
+        style={{ color: "var(--color-text-faint)" }}
+        onMouseEnter={(e) => (e.currentTarget.style.color = "var(--color-text-muted)")}
+        onMouseLeave={(e) => (e.currentTarget.style.color = "var(--color-text-faint)")}
       >
-        <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
-        <path d="M21 3v5h-5" />
-        <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
-        <path d="M8 16H3v5" />
-      </svg>
-      {state === "error" ? (
-        <span className="text-red-500">Sync failed</span>
-      ) : state === "syncing" ? (
-        "Syncing…"
-      ) : syncedAt ? (
-        `Synced ${syncedAt}`
-      ) : (
-        "Sync"
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={state === "syncing" ? "animate-spin" : ""}
+        >
+          <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+          <path d="M21 3v5h-5" />
+          <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+          <path d="M8 16H3v5" />
+        </svg>
+        {state === "error" ? (
+          <span className="text-red-500">Sync failed</span>
+        ) : state === "syncing" ? (
+          "Syncing…"
+        ) : syncedAt ? (
+          `Synced ${syncedAt}`
+        ) : (
+          "Sync"
+        )}
+      </button>
+
+      {state === "error" && errorSummary && (
+        <p className="text-xs text-right" style={{ color: "var(--color-negative, #ef4444)", maxWidth: 260 }}>
+          {errorSummary}
+        </p>
       )}
-    </button>
+    </div>
   );
 }

--- a/web/src/lib/sync/fitbit.ts
+++ b/web/src/lib/sync/fitbit.ts
@@ -36,12 +36,13 @@ async function refreshFitbitToken(
 
   // Save rotated refresh token back to profile table
   if (data.refresh_token && data.refresh_token !== refreshToken && userId) {
-    await db
+    const { error: saveErr } = await db
       .from("profile")
       .upsert(
         { user_id: userId, key: "fitbit_refresh_token", value: data.refresh_token },
         { onConflict: "user_id,key" },
       );
+    if (saveErr) throw new Error(`Failed to save rotated Fitbit token: ${saveErr.message}`);
   }
 
   return data.access_token as string;


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `refreshFitbitToken` in `web/src/lib/sync/fitbit.ts` was silently discarding the result of the rotated-token upsert. Fitbit rotates the refresh token on every use — if the save failed (which it did when the multitenancy migration changed the `profile` table's unique constraint), the old token stayed in the DB while Fitbit had already moved on. Next sync: `invalid_grant`. Now throws on save failure.
- **Python/web divergence fixed**: `scripts/sync-fitbit.py` was saving rotated tokens only to `.env`, while the web app reads from Supabase's `profile` table. Over time these drifted apart and each invalidated the other's token. The script now writes the rotated token to both `.env` and Supabase on every rotation.
- **Sync button improved**: Previously showed a generic red "Sync failed" with no detail. Now parses the error response from each source and displays the specific message below the button (e.g. `fitbit: Fitbit token refresh failed 400: invalid_grant…`).

## Test plan

- [ ] Click Sync on dashboard — should succeed (green) or show specific per-source error text if a source is misconfigured
- [ ] Confirm Fitbit data syncs correctly after re-auth
- [ ] Confirm `scripts/sync-fitbit.py` runs without error and updates both `.env` and Supabase profile table on token rotation

Closes #133 (partial — sync error visibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)