### PR TITLE
fix: replace broken FK join on Tasks page with two-query approach (#172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (tasks tab broken by relational join — issue #172)
+- **`web/src/app/(protected)/tasks/page.tsx`** — replaced `tasks!tasks_parent_id_fkey` relational join (which silently errored when the FK constraint name didn't match) with a separate subtasks query merged in JS; added `console.error` logging for all three query results so future failures surface in server logs
+- **`web/src/lib/types.ts`** — updated `Task.subtasks` from `Subtask[]` to `Task[]` to match the two-query merge approach
+
 ### Added (journal editor Submit button — issue #178)
 - **`web/src/components/journal/journal-editor.tsx`** — added explicit Submit button below the Reflect and Free Write tab content; on click flushes any pending debounce, saves immediately, clears form fields, shows a 3-second "Entry saved." confirmation banner, and scrolls to past entries
 - **`web/src/app/(protected)/journal/page.tsx`** — added `id="journal-history"` to the past-entries section so the editor can scroll to it after submit

--- a/web/src/app/(protected)/tasks/page.tsx
+++ b/web/src/app/(protected)/tasks/page.tsx
@@ -160,10 +160,10 @@ const priorityOrder = { high: 0, medium: 1, low: 2 };
 export default async function TasksPage() {
   const supabase = await createClient();
 
-  const [activeResult, completedResult] = await Promise.all([
+  const [activeResult, completedResult, subtasksResult] = await Promise.all([
     supabase
       .from("tasks")
-      .select("*, subtasks:tasks!tasks_parent_id_fkey(id, title, status, created_at)")
+      .select("*")
       .is("parent_id", null)
       .eq("status", "active")
       .order("created_at", { ascending: false }),
@@ -174,13 +174,32 @@ export default async function TasksPage() {
       .eq("status", "completed")
       .order("completed_at", { ascending: false })
       .limit(10),
+    supabase
+      .from("tasks")
+      .select("id, title, status, created_at, parent_id")
+      .not("parent_id", "is", null)
+      .eq("status", "active"),
   ]);
 
-  const tasks = ((activeResult.data ?? []) as Task[]).sort(
-    (a, b) =>
-      (priorityOrder[a.priority ?? "low"] ?? 2) -
-      (priorityOrder[b.priority ?? "low"] ?? 2)
-  );
+  if (activeResult.error)    console.error("[tasks] active query error:", activeResult.error.message);
+  if (completedResult.error) console.error("[tasks] completed query error:", completedResult.error.message);
+  if (subtasksResult.error)  console.error("[tasks] subtasks query error:", subtasksResult.error.message);
+
+  const subtasksByParent = new Map<string, Task[]>();
+  for (const s of (subtasksResult.data ?? []) as Task[]) {
+    if (!s.parent_id) continue;
+    const arr = subtasksByParent.get(s.parent_id) ?? [];
+    arr.push(s);
+    subtasksByParent.set(s.parent_id, arr);
+  }
+
+  const tasks = ((activeResult.data ?? []) as Task[])
+    .map((t) => ({ ...t, subtasks: subtasksByParent.get(t.id) ?? [] }))
+    .sort(
+      (a, b) =>
+        (priorityOrder[a.priority ?? "low"] ?? 2) -
+        (priorityOrder[b.priority ?? "low"] ?? 2)
+    );
   const completedTasks = (completedResult.data ?? []) as Task[];
 
   const high   = tasks.filter((t) => t.priority === "high");

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -32,7 +32,7 @@ export interface Task {
   completed_at: string | null;
   created_at: string;
   parent_id: string | null;
-  subtasks?: Subtask[];
+  subtasks?: Task[];
 }
 
 export interface FitnessLog {


### PR DESCRIPTION
## Summary
- Removes the Supabase relational join \`tasks!tasks_parent_id_fkey\` which was silently erroring and causing the Tasks tab to show no tasks
- Replaces it with a separate subtasks query; results are merged in JS before rendering
- Adds \`console.error\` logging for all three query results so future failures are visible in server logs

## Test plan
- [ ] Tasks created via Bridge chat now appear in the Tasks tab
- [ ] Manually added tasks appear immediately after adding
- [ ] Subtasks still render under their parent task
- [ ] Completing a subtask still auto-completes the parent when all siblings are done
- [ ] \`cd web && npx tsc --noEmit\` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)