### PR TITLE
feat: add loading skeletons to all protected routes (#164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (loading skeletons for all protected routes — issue #164)
+- **`web/src/app/(protected)/dashboard/loading.tsx`** — header + health breakdown chart + 2×2 card grid
+- **`web/src/app/(protected)/fitness/loading.tsx`** — header + window selector strip + 2×2 chart grid
+- **`web/src/app/(protected)/habits/loading.tsx`** — header + radial circle + streak chart + habit row list
+- **`web/src/app/(protected)/tasks/loading.tsx`** — header + add-form card + 3 priority group skeletons
+- **`web/src/app/(protected)/weekly/loading.tsx`** — header + 3 summary cards + chart + summary card
+- **`web/src/app/(protected)/journal/loading.tsx`** — header + tall editor card + 2 collapsed entry rows
+- **`web/src/app/(protected)/meals/loading.tsx`** — header + tab bar pills + 2 content cards
+- **`web/src/app/(protected)/notifications/loading.tsx`** — header + 5 notification row skeletons
+- **`web/src/app/(protected)/settings/loading.tsx`** — header + 6 label/input row skeletons
+- **`web/src/app/(protected)/chat/loading.tsx`** — centered "Loading conversation…" text + input bar skeleton; eliminates blank-page gap on all protected route navigations
+
 ### Added (edit task due date and priority — issue #157)
 - **`web/src/app/(protected)/tasks/page.tsx`** — `updateTask` server action now accepts a `fields` object (`title?`, `due_date?`, `priority?`) instead of a bare title string; also revalidates `/dashboard` on update
 - **`web/src/components/tasks/task-item.tsx`** — `updateAction` prop updated to match new fields signature; `SubtaskRow` and `TaskItem` `commitEdit` calls updated accordingly; added `showEditPanel` toggle (Pencil icon, size 13) next to the Archive button; when open, renders an inline row with a date input, a clear-date button, a priority select, and Save/cancel buttons; initializes from current task values

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,5 +1,16 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  experimental: {
+    // Cache dynamic route RSC payloads in the client-side router cache.
+    // Without this, force-dynamic pages re-fetch on every tab switch (stale=0).
+    // With this, a tab you've already visited serves instantly until the window
+    // expires. Server actions that call revalidatePath() still bust the cache.
+    staleTimes: {
+      dynamic: 300, // seconds — covers rapid tab-switching
+      static: 180,
+    },
+  },
+};
 
 export default nextConfig;

--- a/web/src/app/(protected)/chat/loading.tsx
+++ b/web/src/app/(protected)/chat/loading.tsx
@@ -1,0 +1,16 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="flex flex-col h-[calc(100vh-8rem)]">
+      {/* Message area */}
+      <div className="flex-1 flex items-center justify-center">
+        <span className="text-sm" style={{ color: "var(--color-text-muted)" }}>
+          Loading conversation…
+        </span>
+      </div>
+      {/* Input bar */}
+      <Skeleton className="h-12 w-full rounded-xl" />
+    </div>
+  );
+}

