### PR TITLE
perf: memoize MessageBubble and ToolStatusBar to fix streaming lag on mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ memory/timer_state.json
 # Personal Claude Code settings (overrides for local machine only)
 .claude/settings.local.json
 credentials.json
+.vercel

--- a/web/src/components/chat/message-bubble.tsx
+++ b/web/src/components/chat/message-bubble.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import type { Message } from "ai";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -6,7 +7,105 @@ interface Props {
   message: Message;
 }
 
-export default function MessageBubble({ message }: Props) {
+// Stable reference — defined outside the component so it never triggers a
+// ReactMarkdown re-render from a new object identity on each parent update.
+const MD_COMPONENTS: React.ComponentProps<typeof ReactMarkdown>["components"] = {
+  p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+  strong: ({ children }) => (
+    <strong style={{ fontWeight: 600, color: "var(--color-text)" }}>{children}</strong>
+  ),
+  em: ({ children }) => (
+    <em style={{ fontStyle: "italic", color: "var(--color-text-muted)" }}>{children}</em>
+  ),
+  h1: ({ children }) => (
+    <h1 className="font-heading mt-3 mb-1 first:mt-0" style={{ fontSize: 15, fontWeight: 600, color: "var(--color-text)" }}>
+      {children}
+    </h1>
+  ),
+  h2: ({ children }) => (
+    <h2 className="font-heading mt-3 mb-1 first:mt-0" style={{ fontSize: 14, fontWeight: 600, color: "var(--color-text)" }}>
+      {children}
+    </h2>
+  ),
+  h3: ({ children }) => (
+    <h3 className="mt-2 mb-1 first:mt-0" style={{ fontSize: 13, fontWeight: 500, color: "var(--color-text-muted)" }}>
+      {children}
+    </h3>
+  ),
+  ul: ({ children }) => (
+    <ul className="list-disc list-inside mb-2 space-y-0.5" style={{ color: "var(--color-text-muted)" }}>
+      {children}
+    </ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="list-decimal list-inside mb-2 space-y-0.5" style={{ color: "var(--color-text-muted)" }}>
+      {children}
+    </ol>
+  ),
+  li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+  code: ({ children, className }) => {
+    const isBlock = className?.includes("language-");
+    return isBlock ? (
+      <code
+        className="block rounded-lg px-3 py-2 my-2 text-xs overflow-x-auto whitespace-pre"
+        style={{ background: "var(--color-surface-raised)", color: "var(--color-text-muted)" }}
+      >
+        {children}
+      </code>
+    ) : (
+      <code
+        className="rounded px-1 py-0.5 text-xs"
+        style={{ background: "var(--color-surface-raised)", color: "var(--color-text-muted)" }}
+      >
+        {children}
+      </code>
+    );
+  },
+  pre: ({ children }) => <pre className="my-2">{children}</pre>,
+  table: ({ children }) => (
+    <div className="overflow-x-auto my-2">
+      <table className="w-full text-xs" style={{ borderCollapse: "collapse" }}>
+        {children}
+      </table>
+    </div>
+  ),
+  thead: ({ children }) => <thead>{children}</thead>,
+  tbody: ({ children }) => <tbody>{children}</tbody>,
+  tr: ({ children }) => (
+    <tr style={{ borderBottom: "1px solid var(--color-border)" }}>{children}</tr>
+  ),
+  th: ({ children }) => (
+    <th
+      className="text-left px-3 py-1.5"
+      style={{
+        fontWeight: 500,
+        color: "var(--color-text-muted)",
+        borderBottom: "1px solid var(--color-border)",
+      }}
+    >
+      {children}
+    </th>
+  ),
+  td: ({ children }) => (
+    <td className="px-3 py-1.5" style={{ color: "var(--color-text-muted)" }}>
+      {children}
+    </td>
+  ),
+  hr: () => <hr style={{ borderColor: "var(--color-border)", margin: "12px 0" }} />,
+  blockquote: ({ children }) => (
+    <blockquote
+      className="pl-3 italic my-2"
+      style={{ borderLeft: "2px solid var(--color-border)", color: "var(--color-text-muted)" }}
+    >
+      {children}
+    </blockquote>
+  ),
+};
+
+// memo: only re-renders when message.content or message.role changes.
+// During streaming, only the last (actively updating) bubble re-renders —
+// all prior messages are skipped, eliminating per-token markdown re-parsing.
+const MessageBubble = memo(function MessageBubble({ message }: Props) {
   const isUser = message.role === "user";
 
   return (
@@ -32,105 +131,13 @@ export default function MessageBubble({ message }: Props) {
         {isUser ? (
           message.content
         ) : (
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
-            components={{
-              p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
-              strong: ({ children }) => (
-                <strong style={{ fontWeight: 600, color: "var(--color-text)" }}>{children}</strong>
-              ),
-              em: ({ children }) => (
-                <em style={{ fontStyle: "italic", color: "var(--color-text-muted)" }}>{children}</em>
-              ),
-              h1: ({ children }) => (
-                <h1 className="font-heading mt-3 mb-1 first:mt-0" style={{ fontSize: 15, fontWeight: 600, color: "var(--color-text)" }}>
-                  {children}
-                </h1>
-              ),
-              h2: ({ children }) => (
-                <h2 className="font-heading mt-3 mb-1 first:mt-0" style={{ fontSize: 14, fontWeight: 600, color: "var(--color-text)" }}>
-                  {children}
-                </h2>
-              ),
-              h3: ({ children }) => (
-                <h3 className="mt-2 mb-1 first:mt-0" style={{ fontSize: 13, fontWeight: 500, color: "var(--color-text-muted)" }}>
-                  {children}
-                </h3>
-              ),
-              ul: ({ children }) => (
-                <ul className="list-disc list-inside mb-2 space-y-0.5" style={{ color: "var(--color-text-muted)" }}>
-                  {children}
-                </ul>
-              ),
-              ol: ({ children }) => (
-                <ol className="list-decimal list-inside mb-2 space-y-0.5" style={{ color: "var(--color-text-muted)" }}>
-                  {children}
-                </ol>
-              ),
-              li: ({ children }) => <li className="leading-relaxed">{children}</li>,
-              code: ({ children, className }) => {
-                const isBlock = className?.includes("language-");
-                return isBlock ? (
-                  <code
-                    className="block rounded-lg px-3 py-2 my-2 text-xs overflow-x-auto whitespace-pre"
-                    style={{ background: "var(--color-surface-raised)", color: "var(--color-text-muted)" }}
-                  >
-                    {children}
-                  </code>
-                ) : (
-                  <code
-                    className="rounded px-1 py-0.5 text-xs"
-                    style={{ background: "var(--color-surface-raised)", color: "var(--color-text-muted)" }}
-                  >
-                    {children}
-                  </code>
-                );
-              },
-              pre: ({ children }) => <pre className="my-2">{children}</pre>,
-              table: ({ children }) => (
-                <div className="overflow-x-auto my-2">
-                  <table className="w-full text-xs" style={{ borderCollapse: "collapse" }}>
-                    {children}
-                  </table>
-                </div>
-              ),
-              thead: ({ children }) => <thead>{children}</thead>,
-              tbody: ({ children }) => <tbody>{children}</tbody>,
-              tr: ({ children }) => (
-                <tr style={{ borderBottom: "1px solid var(--color-border)" }}>{children}</tr>
-              ),
-              th: ({ children }) => (
-                <th
-                  className="text-left px-3 py-1.5"
-                  style={{
-                    fontWeight: 500,
-                    color: "var(--color-text-muted)",
-                    borderBottom: "1px solid var(--color-border)",
-                  }}
-                >
-                  {children}
-                </th>
-              ),
-              td: ({ children }) => (
-                <td className="px-3 py-1.5" style={{ color: "var(--color-text-muted)" }}>
-                  {children}
-                </td>
-              ),
-              hr: () => <hr style={{ borderColor: "var(--color-border)", margin: "12px 0" }} />,
-              blockquote: ({ children }) => (
-                <blockquote
-                  className="pl-3 italic my-2"
-                  style={{ borderLeft: "2px solid var(--color-border)", color: "var(--color-text-muted)" }}
-                >
-                  {children}
-                </blockquote>
-              ),
-            }}
-          >
+          <ReactMarkdown remarkPlugins={[remarkGfm]} components={MD_COMPONENTS}>
             {message.content}
           </ReactMarkdown>
         )}
       </div>
     </div>
   );
-}
+});
+
+export default MessageBubble;

--- a/web/src/components/chat/tool-status-bar.tsx
+++ b/web/src/components/chat/tool-status-bar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import type { Message } from "ai";
 
 const TOOL_LABELS: Record<string, string> = {
@@ -52,7 +53,7 @@ function getInvocations(msg: Message): ToolInvocation[] {
   return (msg.toolInvocations as ToolInvocation[] | undefined) ?? [];
 }
 
-export default function ToolStatusBar({ messages, isLoading }: Props) {
+const ToolStatusBar = memo(function ToolStatusBar({ messages, isLoading }: Props) {
   if (!isLoading) return null;
 
   // Only look at messages since the last user turn
@@ -98,4 +99,6 @@ export default function ToolStatusBar({ messages, isLoading }: Props) {
       </div>
     </div>
   );
-}
+});
+
+export default ToolStatusBar;


### PR DESCRIPTION
## Summary

- Wrap `MessageBubble` in `React.memo` — during streaming, only the actively-updating bubble re-renders; all prior messages in the conversation are skipped entirely
- Move `MD_COMPONENTS` to module scope so `ReactMarkdown` never receives a new object reference between renders, preventing unnecessary internal re-renders
- Wrap `ToolStatusBar` in `React.memo` for the same reason (it also receives the full messages array on every token)
- Add `.vercel` to `.gitignore`

## Why this matters

`useChat` updates the `messages` array on every streaming token. Without memoization, this caused every `MessageBubble` to re-render and re-run `ReactMarkdown` + `remarkGfm` parsing on each token. On mobile with a 20-message conversation, that's 20 full markdown parses per token — the primary cause of streaming lag on mobile.

## Test plan

- [ ] Start a new chat and send a message — streaming should feel noticeably smoother on mobile
- [ ] Long conversations (10+ messages) should not degrade as more messages accumulate
- [ ] Prior messages should not flicker or update during streaming of a new response
- [ ] Markdown rendering (bold, tables, lists, code blocks) still works correctly in all bubbles

🤖 Generated with [Claude Code](https://claude.com/claude-code)