### PR TITLE
feat: allow editing task due date and priority (#157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (edit task due date and priority — issue #157)
+- **`web/src/app/(protected)/tasks/page.tsx`** — `updateTask` server action now accepts a `fields` object (`title?`, `due_date?`, `priority?`) instead of a bare title string; also revalidates `/dashboard` on update
+- **`web/src/components/tasks/task-item.tsx`** — `updateAction` prop updated to match new fields signature; `SubtaskRow` and `TaskItem` `commitEdit` calls updated accordingly; added `showEditPanel` toggle (Pencil icon, size 13) next to the Archive button; when open, renders an inline row with a date input, a clear-date button, a priority select, and Save/cancel buttons; initializes from current task values
+
 ### Added (sign out button — issue #156)
 - **`web/src/components/ui/sign-out-button.tsx`** — new client component; calls `supabase.auth.signOut()` and redirects to `/login`
 - **`web/src/components/nav.tsx`** — desktop sidebar: sign-out section with top border below demo banner; mobile More sheet: Sign Out button as last grid item, inlines sign-out logic to avoid redundant imports

--- a/web/src/app/(protected)/tasks/page.tsx
+++ b/web/src/app/(protected)/tasks/page.tsx
@@ -66,13 +66,17 @@ async function archiveTask(taskId: string): Promise<{ error?: string }> {
   }
 }
 
