### PR TITLE
feat: centralized meal hub with tabs and get_today_meals tool (#163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (centralized meal hub with tabs and get_today_meals tool — issue #163)
+- **`web/src/components/meals/MealsClient.tsx`** — new "use client" component wrapping the entire meals experience in four pill-style tabs (Today, Recipes, Scanner, Plan); tab state managed locally, default tab is Today
+- **Tab: Today** — today's meals grouped by type with macro totals, inline macro progress bars (replicates MacroSummaryCard logic from server-fetched props), quick-log form with meal type + description + collapsible macro fields (calories/protein/carbs/fat), log-via-chat nudge
+- **Tab: Recipes** — client-side searchable list of saved recipes filtered on name/tags/ingredients; each card collapses/expands to reveal ingredients; "Use this recipe" button prompts for meal type then POSTs to `/api/meals/log`
+- **Tab: Scanner** — mounts `FoodPhotoAnalyzer` as-is (pre-upload context textarea already implemented)
+- **Tab: Plan** — ingredient textarea; on submit POSTs to new `/api/meals/suggest`; displays 2–3 Claude-generated suggestion cards with macros, saved-recipe badge, and "Log this" inline logging
+- **`web/src/app/api/meals/suggest/route.ts`** — new POST endpoint; auth-guarded; fetches saved recipes and dietary preferences from profile; calls `generateObject` with Claude Sonnet 4.6 to return 2–3 meal suggestions calibrated to remaining macro budget; flags saved-recipe matches with `isSaved: true` and `recipeId`
+- **`web/src/app/api/chat/route.ts`** — added `get_today_meals` tool (read-only, no-arg query of today's `meal_log` entries); removed `log_meal` tool (meal logging is now exclusively done through the Meals tab UI); updated system prompt to instruct Mr. Bridge to call `get_today_meals` before making any claim about today's intake, and to redirect meal-logging requests to the Meals tab
+- **`web/src/app/(protected)/meals/page.tsx`** — refactored from a monolithic server-rendered page to a thin data-fetching layer; now fetches meals, recipes, and profile (macro goals) in parallel and passes computed props (`todayMeals`, `pastMeals`, `macroTotals`, `macroGoals`, `recipes`) to `MealsClient`; past-6-day log renders below the tab container
+
 ### Added (loading skeletons for all protected routes — issue #164)
 - **`web/src/app/(protected)/dashboard/loading.tsx`** — header + health breakdown chart + 2×2 card grid
 - **`web/src/app/(protected)/fitness/loading.tsx`** — header + window selector strip + 2×2 chart grid

--- a/web/src/app/(protected)/meals/page.tsx
+++ b/web/src/app/(protected)/meals/page.tsx
@@ -1,55 +1,65 @@
 export const dynamic = "force-dynamic";
 
 import { createClient } from "@/lib/supabase/server";
-import Link from "next/link";
-import { MessageSquare } from "lucide-react";
-import { daysAgoString } from "@/lib/timezone";
-import FoodPhotoAnalyzer from "./FoodPhotoAnalyzer";
-import MacroSummaryCard from "@/components/meals/MacroSummaryCard";
-
-interface MealRow {
-  id: string;
-  date: string;
-  meal_type: string;
-  notes: string | null;
-  recipes: { name: string } | null;
-  calories: number | null;
-  protein_g: number | null;
-  carbs_g: number | null;
-  fat_g: number | null;
-}
-
-function fmtDate(d: string) {
-  return new Date(d + "T00:00:00").toLocaleDateString("en-US", {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-  });
-}
-
-const MEAL_ORDER: Record<string, number> = {
-  breakfast: 0, lunch: 1, dinner: 2, snack: 3,
-};
+import { daysAgoString, todayString } from "@/lib/timezone";
+import MealsClient, { type MealRow, type RecipeRow, type MacroGoals, type MacroTotals } from "@/components/meals/MealsClient";
 
 export default async function MealsPage() {
   const supabase = await createClient();
 
-  const { data } = await supabase
-    .from("meal_log")
-    .select("id, date, meal_type, notes, calories, protein_g, carbs_g, fat_g, recipes(name)")
-    .gte("date", daysAgoString(6))
-    .order("date", { ascending: false })
-    .order("meal_type", { ascending: true });
+  const { data: { user } } = await supabase.auth.getUser();
+  const userId = user?.id;
 
-  const meals = (data ?? []) as unknown as MealRow[];
+  const [{ data: mealsData }, { data: recipesData }, { data: profileData }] = await Promise.all([
+    supabase
+      .from("meal_log")
+      .select("id, date, meal_type, notes, calories, protein_g, carbs_g, fat_g, recipes(name)")
+      .gte("date", daysAgoString(6))
+      .order("date", { ascending: false })
+      .order("meal_type", { ascending: true }),
+    userId
+      ? supabase
+          .from("recipes")
+          .select("id, name, cuisine, tags, ingredients")
+          .eq("user_id", userId)
+          .order("name")
+      : Promise.resolve({ data: [] }),
+    supabase.from("profile").select("key, value"),
+  ]);
 
-  // Group by date
-  const byDate = new Map<string, MealRow[]>();
-  for (const meal of meals) {
-    if (!byDate.has(meal.date)) byDate.set(meal.date, []);
-    byDate.get(meal.date)!.push(meal);
+  const meals = (mealsData ?? []) as unknown as MealRow[];
+  const recipes = (recipesData ?? []) as unknown as RecipeRow[];
+
+  // Profile → macro goals
+  const profileMap: Record<string, string> = {};
+  for (const row of profileData ?? []) {
+    profileMap[row.key] = row.value;
   }
-  const dates = Array.from(byDate.keys());
+  const macroGoals: MacroGoals = {
+    calories: profileMap["calorie_goal"] ? parseInt(profileMap["calorie_goal"], 10) : null,
+    protein: profileMap["protein_goal"] ? parseInt(profileMap["protein_goal"], 10) : null,
+    carbs: profileMap["carbs_goal"] ? parseInt(profileMap["carbs_goal"], 10) : null,
+    fat: profileMap["fat_goal"] ? parseInt(profileMap["fat_goal"], 10) : null,
+  };
+
+  // Split meals into today vs past
+  const today = todayString();
+  const todayMeals = meals.filter((m) => m.date === today);
+  const pastMeals = meals.filter((m) => m.date !== today);
+
+  // Compute today's macro totals (entries with at least some macro data)
+  const macroTotals: MacroTotals = todayMeals.reduce(
+    (acc, m) => ({
+      calories: acc.calories + (m.calories ?? 0),
+      protein: acc.protein + (m.protein_g ?? 0),
+      carbs: acc.carbs + (m.carbs_g ?? 0),
+      fat: acc.fat + (m.fat_g ?? 0),
+    }),
+    { calories: 0, protein: 0, carbs: 0, fat: 0 }
+  );
+  macroTotals.protein = Math.round(macroTotals.protein);
+  macroTotals.carbs = Math.round(macroTotals.carbs);
+  macroTotals.fat = Math.round(macroTotals.fat);
 
   return (
     <div className="space-y-6">
@@ -58,105 +68,17 @@ export default async function MealsPage() {
           Meals
         </h1>
         <p className="mt-1" style={{ fontSize: 14, color: "var(--color-text-muted)" }}>
-          Last 7 days
+          Meal Hub
         </p>
       </div>
 
-      {/* Macro summary */}
-      <MacroSummaryCard />
-
-      {/* Photo analyzer */}
-      <FoodPhotoAnalyzer />
-
-      {/* Log via chat nudge */}
-      <div
-        className="flex items-center gap-3 rounded-xl px-4 py-3"
-        style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
-      >
-        <MessageSquare size={16} style={{ color: "var(--color-primary)", flexShrink: 0 }} />
-        <p style={{ fontSize: 14, color: "var(--color-text-muted)" }}>
-          Or log meals by telling{" "}
-          <Link
-            href="/chat"
-            style={{ color: "var(--color-primary)", textDecoration: "underline", textUnderlineOffset: 2 }}
-          >
-            Mr. Bridge
-          </Link>{" "}
-          what you ate.
-        </p>
-      </div>
-
-      {/* Meal log */}
-      {dates.length === 0 ? (
-        <div
-          className="rounded-xl p-8 text-center"
-          style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
-        >
-          <p style={{ fontSize: 14, color: "var(--color-text-faint)" }}>No meals logged this week</p>
-        </div>
-      ) : (
-        <div className="space-y-4">
-          {dates.map((date) => {
-            const dayMeals = (byDate.get(date) ?? []).sort(
-              (a, b) => (MEAL_ORDER[a.meal_type] ?? 9) - (MEAL_ORDER[b.meal_type] ?? 9)
-            );
-            return (
-              <div
-                key={date}
-                className="rounded-xl p-5"
-                style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
-              >
-                <p
-                  className="text-xs uppercase tracking-widest mb-3"
-                  style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}
-                >
-                  {fmtDate(date)}
-                </p>
-                <div className="space-y-2">
-                  {dayMeals.map((m) => {
-                    const hasMacros = m.calories != null || m.protein_g != null;
-                    const macroStr = hasMacros
-                      ? [
-                          m.calories != null && `${m.calories} cal`,
-                          m.protein_g != null && `P ${m.protein_g}g`,
-                          m.carbs_g != null && `C ${m.carbs_g}g`,
-                          m.fat_g != null && `F ${m.fat_g}g`,
-                        ]
-                          .filter(Boolean)
-                          .join(" · ")
-                      : null;
-                    return (
-                    <div key={m.id} className="flex items-baseline gap-3">
-                      <span
-                        style={{
-                          fontSize: 11,
-                          fontWeight: 500,
-                          color: "var(--color-text-muted)",
-                          textTransform: "capitalize",
-                          minWidth: 64,
-                        }}
-                      >
-                        {m.meal_type}
-                      </span>
-                      <div>
-                        <span style={{ fontSize: 14, color: "var(--color-text)" }}>
-                          {m.recipes?.name ?? m.notes ?? "—"}
-                        </span>
-                        {macroStr && (
-                          <span style={{ fontSize: 11, color: "var(--color-text-faint)", marginLeft: 8 }}>
-                            {macroStr}
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                    );
-                  })}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      )}
+      <MealsClient
+        todayMeals={todayMeals}
+        pastMeals={pastMeals}
+        recipes={recipes}
+        macroGoals={macroGoals}
+        macroTotals={macroTotals}
+      />
     </div>
   );
 }

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -238,7 +238,7 @@ Tools available:
 - get_profile, update_profile
 - search_gmail, get_email_body (returns demo emails)
 - list_calendar_events, create_calendar_event, delete_calendar_event, update_calendar_event (demo mode — no real changes)
-- get_recipes, log_meal`
+- get_recipes, get_today_meals`
     : `You are Mr. Bridge, ${userLabel}'s personal AI assistant.
 Today's date is ${todayString()}.
 ${userName ? `Address the user as "${userName}" — use their name naturally in conversation, not robotically after every sentence.` : 'If you learn the user\'s name during the conversation, use it naturally going forward.'}
@@ -276,9 +276,12 @@ Tools available:
 - delete_calendar_event: delete an event by eventId. Always state title/date/time and require explicit user confirmation first.
 - update_calendar_event: patch an existing event by eventId (summary, start, end, location, description). Always state before/after and require explicit user confirmation first.
 - get_recipes: search the saved recipe library by ingredient, name, or tag; omit query to return all saved recipes. Use this as one input alongside your own recipe knowledge — do not limit suggestions to saved recipes only.
-- log_meal: log a meal by type (breakfast/lunch/dinner/snack) with optional recipe link, notes, and estimated macros (calories, protein_g, carbs_g, fat_g) — include macros whenever the user mentions them or you can estimate from the food description
+- get_today_meals: get all meals logged today. Call this before making any claim about what the user has or hasn't eaten today.
 
 Recipes and meal planning are in scope.
+
+Meal logging is done through the Meals tab in the web interface — do not attempt to log meals yourself. If the user asks you to log a meal, tell them to use the Meals tab. You can still read today's logged meals via get_today_meals to give accurate nutrition advice.
+Before making any claim about what the user has or hasn't eaten today, always call get_today_meals first.
 
 Ingredient assumptions: Unless the user states otherwise in this conversation, assume the only ingredients available are bare essentials — salt, pepper, neutral oil, olive oil, butter, garlic, onion, basic dry spices (cumin, paprika, oregano, chili flake, cinnamon, etc.), flour, sugar, baking soda/powder, vinegar, soy sauce, and stock/broth. Do not assume proteins, produce, dairy, or specialty ingredients are on hand.
 
@@ -997,50 +1000,21 @@ When asked what to cook or for recipe ideas:
       },
     }),
 
-    log_meal: tool({
-      description: "Log a meal to the meal_log table. Include estimated macros (calories, protein_g, carbs_g, fat_g) whenever the user mentions them or you can estimate them from the food description.",
-      parameters: jsonSchema<{
-        meal_type: "breakfast" | "lunch" | "dinner" | "snack";
-        notes?: string;
-        recipe_id?: string;
-        date?: string;
-        calories?: number;
-        protein_g?: number;
-        carbs_g?: number;
-        fat_g?: number;
-      }>({
+    get_today_meals: tool({
+      description: "Get all meals logged today. Call this before making any claim about what the user has or hasn't eaten today.",
+      parameters: jsonSchema<Record<string, never>>({
         type: "object",
-        required: ["meal_type"],
-        properties: {
-          meal_type: { type: "string", enum: ["breakfast", "lunch", "dinner", "snack"], description: "Meal type." },
-          notes: { type: "string", description: "Free-text meal description." },
-          recipe_id: { type: "string", description: "UUID of a saved recipe." },
-          date: { type: "string", description: "Date in YYYY-MM-DD format. Defaults to today." },
-          calories: { type: "number", description: "Estimated calories." },
-          protein_g: { type: "number", description: "Estimated protein in grams." },
-          carbs_g: { type: "number", description: "Estimated carbohydrates in grams." },
-          fat_g: { type: "number", description: "Estimated fat in grams." },
-        },
+        properties: {},
       }),
-      execute: async ({ meal_type, notes, recipe_id, date, calories, protein_g, carbs_g, fat_g }) => {
-        const { data, error } = await supabase
+      execute: async () => {
+        const today = todayString();
+        let q = supabase
           .from("meal_log")
-          .insert({
-            user_id: userId,
-            meal_type,
-            notes: notes ?? null,
-            recipe_id: recipe_id ?? null,
-            date: date ?? todayString(),
-            calories: calories ?? null,
-            protein_g: protein_g ?? null,
-            carbs_g: carbs_g ?? null,
-            fat_g: fat_g ?? null,
-            source: "chat",
-          })
-          .select()
-          .single();
-        if (error) return { error: error.message };
-        return data;
+          .select("meal_type, notes, calories, protein_g, carbs_g, fat_g, recipes(name)")
+          .eq("date", today);
+        if (userId) q = q.eq("user_id", userId);
+        const { data } = await q;
+        return data ?? [];
       },
     }),
   };

--- a/web/src/app/api/meals/suggest/route.ts
+++ b/web/src/app/api/meals/suggest/route.ts
@@ -1,0 +1,173 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import { generateObject } from "ai";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+
+export const maxDuration = 30;
+
+const SuggestionsSchema = z.object({
+  suggestions: z
+    .array(
+      z.object({
+        name: z.string().describe("Recipe or dish name"),
+        description: z
+          .string()
+          .describe("1–2 sentence description of the dish, cooking method, and why it fits"),
+        calories: z.number().int().describe("Estimated total calories"),
+        protein_g: z.number().describe("Estimated protein in grams"),
+        carbs_g: z.number().describe("Estimated carbohydrates in grams"),
+        fat_g: z.number().describe("Estimated fat in grams"),
+        isSaved: z
+          .boolean()
+          .describe("true if this matches a saved recipe in the user's library"),
+        recipeId: z
+          .string()
+          .optional()
+          .describe("UUID of the matching saved recipe, if isSaved is true"),
+      })
+    )
+    .min(1)
+    .max(3)
+    .describe("2–3 meal suggestions"),
+});
+
+interface PostBody {
+  ingredients: string;
+  todayMacros: {
+    calories: number;
+    protein_g: number;
+    carbs_g: number;
+    fat_g: number;
+  };
+  goals: {
+    calories: number | null;
+    protein_g: number | null;
+    carbs_g: number | null;
+    fat_g: number | null;
+  };
+}
+
+export async function POST(req: Request) {
+  // Auth guard
+  const serverClient = await createClient();
+  const {
+    data: { user },
+  } = await serverClient.auth.getUser();
+  if (!user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = user.id;
+
+  let body: PostBody;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.ingredients?.trim()) {
+    return Response.json({ error: "ingredients is required" }, { status: 400 });
+  }
+
+  const supabase = createServiceClient();
+
+  // Fetch saved recipes and dietary preferences in parallel
+  const [{ data: savedRecipes }, { data: profileRows }] = await Promise.all([
+    supabase
+      .from("recipes")
+      .select("id, name, cuisine, ingredients, tags")
+      .eq("user_id", userId)
+      .order("name"),
+    supabase.from("profile").select("key, value").eq("user_id", userId),
+  ]);
+
+  const profileMap: Record<string, string> = {};
+  for (const row of profileRows ?? []) {
+    profileMap[row.key] = row.value;
+  }
+
+  // Dietary preferences from profile
+  const dietaryPrefs = [
+    profileMap["dietary_preferences"],
+    profileMap["dietary_restrictions"],
+    profileMap["cuisine_preferences"],
+  ]
+    .filter(Boolean)
+    .join("; ");
+
+  // Macro budget
+  const remaining = {
+    calories:
+      body.goals.calories != null
+        ? Math.max(0, body.goals.calories - body.todayMacros.calories)
+        : null,
+    protein_g:
+      body.goals.protein_g != null
+        ? Math.max(0, body.goals.protein_g - body.todayMacros.protein_g)
+        : null,
+    carbs_g:
+      body.goals.carbs_g != null
+        ? Math.max(0, body.goals.carbs_g - body.todayMacros.carbs_g)
+        : null,
+    fat_g:
+      body.goals.fat_g != null
+        ? Math.max(0, body.goals.fat_g - body.todayMacros.fat_g)
+        : null,
+  };
+
+  // Saved recipe summary for the prompt
+  const savedSummary =
+    savedRecipes && savedRecipes.length > 0
+      ? savedRecipes
+          .map((r) => `- ${r.name} (id: ${r.id}): ${r.ingredients ?? ""}`)
+          .join("\n")
+      : "None";
+
+  const prompt = `You are a meal planning assistant. Suggest 2–3 meals the user can make right now.
+
+INGREDIENTS ON HAND:
+${body.ingredients}
+
+REMAINING MACRO BUDGET FOR TODAY:
+${remaining.calories != null ? `Calories: ${remaining.calories} kcal` : "Calorie goal not set"}
+${remaining.protein_g != null ? `Protein: ${remaining.protein_g}g` : "Protein goal not set"}
+${remaining.carbs_g != null ? `Carbs: ${remaining.carbs_g}g` : "Carbs goal not set"}
+${remaining.fat_g != null ? `Fat: ${remaining.fat_g}g` : "Fat goal not set"}
+
+DIETARY PREFERENCES:
+${dietaryPrefs || "None specified"}
+
+USER'S SAVED RECIPE LIBRARY (check these first for matches):
+${savedSummary}
+
+INSTRUCTIONS:
+- Suggest meals that can be made primarily from the listed ingredients
+- Assume bare pantry staples are available: salt, pepper, oil, butter, garlic, onion, basic dry spices, soy sauce, stock
+- Check the saved recipe library first — if a saved recipe is a good fit, set isSaved=true and recipeId to the recipe's UUID
+- Fill remaining slots with original suggestions from your knowledge (isSaved=false)
+- Prioritize hitting the remaining macro budget — prefer protein-forward meals if protein budget is large
+- Macro estimates should be conservative and realistic
+- Keep descriptions concise: cooking method + why it fits the macros`;
+
+  try {
+    const { object } = await generateObject({
+      model: anthropic("claude-sonnet-4-6"),
+      schema: SuggestionsSchema,
+      messages: [
+        {
+          role: "user",
+          content: prompt,
+        },
+      ],
+    });
+
+    return Response.json(object);
+  } catch (err) {
+    console.error("[meals/suggest] Claude error:", err);
+    return Response.json(
+      { error: err instanceof Error ? err.message : "Failed to generate suggestions" },
+      { status: 500 }
+    );
+  }
+}

--- a/web/src/components/meals/MealsClient.tsx
+++ b/web/src/components/meals/MealsClient.tsx
@@ -1,0 +1,998 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { MessageSquare, ChevronDown, ChevronUp, RefreshCw, Loader2 } from "lucide-react";
+import Link from "next/link";
+import FoodPhotoAnalyzer from "@/app/(protected)/meals/FoodPhotoAnalyzer";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface MealRow {
+  id: string;
+  date: string;
+  meal_type: string;
+  notes: string | null;
+  recipes: { name: string } | null;
+  calories: number | null;
+  protein_g: number | null;
+  carbs_g: number | null;
+  fat_g: number | null;
+}
+
+export interface RecipeRow {
+  id: string;
+  name: string;
+  cuisine: string | null;
+  tags: string[] | null;
+  ingredients: string | null;
+}
+
+export interface MacroGoals {
+  calories: number | null;
+  protein: number | null;
+  carbs: number | null;
+  fat: number | null;
+}
+
+export interface MacroTotals {
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+}
+
+interface Suggestion {
+  name: string;
+  description: string;
+  calories: number;
+  protein_g: number;
+  carbs_g: number;
+  fat_g: number;
+  isSaved: boolean;
+  recipeId?: string;
+}
+
+interface Props {
+  todayMeals: MealRow[];
+  pastMeals: MealRow[];
+  recipes: RecipeRow[];
+  macroGoals: MacroGoals;
+  macroTotals: MacroTotals;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+type Tab = "today" | "recipes" | "scanner" | "plan";
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: "today", label: "Today" },
+  { id: "recipes", label: "Recipes" },
+  { id: "scanner", label: "Scanner" },
+  { id: "plan", label: "Plan" },
+];
+
+const MEAL_ORDER: Record<string, number> = {
+  breakfast: 0, lunch: 1, dinner: 2, snack: 3,
+};
+
+const MEAL_TYPES = ["breakfast", "lunch", "dinner", "snack"] as const;
+type MealType = typeof MEAL_TYPES[number];
+
+// ─── Shared styles ────────────────────────────────────────────────────────────
+
+const inputStyle = {
+  background: "var(--color-bg)",
+  border: "1px solid var(--color-border)",
+  color: "var(--color-text)",
+  outline: "none",
+  fontSize: 16, // Prevents iOS auto-zoom on focus
+  borderRadius: 8,
+  padding: "10px 12px",
+  width: "100%",
+  WebkitAppearance: "none" as const,
+} as const;
+
+// ─── Macro progress bar ───────────────────────────────────────────────────────
+
+function progressColor(pct: number): string {
+  if (pct > 100) return "var(--color-danger)";
+  if (pct >= 85) return "var(--color-warning)";
+  return "var(--color-positive)";
+}
+
+interface MacroBarProps {
+  label: string;
+  unit: string;
+  consumed: number;
+  goal: number | null;
+}
+
+function MacroBar({ label, unit, consumed, goal }: MacroBarProps) {
+  if (goal === null) return null;
+  const pct = goal > 0 ? (consumed / goal) * 100 : 0;
+  const color = progressColor(pct);
+  const remaining = goal - consumed;
+  const isOver = remaining < 0;
+  const clamped = Math.min(pct, 100);
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-baseline justify-between">
+        <span style={{ fontSize: 13, fontWeight: 500, color: "var(--color-text)" }}>
+          {label}
+        </span>
+        <div className="flex items-baseline gap-1.5">
+          <span style={{ fontSize: 13, color: "var(--color-text)" }}>
+            {consumed}
+            <span style={{ color: "var(--color-text-muted)", fontSize: 11 }}>{unit}</span>
+          </span>
+          <span style={{ fontSize: 11, color: "var(--color-text-faint)" }}>/</span>
+          <span style={{ fontSize: 11, color: "var(--color-text-muted)" }}>
+            {goal}{unit}
+          </span>
+          <span style={{ fontSize: 11, fontWeight: 500, color, minWidth: 52, textAlign: "right" }}>
+            {isOver
+              ? `+${Math.abs(remaining)}${unit} over`
+              : `${remaining}${unit} left`}
+          </span>
+        </div>
+      </div>
+      <div className="rounded-full overflow-hidden" style={{ height: 4, background: "var(--color-border)" }}>
+        <div
+          className="h-full rounded-full transition-all duration-300"
+          style={{ width: `${clamped}%`, background: color }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ─── Today Tab ────────────────────────────────────────────────────────────────
+
+function TodayTab({
+  todayMeals,
+  macroGoals,
+  macroTotals,
+}: {
+  todayMeals: MealRow[];
+  macroGoals: MacroGoals;
+  macroTotals: MacroTotals;
+}) {
+  const router = useRouter();
+  const [logMealType, setLogMealType] = useState<MealType>("breakfast");
+  const [logDesc, setLogDesc] = useState("");
+  const [macrosOpen, setMacrosOpen] = useState(false);
+  const [logCal, setLogCal] = useState("");
+  const [logProtein, setLogProtein] = useState("");
+  const [logCarbs, setLogCarbs] = useState("");
+  const [logFat, setLogFat] = useState("");
+  const [logging, setLogging] = useState(false);
+
+  const hasAnyGoal =
+    macroGoals.calories !== null ||
+    macroGoals.protein !== null ||
+    macroGoals.carbs !== null ||
+    macroGoals.fat !== null;
+
+  const sortedMeals = [...todayMeals].sort(
+    (a, b) => (MEAL_ORDER[a.meal_type] ?? 9) - (MEAL_ORDER[b.meal_type] ?? 9)
+  );
+
+  async function handleLog() {
+    if (!logDesc.trim()) return;
+    setLogging(true);
+    try {
+      const body: Record<string, string | number> = {
+        meal_type: logMealType,
+        notes: logDesc.trim(),
+      };
+      if (logCal && !isNaN(parseInt(logCal, 10))) body.calories = parseInt(logCal, 10);
+      if (logProtein && !isNaN(parseFloat(logProtein))) body.protein_g = parseFloat(logProtein);
+      if (logCarbs && !isNaN(parseFloat(logCarbs))) body.carbs_g = parseFloat(logCarbs);
+      if (logFat && !isNaN(parseFloat(logFat))) body.fat_g = parseFloat(logFat);
+
+      const res = await fetch("/api/meals/log", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error("Failed to log meal");
+
+      setLogDesc("");
+      setLogCal("");
+      setLogProtein("");
+      setLogCarbs("");
+      setLogFat("");
+      setMacrosOpen(false);
+      router.refresh();
+    } finally {
+      setLogging(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Macro summary */}
+      {hasAnyGoal ? (
+        <div
+          className="rounded-xl p-5"
+          style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+        >
+          <p
+            className="text-xs uppercase tracking-widest mb-4"
+            style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}
+          >
+            Today&apos;s Macros
+          </p>
+          <div className="space-y-4">
+            <MacroBar label="Calories" unit=" kcal" consumed={macroTotals.calories} goal={macroGoals.calories} />
+            <MacroBar label="Protein" unit="g" consumed={macroTotals.protein} goal={macroGoals.protein} />
+            <MacroBar label="Carbs" unit="g" consumed={macroTotals.carbs} goal={macroGoals.carbs} />
+            <MacroBar label="Fat" unit="g" consumed={macroTotals.fat} goal={macroGoals.fat} />
+          </div>
+        </div>
+      ) : (
+        <div
+          className="rounded-xl p-5"
+          style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+        >
+          <p style={{ fontSize: 14, color: "var(--color-text-muted)" }}>
+            No nutrition goals set.{" "}
+            <Link
+              href="/settings"
+              style={{ color: "var(--color-primary)", textDecoration: "underline", textUnderlineOffset: 2 }}
+            >
+              Configure goals in Settings
+            </Link>{" "}
+            to track progress here.
+          </p>
+        </div>
+      )}
+
+      {/* Today's logged meals */}
+      <div
+        className="rounded-xl p-5"
+        style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+      >
+        <p
+          className="text-xs uppercase tracking-widest mb-4"
+          style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}
+        >
+          Logged Today
+        </p>
+
+        {sortedMeals.length === 0 ? (
+          <p style={{ fontSize: 14, color: "var(--color-text-faint)" }}>
+            Nothing logged yet today.
+          </p>
+        ) : (
+          <div className="space-y-2 mb-4">
+            {sortedMeals.map((m) => {
+              const hasMacros = m.calories != null || m.protein_g != null;
+              const macroStr = hasMacros
+                ? [
+                    m.calories != null && `${m.calories} cal`,
+                    m.protein_g != null && `P ${m.protein_g}g`,
+                    m.carbs_g != null && `C ${m.carbs_g}g`,
+                    m.fat_g != null && `F ${m.fat_g}g`,
+                  ]
+                    .filter(Boolean)
+                    .join(" · ")
+                : null;
+              return (
+                <div key={m.id} className="flex items-baseline gap-3">
+                  <span
+                    style={{
+                      fontSize: 11,
+                      fontWeight: 500,
+                      color: "var(--color-text-muted)",
+                      textTransform: "capitalize",
+                      minWidth: 64,
+                    }}
+                  >
+                    {m.meal_type}
+                  </span>
+                  <div>
+                    <span style={{ fontSize: 14, color: "var(--color-text)" }}>
+                      {m.recipes?.name ?? m.notes ?? "—"}
+                    </span>
+                    {macroStr && (
+                      <span style={{ fontSize: 11, color: "var(--color-text-faint)", marginLeft: 8 }}>
+                        {macroStr}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Divider */}
+        <div style={{ borderTop: "1px solid var(--color-border)", marginBottom: 14 }} />
+
+        {/* Quick-log form */}
+        <p
+          className="text-xs uppercase tracking-widest mb-3"
+          style={{ color: "var(--color-text-faint)", letterSpacing: "0.07em" }}
+        >
+          Quick log
+        </p>
+        <div className="flex gap-2 mb-2">
+          <select
+            value={logMealType}
+            onChange={(e) => setLogMealType(e.target.value as MealType)}
+            style={{ ...inputStyle, width: "auto", minWidth: 110, flexShrink: 0 }}
+          >
+            {MEAL_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {t.charAt(0).toUpperCase() + t.slice(1)}
+              </option>
+            ))}
+          </select>
+          <input
+            type="text"
+            value={logDesc}
+            onChange={(e) => setLogDesc(e.target.value)}
+            placeholder="What did you eat?"
+            onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) handleLog(); }}
+            style={{ ...inputStyle, flex: 1 }}
+          />
+          <button
+            onClick={handleLog}
+            disabled={logging || !logDesc.trim()}
+            className="flex items-center justify-center rounded-xl font-medium transition-opacity active:opacity-70 disabled:opacity-40"
+            style={{
+              background: "var(--color-primary)",
+              color: "#fff",
+              fontSize: 14,
+              padding: "10px 14px",
+              whiteSpace: "nowrap",
+              flexShrink: 0,
+            }}
+          >
+            {logging ? <Loader2 size={14} className="animate-spin" /> : "Log"}
+          </button>
+        </div>
+
+        <button
+          onClick={() => setMacrosOpen((v) => !v)}
+          className="flex items-center gap-1 transition-opacity active:opacity-70"
+          style={{ fontSize: 12, color: "var(--color-primary)", background: "none", border: "none", cursor: "pointer", padding: "2px 0" }}
+        >
+          {macrosOpen ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+          Add macros
+        </button>
+
+        {macrosOpen && (
+          <div
+            className="grid grid-cols-4 gap-2 mt-3 pt-3"
+            style={{ borderTop: "1px solid var(--color-border)" }}
+          >
+            {[
+              { label: "Cal", value: logCal, setter: setLogCal, mode: "numeric" as const },
+              { label: "P (g)", value: logProtein, setter: setLogProtein, mode: "decimal" as const },
+              { label: "C (g)", value: logCarbs, setter: setLogCarbs, mode: "decimal" as const },
+              { label: "F (g)", value: logFat, setter: setLogFat, mode: "decimal" as const },
+            ].map(({ label, value, setter, mode }) => (
+              <div key={label}>
+                <label style={{ display: "block", fontSize: 11, color: "var(--color-text-muted)", marginBottom: 4 }}>
+                  {label}
+                </label>
+                <input
+                  type="text"
+                  inputMode={mode}
+                  value={value}
+                  onChange={(e) => setter(e.target.value)}
+                  placeholder="0"
+                  style={{ ...inputStyle, padding: "7px 8px", fontSize: 13 }}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Log via chat nudge */}
+      <div
+        className="flex items-center gap-3 rounded-xl px-4 py-3"
+        style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+      >
+        <MessageSquare size={16} style={{ color: "var(--color-primary)", flexShrink: 0 }} />
+        <p style={{ fontSize: 14, color: "var(--color-text-muted)" }}>
+          Or ask{" "}
+          <Link
+            href="/chat"
+            style={{ color: "var(--color-primary)", textDecoration: "underline", textUnderlineOffset: 2 }}
+          >
+            Mr. Bridge
+          </Link>{" "}
+          for meal ideas based on what you have on hand.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ─── Recipes Tab ──────────────────────────────────────────────────────────────
+
+function RecipesTab({ recipes }: { recipes: RecipeRow[] }) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [useRecipeId, setUseRecipeId] = useState<string | null>(null);
+  const [useRecipeMealType, setUseRecipeMealType] = useState<MealType>("lunch");
+  const [logging, setLogging] = useState(false);
+
+  const q = query.toLowerCase();
+  const filtered = q
+    ? recipes.filter((r) => {
+        const haystack = [
+          r.name,
+          r.cuisine,
+          ...(r.tags ?? []),
+          r.ingredients ?? "",
+        ]
+          .join(" ")
+          .toLowerCase();
+        return haystack.includes(q);
+      })
+    : recipes;
+
+  async function handleUseRecipe(recipeId: string) {
+    setLogging(true);
+    try {
+      const recipe = recipes.find((r) => r.id === recipeId);
+      const res = await fetch("/api/meals/log", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          meal_type: useRecipeMealType,
+          recipe_id: recipeId,
+          notes: recipe?.name ?? null,
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to log meal");
+      setUseRecipeId(null);
+      router.refresh();
+    } finally {
+      setLogging(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search recipes, ingredients, tags…"
+        style={inputStyle}
+      />
+
+      {filtered.length === 0 ? (
+        <div
+          className="rounded-xl p-8 text-center"
+          style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+        >
+          <p style={{ fontSize: 14, color: "var(--color-text-faint)" }}>
+            {recipes.length === 0 ? "No saved recipes yet." : "No recipes match your search."}
+          </p>
+        </div>
+      ) : (
+        filtered.map((r) => {
+          const isExpanded = expandedId === r.id;
+          const isUsing = useRecipeId === r.id;
+          return (
+            <div
+              key={r.id}
+              className="rounded-xl overflow-hidden"
+              style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+            >
+              <button
+                onClick={() => setExpandedId(isExpanded ? null : r.id)}
+                className="w-full text-left px-4 py-4 flex items-start justify-between gap-3"
+                style={{ background: "none", border: "none", cursor: "pointer" }}
+              >
+                <div>
+                  <p style={{ fontSize: 14, fontWeight: 600, color: "var(--color-text)" }}>
+                    {r.name}
+                  </p>
+                  {r.cuisine && (
+                    <p style={{ fontSize: 12, color: "var(--color-text-muted)", marginTop: 2 }}>
+                      {r.cuisine}
+                    </p>
+                  )}
+                  {r.tags && r.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-2">
+                      {r.tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className="rounded-full px-2 py-0.5"
+                          style={{
+                            fontSize: 11,
+                            background: "color-mix(in srgb, var(--color-primary) 12%, transparent)",
+                            color: "var(--color-primary)",
+                          }}
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                {isExpanded ? (
+                  <ChevronUp size={15} style={{ color: "var(--color-text-faint)", flexShrink: 0, marginTop: 2 }} />
+                ) : (
+                  <ChevronDown size={15} style={{ color: "var(--color-text-faint)", flexShrink: 0, marginTop: 2 }} />
+                )}
+              </button>
+
+              {isExpanded && (
+                <div
+                  className="px-4 pb-4 pt-1"
+                  style={{ borderTop: "1px solid var(--color-border)" }}
+                >
+                  {r.ingredients && (
+                    <p style={{ fontSize: 13, color: "var(--color-text-muted)", lineHeight: 1.6, marginBottom: 12 }}>
+                      {r.ingredients}
+                    </p>
+                  )}
+
+                  {isUsing ? (
+                    <div className="flex items-center gap-2">
+                      <select
+                        value={useRecipeMealType}
+                        onChange={(e) => setUseRecipeMealType(e.target.value as MealType)}
+                        style={{ ...inputStyle, width: "auto", minWidth: 110 }}
+                      >
+                        {MEAL_TYPES.map((t) => (
+                          <option key={t} value={t}>
+                            {t.charAt(0).toUpperCase() + t.slice(1)}
+                          </option>
+                        ))}
+                      </select>
+                      <button
+                        onClick={() => handleUseRecipe(r.id)}
+                        disabled={logging}
+                        className="flex items-center gap-1.5 rounded-xl font-medium transition-opacity active:opacity-70 disabled:opacity-40"
+                        style={{
+                          background: "var(--color-primary)",
+                          color: "#fff",
+                          fontSize: 14,
+                          padding: "10px 14px",
+                        }}
+                      >
+                        {logging ? <Loader2 size={14} className="animate-spin" /> : "Log"}
+                      </button>
+                      <button
+                        onClick={() => setUseRecipeId(null)}
+                        style={{ fontSize: 13, color: "var(--color-text-muted)", background: "none", border: "none", cursor: "pointer" }}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      onClick={() => setUseRecipeId(r.id)}
+                      className="rounded-xl font-medium transition-opacity active:opacity-70"
+                      style={{
+                        background: "var(--color-primary)",
+                        color: "#fff",
+                        fontSize: 14,
+                        padding: "9px 16px",
+                        border: "none",
+                        cursor: "pointer",
+                      }}
+                    >
+                      Use this recipe
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}
+
+// ─── Plan Tab ─────────────────────────────────────────────────────────────────
+
+function PlanTab({
+  macroTotals,
+  macroGoals,
+}: {
+  macroTotals: MacroTotals;
+  macroGoals: MacroGoals;
+}) {
+  const router = useRouter();
+  const [ingredients, setIngredients] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [error, setError] = useState("");
+  const [logStates, setLogStates] = useState<Record<number, { open: boolean; mealType: MealType; logging: boolean }>>({});
+
+  async function handleSuggest() {
+    if (!ingredients.trim()) return;
+    setLoading(true);
+    setError("");
+    setSuggestions([]);
+    try {
+      const res = await fetch("/api/meals/suggest", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ingredients: ingredients.trim(),
+          todayMacros: {
+            calories: macroTotals.calories,
+            protein_g: macroTotals.protein,
+            carbs_g: macroTotals.carbs,
+            fat_g: macroTotals.fat,
+          },
+          goals: {
+            calories: macroGoals.calories,
+            protein_g: macroGoals.protein,
+            carbs_g: macroGoals.carbs,
+            fat_g: macroGoals.fat,
+          },
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok || data.error) throw new Error(data.error ?? "Failed to get suggestions");
+      setSuggestions(data.suggestions ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to get suggestions");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function getLogState(i: number) {
+    return logStates[i] ?? { open: false, mealType: "dinner" as MealType, logging: false };
+  }
+
+  function setLogState(i: number, update: Partial<{ open: boolean; mealType: MealType; logging: boolean }>) {
+    setLogStates((prev) => ({
+      ...prev,
+      [i]: { ...getLogState(i), ...update },
+    }));
+  }
+
+  async function handleLog(i: number, suggestion: Suggestion) {
+    const state = getLogState(i);
+    setLogState(i, { logging: true });
+    try {
+      const body: Record<string, string | number> = {
+        meal_type: state.mealType,
+        notes: suggestion.name,
+        calories: suggestion.calories,
+        protein_g: suggestion.protein_g,
+        carbs_g: suggestion.carbs_g,
+        fat_g: suggestion.fat_g,
+      };
+      if (suggestion.recipeId) body.recipe_id = suggestion.recipeId;
+
+      const res = await fetch("/api/meals/log", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error("Failed to log meal");
+      setLogState(i, { open: false, logging: false });
+      router.refresh();
+    } catch {
+      setLogState(i, { logging: false });
+    }
+  }
+
+  const remainingCal =
+    macroGoals.calories != null ? macroGoals.calories - macroTotals.calories : null;
+  const remainingProtein =
+    macroGoals.protein != null ? macroGoals.protein - macroTotals.protein : null;
+
+  return (
+    <div className="space-y-4">
+      <div
+        className="rounded-xl p-5"
+        style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+      >
+        <p
+          className="text-xs uppercase tracking-widest mb-3"
+          style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}
+        >
+          What do you have on hand?
+        </p>
+        {(remainingCal != null || remainingProtein != null) && (
+          <p style={{ fontSize: 12, color: "var(--color-text-faint)", marginBottom: 10 }}>
+            Remaining today:{" "}
+            {remainingCal != null && `${Math.max(0, remainingCal)} kcal`}
+            {remainingCal != null && remainingProtein != null && " · "}
+            {remainingProtein != null && `${Math.max(0, remainingProtein)}g protein`}
+          </p>
+        )}
+        <textarea
+          value={ingredients}
+          onChange={(e) => setIngredients(e.target.value)}
+          rows={3}
+          placeholder="e.g. chicken breast, broccoli, rice"
+          style={{ ...inputStyle, resize: "none", lineHeight: 1.6, marginBottom: 10 }}
+        />
+        <button
+          onClick={handleSuggest}
+          disabled={loading || !ingredients.trim()}
+          className="flex items-center justify-center gap-2 rounded-xl font-medium transition-opacity active:opacity-70 disabled:opacity-40"
+          style={{
+            background: "var(--color-primary)",
+            color: "#fff",
+            fontSize: 15,
+            padding: "12px 20px",
+            width: "100%",
+            border: "none",
+            cursor: loading || !ingredients.trim() ? "default" : "pointer",
+          }}
+        >
+          {loading ? (
+            <>
+              <Loader2 size={15} className="animate-spin" />
+              Finding suggestions…
+            </>
+          ) : (
+            <>
+              <RefreshCw size={15} />
+              Get suggestions
+            </>
+          )}
+        </button>
+        {error && (
+          <p style={{ fontSize: 13, color: "var(--color-danger, #ef4444)", marginTop: 10 }}>
+            {error}
+          </p>
+        )}
+      </div>
+
+      {suggestions.length > 0 && (
+        <div className="space-y-3">
+          {suggestions.map((s, i) => {
+            const state = getLogState(i);
+            return (
+              <div
+                key={i}
+                className="rounded-xl p-4"
+                style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+              >
+                {s.isSaved && (
+                  <span
+                    className="rounded-full px-2 py-0.5 inline-block mb-2"
+                    style={{
+                      fontSize: 11,
+                      background: "color-mix(in srgb, var(--color-positive) 15%, transparent)",
+                      color: "var(--color-positive)",
+                    }}
+                  >
+                    Saved recipe
+                  </span>
+                )}
+                <p style={{ fontSize: 15, fontWeight: 600, color: "var(--color-text)", marginBottom: 4 }}>
+                  {s.name}
+                </p>
+                <p style={{ fontSize: 13, color: "var(--color-text-muted)", lineHeight: 1.5, marginBottom: 10 }}>
+                  {s.description}
+                </p>
+                <div className="flex gap-4 mb-3" style={{ fontSize: 12, color: "var(--color-text-faint)" }}>
+                  <span>~{s.calories} cal</span>
+                  <span>P {s.protein_g}g</span>
+                  <span>C {s.carbs_g}g</span>
+                  <span>F {s.fat_g}g</span>
+                </div>
+
+                {state.open ? (
+                  <div className="flex items-center gap-2">
+                    <select
+                      value={state.mealType}
+                      onChange={(e) => setLogState(i, { mealType: e.target.value as MealType })}
+                      style={{ ...inputStyle, width: "auto", minWidth: 110 }}
+                    >
+                      {MEAL_TYPES.map((t) => (
+                        <option key={t} value={t}>
+                          {t.charAt(0).toUpperCase() + t.slice(1)}
+                        </option>
+                      ))}
+                    </select>
+                    <button
+                      onClick={() => handleLog(i, s)}
+                      disabled={state.logging}
+                      className="flex items-center gap-1.5 rounded-xl font-medium transition-opacity active:opacity-70 disabled:opacity-40"
+                      style={{
+                        background: "var(--color-primary)",
+                        color: "#fff",
+                        fontSize: 14,
+                        padding: "10px 14px",
+                        border: "none",
+                        cursor: "pointer",
+                      }}
+                    >
+                      {state.logging ? <Loader2 size={14} className="animate-spin" /> : "Log"}
+                    </button>
+                    <button
+                      onClick={() => setLogState(i, { open: false })}
+                      style={{ fontSize: 13, color: "var(--color-text-muted)", background: "none", border: "none", cursor: "pointer" }}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    onClick={() => setLogState(i, { open: true })}
+                    className="rounded-xl font-medium transition-opacity active:opacity-70"
+                    style={{
+                      background: "var(--color-primary)",
+                      color: "#fff",
+                      fontSize: 14,
+                      padding: "9px 16px",
+                      border: "none",
+                      cursor: "pointer",
+                    }}
+                  >
+                    Log this
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Root component ───────────────────────────────────────────────────────────
+
+export default function MealsClient({
+  todayMeals,
+  pastMeals,
+  recipes,
+  macroGoals,
+  macroTotals,
+}: Props) {
+  const [tab, setTab] = useState<Tab>("today");
+
+  return (
+    <div className="space-y-5">
+      {/* Tab bar — pill style matching GranularityToggle */}
+      <div
+        className="flex items-center gap-0.5 p-0.5 rounded-lg"
+        style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+      >
+        {TABS.map(({ id, label }) => {
+          const active = tab === id;
+          return (
+            <button
+              key={id}
+              onClick={() => setTab(id)}
+              className="flex-1 px-2.5 py-1.5 rounded-md text-xs font-medium transition-all duration-150"
+              style={{
+                background: active ? "var(--color-primary)" : "transparent",
+                color: active ? "#fff" : "var(--color-text-muted)",
+                border: "none",
+                cursor: "pointer",
+              }}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Tab panels */}
+      {tab === "today" && (
+        <TodayTab
+          todayMeals={todayMeals}
+          macroGoals={macroGoals}
+          macroTotals={macroTotals}
+        />
+      )}
+      {tab === "recipes" && <RecipesTab recipes={recipes} />}
+      {tab === "scanner" && <FoodPhotoAnalyzer />}
+      {tab === "plan" && (
+        <PlanTab macroTotals={macroTotals} macroGoals={macroGoals} />
+      )}
+
+      {/* Past meals — always visible below the tabs */}
+      {pastMeals.length > 0 && (
+        <PastMeals pastMeals={pastMeals} />
+      )}
+    </div>
+  );
+}
+
+// ─── Past Meals (below tabs, always visible) ──────────────────────────────────
+
+function fmtDate(d: string) {
+  return new Date(d + "T00:00:00").toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function PastMeals({ pastMeals }: { pastMeals: MealRow[] }) {
+  const byDate = new Map<string, MealRow[]>();
+  for (const meal of pastMeals) {
+    if (!byDate.has(meal.date)) byDate.set(meal.date, []);
+    byDate.get(meal.date)!.push(meal);
+  }
+  const dates = Array.from(byDate.keys());
+
+  return (
+    <div className="space-y-4">
+      <p
+        className="text-xs uppercase tracking-widest"
+        style={{ color: "var(--color-text-faint)", letterSpacing: "0.07em" }}
+      >
+        Past 6 Days
+      </p>
+      {dates.map((date) => {
+        const dayMeals = (byDate.get(date) ?? []).sort(
+          (a, b) => (MEAL_ORDER[a.meal_type] ?? 9) - (MEAL_ORDER[b.meal_type] ?? 9)
+        );
+        return (
+          <div
+            key={date}
+            className="rounded-xl p-5"
+            style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+          >
+            <p
+              className="text-xs uppercase tracking-widest mb-3"
+              style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}
+            >
+              {fmtDate(date)}
+            </p>
+            <div className="space-y-2">
+              {dayMeals.map((m) => {
+                const hasMacros = m.calories != null || m.protein_g != null;
+                const macroStr = hasMacros
+                  ? [
+                      m.calories != null && `${m.calories} cal`,
+                      m.protein_g != null && `P ${m.protein_g}g`,
+                      m.carbs_g != null && `C ${m.carbs_g}g`,
+                      m.fat_g != null && `F ${m.fat_g}g`,
+                    ]
+                      .filter(Boolean)
+                      .join(" · ")
+                  : null;
+                return (
+                  <div key={m.id} className="flex items-baseline gap-3">
+                    <span
+                      style={{
+                        fontSize: 11,
+                        fontWeight: 500,
+                        color: "var(--color-text-muted)",
+                        textTransform: "capitalize",
+                        minWidth: 64,
+                      }}
+                    >
+                      {m.meal_type}
+                    </span>
+                    <div>
+                      <span style={{ fontSize: 14, color: "var(--color-text)" }}>
+                        {m.recipes?.name ?? m.notes ?? "—"}
+                      </span>
+                      {macroStr && (
+                        <span style={{ fontSize: 11, color: "var(--color-text-faint)", marginLeft: 8 }}>
+                          {macroStr}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Meal Hub tabs** — `/meals` is now a four-tab layout (Today / Recipes / Scanner / Plan) via new `MealsClient.tsx` client component; server page fetches all data in parallel and passes it down as props
- **Today tab** — today's logged meals grouped by type, inline macro progress bars, quick-log form (meal type + description + collapsible macro fields)
- **Recipes tab** — searchable saved-recipe list; each card expands to show ingredients; "Use this recipe" logs it with meal type selection
- **Scanner tab** — `FoodPhotoAnalyzer` mounted as-is (pre-upload context textarea already existed)
- **Plan tab** — ingredient textarea → POST to new `/api/meals/suggest` → 2–3 Claude Sonnet suggestions calibrated to remaining macro budget; saved-recipe matches flagged; "Log this" inline logging
- **`/api/meals/suggest`** — new POST endpoint; auth-guarded; `generateObject` with Zod schema; checks saved recipes first, fills with general knowledge
- **Chat: `get_today_meals` tool** — read-only query of today's `meal_log`; Mr. Bridge must call this before making any claim about what's been eaten
- **Chat: `log_meal` removed** — meal logging is now exclusively done through the Meals tab; chat redirects logging requests to the UI
- **Nudge copy updated** — "ask Mr. Bridge for meal ideas" instead of "log meals via chat"

## Test plan

- [ ] Navigate to `/meals` — four tab pills render at top
- [ ] Today tab: macro bars match Settings goals; quick-log form logs and refreshes; "Add macros" toggle expands
- [ ] Recipes tab: search filters; card expand/collapse; "Use this recipe" → meal type → logs and refreshes
- [ ] Scanner tab: context textarea visible before upload; photo analysis works
- [ ] Plan tab: enter ingredients → suggestions load with macros and saved-recipe badges; "Log this" works
- [ ] Chat: ask "what have I eaten today?" → `get_today_meals` tool is called; asking to log a meal gets redirected to Meals tab
- [ ] `cd web && npx tsc --noEmit` passes (verified: exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)