### PR TITLE
fix: chat session lost on mobile refresh (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (chat session lost on mobile tab switch and refresh — issue #171)
+- **`web/src/components/chat/chat-page-client.tsx`** — added `useEffect` to persist `activeSessionId` to `sessionStorage` on every change; added mount-time fallback that reads `sessionStorage` when `initialSessionId` is null (covers edge cases where SSR couldn't resolve the last session)
+- **`web/src/app/(protected)/chat/page.tsx`** — server-side fix was already in place (queries `chat_sessions` ordered by `last_active_at desc`, pre-loads `initialMessages`); no changes needed
+
 ### Fixed (radial wheel clipping on mobile — issue #170)
 - **`web/src/components/habits/radial-completion.tsx`** — increased `ResponsiveContainer` height from 220 → 260; reduced `outerRadius` from 90 → 80 to prevent outer rings from overflowing the card on 390px viewports
 

--- a/web/src/components/chat/chat-page-client.tsx
+++ b/web/src/components/chat/chat-page-client.tsx
@@ -40,6 +40,20 @@ export default function ChatPageClient({ initialSessionId, initialMessages }: Pr
     if (stored !== null) setHistoryOpen(stored === "true");
   }, []);
 
+  // Persist activeSessionId to sessionStorage on every change (belt-and-suspenders)
+  useEffect(() => {
+    sessionStorage.setItem("chatActiveSessionId", activeSessionId);
+  }, [activeSessionId]);
+
+  // On mount: if SSR couldn't provide a session, check sessionStorage as fallback
+  useEffect(() => {
+    if (!initialSessionId) {
+      const stored = sessionStorage.getItem("chatActiveSessionId");
+      if (stored) setActiveSessionId(stored);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const fetchSessions = useCallback(async () => {
     try {
       const res = await fetch("/api/chat/sessions");


### PR DESCRIPTION
## Summary
- `chat/page.tsx` already had the server-side fix (queries most recent session, pre-loads messages) — no change needed there
- `chat-page-client.tsx` now persists `activeSessionId` to `sessionStorage` on every change, and reads it as a fallback on mount when `initialSessionId` is null

## Cross-platform notes
Primarily a mobile issue (Brave iOS/Android, Safari, Chrome) because mobile browsers aggressively discard background tabs from memory — returning to the tab triggers a full page reload and loss of JS state. Desktop is affected only on hard refresh or browser restart. The SSR fix is the primary protection on all platforms; sessionStorage is belt-and-suspenders.

## Test plan
- [ ] Refresh /chat on mobile (Brave, Safari, Chrome) — previous conversation is restored
- [ ] Switch tabs and return on mobile — session still present
- [ ] New chat button still creates a fresh session
- [ ] Hard refresh on desktop — session restored via SSR
- [ ] No regression: desktop sidebar, session switching, load-more pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)