-async function updateTask(taskId: string, title: string): Promise<{ error?: string }> {
+async function updateTask(
+  taskId: string,
+  fields: { title?: string; due_date?: string | null; priority?: string | null }
+): Promise<{ error?: string }> {
   "use server";
   try {
     const supabase = await createClient();
-    const { error } = await supabase.from("tasks").update({ title }).eq("id", taskId);
+    const { error } = await supabase.from("tasks").update(fields).eq("id", taskId);
     if (error) return { error: error.message };
     revalidatePath("/tasks");
+    revalidatePath("/dashboard");
     return {};
   } catch (err) {
     return { error: err instanceof Error ? err.message : "Failed to update task" };

--- a/web/src/components/tasks/task-item.tsx
+++ b/web/src/components/tasks/task-item.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useTransition, useRef, useEffect } from "react";
-import { Archive, ChevronDown, ChevronRight, X } from "lucide-react";
+import { Archive, ChevronDown, ChevronRight, Pencil, X } from "lucide-react";
 import type { Task, Subtask } from "@/lib/types";
 
 const PRIORITY_COLOR: Record<string, string> = {
@@ -25,7 +25,7 @@ interface Props {
   task: Task;
   completeAction:       (id: string) => Promise<{ error?: string }>;
   archiveAction:        (id: string) => Promise<{ error?: string }>;
-  updateAction:         (id: string, title: string) => Promise<{ error?: string }>;
+  updateAction:         (id: string, fields: { title?: string; due_date?: string | null; priority?: string | null }) => Promise<{ error?: string }>;
   addSubtaskAction:     (parentId: string, title: string) => Promise<{ error?: string }>;
   completeSubtaskAction:(id: string) => Promise<{ error?: string }>;
   deleteSubtaskAction:  (id: string) => Promise<{ error?: string }>;
@@ -40,7 +40,7 @@ function SubtaskRow({
   subtask: Subtask;
   completeSubtaskAction: (id: string) => Promise<{ error?: string }>;
   deleteSubtaskAction:   (id: string) => Promise<{ error?: string }>;
-  updateAction:          (id: string, title: string) => Promise<{ error?: string }>;
+  updateAction:          (id: string, fields: { title?: string; due_date?: string | null; priority?: string | null }) => Promise<{ error?: string }>;
 }) {
   const [isPending, startTransition] = useTransition();
   const [editing, setEditing]       = useState(false);
@@ -55,7 +55,7 @@ function SubtaskRow({
     setEditing(false);
     const trimmed = editTitle.trim();
     if (trimmed && trimmed !== subtask.title) {
-      startTransition(async () => { await updateAction(subtask.id, trimmed); });
+      startTransition(async () => { await updateAction(subtask.id, { title: trimmed }); });
     } else {
       setEditTitle(subtask.title);
     }
@@ -157,6 +157,10 @@ export default function TaskItem({
   const [addInput, setAddInput] = useState("");
   const addInputRef = useRef<HTMLInputElement>(null);
 
+  const [showEditPanel, setShowEditPanel] = useState(false);
+  const [editDueDate, setEditDueDate]     = useState(task.due_date ?? "");
+  const [editPriority, setEditPriority]   = useState<"high" | "medium" | "low">((task.priority as "high" | "medium" | "low") ?? "medium");
+
   useEffect(() => {
     if (editing) inputRef.current?.focus();
   }, [editing]);
@@ -180,7 +184,7 @@ export default function TaskItem({
     setEditing(false);
     const trimmed = editTitle.trim();
     if (trimmed && trimmed !== task.title) {
-      startTransition(async () => { await updateAction(task.id, trimmed); });
+      startTransition(async () => { await updateAction(task.id, { title: trimmed }); });
     } else {
       setEditTitle(task.title);
     }
@@ -283,6 +287,16 @@ export default function TaskItem({
           </button>
         )}
 
+        {/* Edit due date / priority */}
+        <button
+          onClick={() => setShowEditPanel((v) => !v)}
+          className="flex-shrink-0 p-1 rounded transition-opacity hover:opacity-70"
+          style={{ color: "var(--color-text-muted)" }}
+          title="Edit due date / priority"
+        >
+          <Pencil size={13} />
+        </button>
+
         {/* Archive */}
         <button
           onClick={handleArchive}
@@ -294,6 +308,64 @@ export default function TaskItem({
           <Archive size={13} />
         </button>
       </div>
+
+      {/* Due date / priority edit panel */}
+      {showEditPanel && (
+        <div className="flex items-center gap-3 px-4 pb-3" style={{ marginLeft: 36 }}>
+          {/* Due date */}
+          <input
+            type="date"
+            value={editDueDate}
+            onChange={(e) => setEditDueDate(e.target.value)}
+            className="text-xs rounded-lg px-2 py-1 focus:outline-none"
+            style={{
+              background: "var(--color-surface)",
+              border: "1px solid var(--color-border)",
+              color: "var(--color-text)",
+            }}
+          />
+          {/* Clear due date */}
+          {editDueDate && (
+            <button onClick={() => setEditDueDate("")} style={{ color: "var(--color-text-faint)" }}>
+              <X size={12} />
+            </button>
+          )}
+          {/* Priority */}
+          <select
+            value={editPriority}
+            onChange={(e) => setEditPriority(e.target.value as "high" | "medium" | "low")}
+            className="text-xs rounded-lg px-2 py-1 focus:outline-none"
+            style={{
+              background: "var(--color-surface)",
+              border: "1px solid var(--color-border)",
+              color: "var(--color-text)",
+            }}
+          >
+            <option value="high">High</option>
+            <option value="medium">Medium</option>
+            <option value="low">Low</option>
+          </select>
+          {/* Save */}
+          <button
+            onClick={() => {
+              setShowEditPanel(false);
+              startTransition(async () => {
+                await updateAction(task.id, {
+                  due_date: editDueDate || null,
+                  priority: editPriority || null,
+                });
+              });
+            }}
+            className="text-xs px-2 py-1 rounded-lg"
+            style={{ background: "var(--color-primary)", color: "white" }}
+          >
+            Save
+          </button>
+          <button onClick={() => setShowEditPanel(false)} style={{ color: "var(--color-text-faint)" }}>
+            <X size={12} />
+          </button>
+        </div>
+      )}
 
       {/* Subtask list + add input */}
       {expanded && (


### PR DESCRIPTION
## Summary
- Extends `updateTask` server action to accept a `fields` object (`title?`, `due_date?`, `priority?`) instead of a bare title string
- Adds a Pencil icon button next to Archive on each task; clicking it toggles an inline edit panel with a date picker, clear button, priority select, and Save/cancel
- `SubtaskRow` and `TaskItem` title-only `commitEdit` calls updated to the new `{ title }` fields shape

## Test plan
- [ ] Click Pencil icon on a task — edit panel appears below the task row
- [ ] Change due date and save — task updates and panel closes; due date badge reflects new value
- [ ] Clear due date (X button) and save — due date badge disappears
- [ ] Change priority and save — task moves to the correct priority group on next render
- [ ] Cancel (X button) — panel closes with no changes persisted
- [ ] Inline title editing still works (click title text, type, Enter/blur)
- [ ] Subtask title editing still works
- [ ] `npx tsc --noEmit` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)