--- a/web/src/app/(protected)/dashboard/loading.tsx
+++ b/web/src/app/(protected)/dashboard/loading.tsx
@@ -1,0 +1,18 @@
+import { Skeleton, SkeletonCard, SkeletonChart } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-8 w-56" />
+      <SkeletonChart height={220} />
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <SkeletonCard />
+        <SkeletonCard />
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <SkeletonCard />
+        <SkeletonCard />
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(protected)/fitness/loading.tsx
+++ b/web/src/app/(protected)/fitness/loading.tsx
@@ -1,0 +1,21 @@
+import { Skeleton, SkeletonChart } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-8 w-32" />
+      {/* Window selector strip */}
+      <div className="flex gap-2">
+        {[80, 64, 80, 96].map((w, i) => (
+          <Skeleton key={i} className="h-8 rounded-full" style={{ width: w }} />
+        ))}
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <SkeletonChart height={180} />
+        <SkeletonChart height={180} />
+        <SkeletonChart height={180} />
+        <SkeletonChart height={180} />
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(protected)/habits/loading.tsx
+++ b/web/src/app/(protected)/habits/loading.tsx
@@ -1,0 +1,33 @@
+import { Skeleton, SkeletonChart } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-8 w-28" />
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Radial completion circle */}
+        <div
+          className="rounded-xl p-5 flex flex-col items-center gap-4"
+          style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+        >
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="rounded-full" style={{ width: 120, height: 120 }} />
+        </div>
+        <SkeletonChart height={120} />
+      </div>
+      {/* Habit rows */}
+      <div
+        className="rounded-xl p-5 space-y-3"
+        style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+      >
+        <Skeleton className="h-4 w-24 mb-4" />
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="flex items-center gap-3">
+            <Skeleton className="rounded-full" style={{ width: 20, height: 20, flexShrink: 0 }} />
+            <Skeleton className="h-4 flex-1" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(protected)/journal/loading.tsx
+++ b/web/src/app/(protected)/journal/loading.tsx
@@ -1,0 +1,28 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-8 w-28" />
+      {/* Editor card */}
+      <div
+        className="rounded-xl p-5"
+        style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+      >
+        <Skeleton className="h-4 w-32 mb-4" />
+        <Skeleton style={{ height: 300 }} />
+      </div>
+      {/* Past entries */}
+      {[1, 2].map((i) => (
+        <div
+          key={i}
+          className="rounded-xl p-5 flex items-center justify-between"
+          style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+        >
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-4 w-16" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/app/(protected)/meals/loading.tsx
+++ b/web/src/app/(protected)/meals/loading.tsx
@@ -1,0 +1,17 @@
+import { Skeleton, SkeletonCard } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-8 w-28" />
+      {/* Tab bar */}
+      <div className="flex gap-2">
+        {[72, 88, 64, 80].map((w, i) => (
+          <Skeleton key={i} className="h-8 rounded-full" style={{ width: w }} />
+        ))}
+      </div>
+      <SkeletonCard />
+      <SkeletonCard />
+    </div>
+  );
+}

--- a/web/src/app/(protected)/notifications/loading.tsx
+++ b/web/src/app/(protected)/notifications/loading.tsx
@@ -1,0 +1,28 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-8 w-40" />
+      <div
+        className="rounded-xl divide-y"
+        style={{
+          background: "var(--color-surface)",
+          border: "1px solid var(--color-border)",
+          borderColor: "var(--color-border)",
+        }}
+      >
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="flex items-start gap-3 p-4">
+            <Skeleton className="rounded-full mt-0.5" style={{ width: 8, height: 8, flexShrink: 0 }} />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-1/2" />
+            </div>
+            <Skeleton className="h-3 w-16 shrink-0" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(protected)/settings/loading.tsx
+++ b/web/src/app/(protected)/settings/loading.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-8 w-28" />
+      <div
+        className="rounded-xl p-5 space-y-5"
+        style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+      >
+        {[1, 2, 3, 4, 5, 6].map((i) => (
+          <div key={i} className="flex items-center justify-between gap-4">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-9 w-48 rounded-lg" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(protected)/tasks/loading.tsx
+++ b/web/src/app/(protected)/tasks/loading.tsx
@@ -1,0 +1,36 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+function PriorityGroup() {
+  return (
+    <div
+      className="rounded-xl p-5 space-y-3"
+      style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+    >
+      <Skeleton className="h-4 w-16 mb-3" />
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="flex items-center gap-3">
+          <Skeleton className="rounded" style={{ width: 16, height: 16, flexShrink: 0 }} />
+          <Skeleton className="h-4 flex-1" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-8 w-24" />
+      {/* Add-task form */}
+      <div
+        className="rounded-xl p-5"
+        style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+      >
+        <Skeleton className="h-9 w-full" />
+      </div>
+      <PriorityGroup />
+      <PriorityGroup />
+      <PriorityGroup />
+    </div>
+  );
+}

--- a/web/src/app/(protected)/weekly/loading.tsx
+++ b/web/src/app/(protected)/weekly/loading.tsx
@@ -1,0 +1,16 @@
+import { Skeleton, SkeletonCard, SkeletonChart } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-8 w-44" />
+      <div className="grid grid-cols-3 gap-4">
+        <SkeletonCard />
+        <SkeletonCard />
+        <SkeletonCard />
+      </div>
+      <SkeletonChart height={200} />
+      <SkeletonCard />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `loading.tsx` to all 10 protected routes (`/dashboard`, `/fitness`, `/habits`, `/tasks`, `/weekly`, `/journal`, `/meals`, `/notifications`, `/settings`, `/chat`) using the existing `Skeleton`, `SkeletonCard`, and `SkeletonChart` components
- Sets `staleTimes.dynamic: 300` in `next.config.ts` so revisited tabs are served instantly from the router cache for up to 5 minutes — `router.refresh()` in the sync button already busts the cache after a sync

## What was the actual problem

All pages had `export const dynamic = "force-dynamic"`, which sets the router cache stale time to 0 — every tab switch re-fetched from Supabase even if you'd just visited. Combined with no loading state, this caused a 2–4 second blank page on every navigation.

## Test plan

- [ ] Navigate between tabs — loading skeletons should appear immediately on first visit
- [ ] Navigate back to a previously visited tab — should be instant (router cache)
- [ ] Hit the sync button — data should refresh and re-fetch correctly
- [ ] Make a mutation (add task, toggle habit) — changes should appear immediately via `revalidatePath`

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)