### PR TITLE
fix: radial wheel clipping on mobile (#170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (radial wheel clipping on mobile — issue #170)
+- **`web/src/components/habits/radial-completion.tsx`** — increased `ResponsiveContainer` height from 220 → 260; reduced `outerRadius` from 90 → 80 to prevent outer rings from overflowing the card on 390px viewports
+
 ### Added (nutrition facts label scanner with serving multiplier and daily macro context — issue #165)
 - **`web/src/app/api/meals/analyze-photo/route.ts`** — added `NutritionLabelSchema` (product name, serving size, servings per container, calories, protein, carbs, fat, fiber, sugar, sodium, readable flag, notes); added optional `mode` form field (`food` | `label`, default `food`); in label mode calls `generateObject` with `NutritionLabelSchema` and an exact-read prompt; both modes now return `{ mode, ...object }` so the client can distinguish
 - **`web/src/app/api/meals/today-totals/route.ts`** — new auth-gated GET route; queries `meal_log` for today's date and returns summed `calories / protein_g / carbs_g / fat_g`

--- a/web/src/components/habits/radial-completion.tsx
+++ b/web/src/components/habits/radial-completion.tsx
@@ -75,12 +75,12 @@ export function RadialCompletion({ habits, weekLogs }: Props) {
       <p className="text-xs uppercase tracking-widest mb-2" style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}>
         Weekly Completion
       </p>
-      <ResponsiveContainer width="100%" height={220}>
+      <ResponsiveContainer width="100%" height={260}>
         <RadialBarChart
           cx="50%"
           cy="50%"
           innerRadius={20}
-          outerRadius={90}
+          outerRadius={80}
           data={data}
           startAngle={180}
           endAngle={-180}


### PR DESCRIPTION
## Summary
- Increased ResponsiveContainer height from 220 → 260
- Reduced outerRadius from 90 → 80

## Test plan
- [ ] Open /habits on a 390px viewport — all rings visible, no clipping
- [ ] Desktop layout unchanged