### PR TITLE
feat: journal two-tab redesign (Write + History)

### DIFF
--- a/web/src/app/(protected)/journal/page.tsx
+++ b/web/src/app/(protected)/journal/page.tsx
@@ -2,8 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
-import JournalEditor from "@/components/journal/journal-editor";
-import JournalHistory from "@/components/journal/journal-history";
+import JournalTabs from "@/components/journal/journal-tabs";
 import type { JournalEntry, JournalResponses } from "@/lib/types";
 import { todayString } from "@/lib/timezone";
 
@@ -37,18 +36,17 @@ export default async function JournalPage() {
   const supabase = await createClient();
   const today = todayString();
 
-  const [todayResult, historyResult] = await Promise.all([
+  const [todayResult, allResult] = await Promise.all([
     supabase.from("journal_entries").select("*").eq("date", today).maybeSingle(),
     supabase
       .from("journal_entries")
       .select("*")
-      .neq("date", today)
       .order("date", { ascending: false })
-      .limit(30),
+      .limit(31),
   ]);
 
   const todayEntry  = todayResult.data as JournalEntry | null;
-  const pastEntries = (historyResult.data ?? []) as JournalEntry[];
+  const allEntries  = (allResult.data ?? []) as JournalEntry[];
 
   const dateLabel = new Date(today + "T00:00:00").toLocaleDateString("en-US", {
     weekday: "long",
@@ -68,26 +66,13 @@ export default async function JournalPage() {
         </p>
       </div>
 
-      {/* Today's editor */}
-      <JournalEditor
-        date={today}
+      <JournalTabs
+        today={today}
         initialResponses={todayEntry?.responses ?? {}}
         initialFreeWrite={todayEntry?.free_write ?? ""}
+        allEntries={allEntries}
         saveAction={saveJournalEntry}
       />
-
-      {/* Past entries */}
-      {pastEntries.length > 0 && (
-        <section id="journal-history">
-          <p
-            className="text-xs uppercase tracking-widest mb-3"
-            style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}
-          >
-            Past Entries
-          </p>
-          <JournalHistory entries={pastEntries} />
-        </section>
-      )}
     </div>
   );
 }

--- a/web/src/components/journal/journal-editor.tsx
+++ b/web/src/components/journal/journal-editor.tsx
@@ -61,7 +61,6 @@ export default function JournalEditor({
   const [responses, setResponses]   = useState<JournalResponses>(initialResponses);
   const [freeWrite, setFreeWrite]   = useState(initialFreeWrite);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
-  const [submitted, setSubmitted]   = useState(false);
   const [, startTransition]         = useTransition();
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -97,16 +96,15 @@ export default function JournalEditor({
     scheduleAutoSave(responses, value);
   }
 
-  function handleSubmit() {
+  async function handleSubmit() {
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = null;
-    triggerSave(responses, freeWrite);
+    setSaveStatus("saving");
+    await saveAction(date, responses, freeWrite);
+    setSaveStatus("saved");
     setResponses({});
     setFreeWrite("");
-    setSubmitted(true);
-    document.getElementById("journal-history")?.scrollIntoView({ behavior: "smooth" });
     onSubmit?.();
-    setTimeout(() => setSubmitted(false), 3000);
   }
 
   // Clear debounce on unmount
@@ -157,15 +155,7 @@ export default function JournalEditor({
         </span>
       </div>
 
-      {/* Confirmation banner */}
-      {submitted ? (
-        <div className="p-5 flex items-center justify-center" style={{ minHeight: 120 }}>
-          <p className="text-sm font-medium" style={{ color: "var(--color-positive)" }}>
-            Entry saved.
-          </p>
-        </div>
-      ) : (
-        <>
+      <>
           {/* Reflect tab */}
           {tab === "reflect" && (
             <div className="p-5 space-y-5">
@@ -258,7 +248,6 @@ export default function JournalEditor({
             </button>
           </div>
         </>
-      )}
     </div>
   );
 }

--- a/web/src/components/journal/journal-history.tsx
+++ b/web/src/components/journal/journal-history.tsx
@@ -14,9 +14,11 @@ const PROMPT_LABELS: Record<string, string> = {
 
 interface Props {
   entries: JournalEntry[];
+  today?: string;
+  onEdit?: (entry: JournalEntry) => void;
 }
 
-export default function JournalHistory({ entries }: Props) {
+export default function JournalHistory({ entries, today, onEdit }: Props) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
   function toggle(id: string) {
@@ -29,20 +31,23 @@ export default function JournalHistory({ entries }: Props) {
 
   if (entries.length === 0) {
     return (
-      <p style={{ fontSize: 14, color: "var(--color-text-faint)" }}>No past entries yet.</p>
+      <p style={{ fontSize: 14, color: "var(--color-text-faint)" }}>No entries yet.</p>
     );
   }
 
   return (
     <div className="space-y-2">
       {entries.map((entry) => {
-        const isOpen = expanded.has(entry.id);
-        const date   = new Date(entry.date + "T00:00:00");
-        const dateLabel = date.toLocaleDateString("en-US", {
-          weekday: "short",
-          month:   "short",
-          day:     "numeric",
-        });
+        const isOpen    = expanded.has(entry.id);
+        const isToday   = today && entry.date === today;
+        const date      = new Date(entry.date + "T00:00:00");
+        const dateLabel = isToday
+          ? "Today"
+          : date.toLocaleDateString("en-US", {
+              weekday: "short",
+              month:   "short",
+              day:     "numeric",
+            });
 
         // Preview: first filled reflect response or first line of free write
         const preview =
@@ -61,32 +66,47 @@ export default function JournalHistory({ entries }: Props) {
             style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
           >
             {/* Accordion header */}
-            <button
-              className="w-full flex items-center gap-3 px-4 py-3 text-left"
-              onClick={() => toggle(entry.id)}
-            >
-              <span style={{ color: "var(--color-text-muted)", flexShrink: 0 }}>
-                {isOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-              </span>
-
-              <span
-                className="text-xs font-medium flex-shrink-0"
-                style={{ color: "var(--color-text-muted)", minWidth: 88 }}
+            <div className="flex items-center">
+              <button
+                className="flex-1 flex items-center gap-3 px-4 py-3 text-left"
+                onClick={() => toggle(entry.id)}
               >
-                {dateLabel}
-              </span>
+                <span style={{ color: "var(--color-text-muted)", flexShrink: 0 }}>
+                  {isOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                </span>
 
-              {!isOpen && (
                 <span
-                  className="text-sm truncate"
+                  className="text-xs font-medium flex-shrink-0"
+                  style={{
+                    color:    isToday ? "var(--color-primary)" : "var(--color-text-muted)",
+                    minWidth: 88,
+                  }}
+                >
+                  {dateLabel}
+                </span>
+
+                {!isOpen && (
+                  <span
+                    className="text-sm truncate"
+                    style={{ color: "var(--color-text-faint)" }}
+                  >
+                    {preview
+                      ? preview.slice(0, 80) + (preview.length > 80 ? "…" : "")
+                      : "No responses"}
+                  </span>
+                )}
+              </button>
+
+              {onEdit && (
+                <button
+                  onClick={() => onEdit(entry)}
+                  className="px-4 py-3 text-xs flex-shrink-0"
                   style={{ color: "var(--color-text-faint)" }}
                 >
-                  {preview
-                    ? preview.slice(0, 80) + (preview.length > 80 ? "…" : "")
-                    : "No responses"}
-                </span>
+                  Edit
+                </button>
               )}
-            </button>
+            </div>
 
             {/* Expanded body */}
             {isOpen && (

--- a/web/src/components/journal/journal-tabs.tsx
+++ b/web/src/components/journal/journal-tabs.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState } from "react";
+import JournalEditor from "./journal-editor";
+import JournalHistory from "./journal-history";
+import type { JournalEntry, JournalResponses } from "@/lib/types";
+
+type OuterTab = "write" | "history";
+
+interface Props {
+  today: string;
+  initialResponses: JournalResponses;
+  initialFreeWrite: string;
+  allEntries: JournalEntry[];
+  saveAction: (
+    date: string,
+    responses: JournalResponses,
+    freeWrite: string
+  ) => Promise<{ error?: string }>;
+}
+
+export default function JournalTabs({
+  today,
+  initialResponses,
+  initialFreeWrite,
+  allEntries,
+  saveAction,
+}: Props) {
+  const [tab, setTab]                     = useState<OuterTab>("write");
+  const [editingEntry, setEditingEntry]   = useState<JournalEntry | null>(null);
+
+  const isEditingPast = editingEntry !== null;
+  const editorDate    = editingEntry?.date ?? today;
+  const editorResponses  = editingEntry?.responses  ?? initialResponses;
+  const editorFreeWrite  = editingEntry?.free_write ?? initialFreeWrite ?? "";
+
+  function handleEditEntry(entry: JournalEntry) {
+    setEditingEntry(entry);
+    setTab("write");
+  }
+
+  function handleSubmit() {
+    setEditingEntry(null);
+    setTab("history");
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Outer tab bar */}
+      <div
+        className="flex gap-1 p-1 rounded-xl self-start"
+        style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", display: "inline-flex" }}
+      >
+        {([["write", "Write"], ["history", "History"]] as [OuterTab, string][]).map(([t, label]) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className="px-4 py-1.5 rounded-lg text-sm font-medium transition-colors"
+            style={{
+              background: tab === t ? "var(--color-primary)"     : "transparent",
+              color:      tab === t ? "var(--color-primary-foreground)" : "var(--color-text-muted)",
+            }}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Write tab */}
+      {tab === "write" && (
+        <div className="space-y-3">
+          {isEditingPast && (
+            <div className="flex items-center gap-3">
+              <button
+                onClick={() => { setEditingEntry(null); }}
+                className="text-xs"
+                style={{ color: "var(--color-text-muted)" }}
+              >
+                ← Back to today
+              </button>
+              <span className="text-xs" style={{ color: "var(--color-text-faint)" }}>
+                Editing{" "}
+                {new Date(editingEntry.date + "T00:00:00").toLocaleDateString("en-US", {
+                  weekday: "long", month: "long", day: "numeric",
+                })}
+              </span>
+            </div>
+          )}
+          <JournalEditor
+            key={editingEntry?.id ?? "today"}
+            date={editorDate}
+            initialResponses={editorResponses}
+            initialFreeWrite={editorFreeWrite}
+            saveAction={saveAction}
+            onSubmit={handleSubmit}
+          />
+        </div>
+      )}
+
+      {/* History tab */}
+      {tab === "history" && (
+        <JournalHistory
+          entries={allEntries}
+          today={today}
+          onEdit={handleEditEntry}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replaces the single-page layout with two outer tabs: **Write** (editor) and **History** (all entries)
- **Fixes #178**: after Submit, the app switches to the History tab instead of showing the same filled-in form — no more stale data on refresh
- History tab shows all entries including today's (labeled **Today**); each row has an **Edit** button
- Editing a past entry loads it into the Write tab with a "← Back to today" label; saves via the existing upsert

## Changes
- **New**: `web/src/components/journal/journal-tabs.tsx` — outer Write/History tab wrapper
- **Modified**: `journal-editor.tsx` — `handleSubmit` now `await`s save before calling `onSubmit()`; removed 3-second submitted banner
- **Modified**: `journal-history.tsx` — added `today` prop (Today label), `onEdit` callback, Edit button per row
- **Modified**: `journal/page.tsx` — fetches all entries (no longer excludes today); renders `JournalTabs`

## Test plan
- [ ] Write a reflect entry → Submit → auto-switches to History tab; today's entry visible with **Today** label
- [ ] Click Write tab → form is empty
- [ ] Hard refresh → lands on Write tab with today's draft pre-filled (expected upsert behavior)
- [ ] Auto-save: type, wait 1.5s → "Saved" indicator appears
- [ ] History tab: click **Edit** on a past entry → Write tab opens pre-filled with "← Back to today" label
- [ ] Edit past entry → Submit → switches back to History; changes reflected

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)