### PR TITLE
fix/feat: meal log editing, emoji picker, habit edit form, task dedup (#173 #174 #175 #176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (task due date label off-by-one — issue #184)
+- **`web/src/components/tasks/task-item.tsx`** — `relativeDue` now compares two midnights using `todayString()` from `@/lib/timezone` instead of subtracting `Date.now()`, eliminating the off-by-one that showed tomorrow's tasks as "Today" late in the evening
+
 ### Fixed (tasks tab broken by relational join — issue #172)
 - **`web/src/app/(protected)/tasks/page.tsx`** — replaced `tasks!tasks_parent_id_fkey` relational join (which silently errored when the FK constraint name didn't match) with a separate subtasks query merged in JS; added `console.error` logging for all three query results so future failures surface in server logs
 - **`web/src/lib/types.ts`** — updated `Task.subtasks` from `Subtask[]` to `Task[]` to match the two-query merge approach

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (deduplicate add_task inserts — issue #176)
+- **`web/src/app/api/chat/route.ts`** — added 90-second deduplication window to `add_task` execute; before inserting, queries for an active task with the same title (case-insensitive) and due_date created in the last 90 seconds; returns the existing row instead of inserting a duplicate (guards against `retryOnOverload` stream-retry double-inserts)
+
+### Fixed (habit edit form — issue #175)
+- **`web/src/app/(protected)/habits/page.tsx`** — added `updateHabit` server action that updates `name`, `emoji`, and `category` on `habit_registry`, scoped to authenticated user; passed as `updateAction` prop to `HabitTodaySection`
+- **`web/src/components/habits/habit-today-section.tsx`** — added `updateAction` to Props interface and passes it down to each `HabitToggle`
+- **`web/src/components/habits/habit-toggle.tsx`** — added `updateAction` prop, local edit state (`editing`, `editName`, `editEmoji`, `editCategory`), and an inline edit form with emoji/name/category inputs and Save/Cancel buttons; shown when manageMode is true and Edit is clicked
+
+### Added (emoji picker for Add Habit form — issue #174)
+- **`web/src/components/habits/habit-today-section.tsx`** — replaced plain emoji text input with an `emoji-picker-react` popover button; closes on emoji selection or outside click
+- **`web/package.json`** — added `emoji-picker-react` dependency
+
+### Added (meal log inline editing — issue #173)
+- **`web/src/app/api/meals/log/route.ts`** — added `PATCH` handler; accepts `id`, `notes`, `meal_type`, `calories`, `protein_g`, `carbs_g`, `fat_g`; validates meal_type; scoped to authenticated user's rows via `.eq("user_id", user.id)`
+- **`web/src/components/meals/MealsClient.tsx`** — added inline edit state and form to both `TodayTab` and `PastMeals`; tapping a meal row enters edit mode with pre-filled fields; Save calls `PATCH /api/meals/log` then refreshes; Cancel discards changes
+
 ### Fixed (task due date label off-by-one — issue #184)
 - **`web/src/components/tasks/task-item.tsx`** — `relativeDue` now compares two midnights using `todayString()` from `@/lib/timezone` instead of subtracting `Date.now()`, eliminating the off-by-one that showed tomorrow's tasks as "Today" late in the evening
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.49.4",
         "ai": "^4.3.15",
+        "emoji-picker-react": "^4.18.0",
         "googleapis": "^171.4.0",
         "lucide-react": "^0.511.0",
         "next": "^15.3.1",
@@ -1913,6 +1914,21 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/emoji-picker-react": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-4.18.0.tgz",
+      "integrity": "sha512-vLTrLfApXAIciguGE57pXPWs9lPLBspbEpPMiUq03TIli2dHZBiB+aZ0R9/Wat0xmTfcd4AuEzQgSYxEZ8C88Q==",
+      "license": "MIT",
+      "dependencies": {
+        "flairup": "1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
@@ -2022,6 +2038,12 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
+    },
+    "node_modules/flairup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/flairup/-/flairup-1.0.0.tgz",
+      "integrity": "sha512-IKlE+pNvL2R+kVL1kEhUYqRxVqeFnjiIvHWDMLFXNaqyUdFXQM2wte44EfMYJNHkW16X991t2Zg8apKkhv7OBA==",
+      "license": "MIT"
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.49.4",
     "ai": "^4.3.15",
+    "emoji-picker-react": "^4.18.0",
     "googleapis": "^171.4.0",
     "lucide-react": "^0.511.0",
     "next": "^15.3.1",

--- a/web/src/app/(protected)/habits/page.tsx
+++ b/web/src/app/(protected)/habits/page.tsx
@@ -55,6 +55,23 @@ async function archiveHabit(habitId: string) {
   revalidatePath("/dashboard");
 }
 
+async function updateHabit(id: string, name: string, emoji: string, category: string) {
+  "use server";
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return;
+  await supabase
+    .from("habit_registry")
+    .update({
+      name: name.trim(),
+      emoji: emoji.trim() || null,
+      category: category.trim() || null,
+    })
+    .eq("id", id)
+    .eq("user_id", user.id);
+  revalidatePath("/habits");
+}
+
 export default async function HabitsPage() {
   const supabase = await createClient();
   const today = todayString();
@@ -126,6 +143,7 @@ export default async function HabitsPage() {
         toggleAction={toggleHabit}
         archiveAction={archiveHabit}
         addAction={addHabit}
+        updateAction={updateHabit}
       />
 
       {habits.length > 0 && (

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -357,6 +357,26 @@ When asked what to cook or for recipe ideas:
         if (due_date && !/^\d{4}-\d{2}-\d{2}$/.test(due_date)) {
           return { error: `due_date must be YYYY-MM-DD format, got: "${due_date}"` };
         }
+
+        // Deduplication guard — prevents double-inserts from stream retries
+        const windowStart = new Date(Date.now() - 90_000).toISOString();
+        let dupQuery = supabase
+          .from("tasks")
+          .select("id, title, priority, status, due_date, category, parent_id, created_at")
+          .eq("user_id", userId)
+          .eq("status", "active")
+          .ilike("title", title.trim())
+          .gte("created_at", windowStart);
+
+        if (due_date) {
+          dupQuery = dupQuery.eq("due_date", due_date);
+        } else {
+          dupQuery = dupQuery.is("due_date", null);
+        }
+
+        const { data: existing } = await dupQuery.maybeSingle();
+        if (existing) return existing;
+
         const { data, error } = await supabase
           .from("tasks")
           .insert({

--- a/web/src/app/api/meals/log/route.ts
+++ b/web/src/app/api/meals/log/route.ts
@@ -56,3 +56,52 @@ export async function POST(req: Request) {
 
   return Response.json(data, { status: 201 });
 }
+
+interface MealLogPatchBody {
+  id: string;
+  notes?: string;
+  meal_type?: "breakfast" | "lunch" | "dinner" | "snack";
+  calories?: number | null;
+  protein_g?: number | null;
+  carbs_g?: number | null;
+  fat_g?: number | null;
+}
+
+export async function PATCH(req: Request) {
+  let body: MealLogPatchBody;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.id) return Response.json({ error: "id is required" }, { status: 400 });
+
+  const validTypes = ["breakfast", "lunch", "dinner", "snack"];
+  if (body.meal_type && !validTypes.includes(body.meal_type)) {
+    return Response.json({ error: "Invalid meal_type" }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return Response.json({ error: "Unauthorized" }, { status: 401 });
+
+  const updates: Record<string, unknown> = {};
+  if (body.notes     !== undefined) updates.notes      = body.notes;
+  if (body.meal_type !== undefined) updates.meal_type  = body.meal_type;
+  if (body.calories  !== undefined) updates.calories   = body.calories;
+  if (body.protein_g !== undefined) updates.protein_g  = body.protein_g;
+  if (body.carbs_g   !== undefined) updates.carbs_g    = body.carbs_g;
+  if (body.fat_g     !== undefined) updates.fat_g      = body.fat_g;
+
+  const { data, error } = await supabase
+    .from("meal_log")
+    .update(updates)
+    .eq("id", body.id)
+    .eq("user_id", user.id)
+    .select()
+    .single();
+
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+  return Response.json(data);
+}

--- a/web/src/components/habits/habit-today-section.tsx
+++ b/web/src/components/habits/habit-today-section.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useRef, useEffect } from "react";
 import HabitToggle from "./habit-toggle";
 import type { HabitRegistry, HabitLog } from "@/lib/types";
+import EmojiPicker, { type EmojiClickData } from "emoji-picker-react";
 
 interface Props {
   habits: HabitRegistry[];
@@ -11,6 +12,7 @@ interface Props {
   toggleAction: (habitId: string, date: string, completed: boolean) => Promise<void>;
   archiveAction: (habitId: string) => Promise<void>;
   addAction: (name: string, emoji: string, category: string) => Promise<void>;
+  updateAction: (id: string, name: string, emoji: string, category: string) => Promise<void>;
 }
 
 export default function HabitTodaySection({
@@ -20,6 +22,7 @@ export default function HabitTodaySection({
   toggleAction,
   archiveAction,
   addAction,
+  updateAction,
 }: Props) {
   const todayLogMap = new Map(todayLogs.map((l) => [l.habit_id, l]));
 
@@ -29,6 +32,19 @@ export default function HabitTodaySection({
   const [emoji, setEmoji] = useState("");
   const [category, setCategory] = useState("");
   const [isPending, startTransition] = useTransition();
+  const [showEmojiPicker, setShowEmojiPicker] = useState(false);
+  const pickerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!showEmojiPicker) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+        setShowEmojiPicker(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [showEmojiPicker]);
 
   function handleAdd() {
     if (!name.trim()) return;
@@ -92,6 +108,7 @@ export default function HabitTodaySection({
             date={date}
             manageMode={manageMode}
             archiveAction={archiveAction}
+            updateAction={updateAction}
           />
         ))}
         {habits.length === 0 && !showAdd && (
@@ -101,14 +118,31 @@ export default function HabitTodaySection({
 
       {showAdd && (
         <div className="mt-3 flex flex-wrap items-center gap-2 py-3 border-t border-neutral-800/50">
-          <input
-            type="text"
-            placeholder="Emoji"
-            value={emoji}
-            onChange={(e) => setEmoji(e.target.value)}
-            maxLength={4}
-            className="w-14 bg-neutral-800 text-neutral-100 text-sm rounded px-2 py-1.5 placeholder-neutral-600 focus:outline-none focus:ring-1 focus:ring-neutral-600"
-          />
+          <div className="relative" ref={pickerRef}>
+            <button
+              type="button"
+              onClick={() => setShowEmojiPicker((v) => !v)}
+              className="w-10 h-8 bg-neutral-800 text-neutral-100 text-lg rounded flex items-center justify-center focus:outline-none focus:ring-1 focus:ring-neutral-600"
+              title="Pick emoji"
+            >
+              {emoji || "😀"}
+            </button>
+            {showEmojiPicker && (
+              <div className="absolute left-0 top-10 z-50">
+                <EmojiPicker
+                  onEmojiClick={(data: EmojiClickData) => {
+                    setEmoji(data.emoji);
+                    setShowEmojiPicker(false);
+                  }}
+                  width={300}
+                  height={400}
+                  searchDisabled={false}
+                  skinTonesDisabled
+                  previewConfig={{ showPreview: false }}
+                />
+              </div>
+            )}
+          </div>
           <input
             type="text"
             placeholder="Habit name"

--- a/web/src/components/habits/habit-toggle.tsx
+++ b/web/src/components/habits/habit-toggle.tsx
@@ -10,6 +10,7 @@ interface Props {
   date: string;
   manageMode?: boolean;
   archiveAction?: (habitId: string) => Promise<void>;
+  updateAction?: (id: string, name: string, emoji: string, category: string) => Promise<void>;
 }
 
 export default function HabitToggle({
@@ -19,10 +20,16 @@ export default function HabitToggle({
   date,
   manageMode,
   archiveAction,
+  updateAction,
 }: Props) {
   const [optimistic, setOptimistic] = useState<boolean | undefined>(log?.completed);
   const [isPending, startTransition] = useTransition();
   const [archivePending, startArchiveTransition] = useTransition();
+  const [editing, setEditing] = useState(false);
+  const [editName, setEditName] = useState(habit.name);
+  const [editEmoji, setEditEmoji] = useState(habit.emoji ?? "");
+  const [editCategory, setEditCategory] = useState(habit.category ?? "");
+  const [editPending, startEditTransition] = useTransition();
 
   const completed = optimistic ?? false;
 
@@ -46,49 +53,115 @@ export default function HabitToggle({
   }
 
   return (
-    <div className={`flex items-center ${isPending || archivePending ? "opacity-60" : ""}`}>
-      <button
-        onClick={handleToggle}
-        disabled={isPending || archivePending}
-        className="flex-1 flex items-center gap-3 py-3 px-1 text-left hover:bg-neutral-800/50 rounded-lg transition-colors"
-      >
-        <span
-          className={`w-5 h-5 rounded-md border flex items-center justify-center flex-shrink-0 transition-colors ${
-            completed ? "bg-blue-500 border-blue-500" : "border-neutral-600"
-          }`}
-        >
-          {completed && (
-            <svg className="w-3 h-3 text-white" viewBox="0 0 12 12" fill="none">
-              <path
-                d="M2 6l3 3 5-5"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          )}
-        </span>
-        <span className="text-lg leading-none">{habit.emoji}</span>
-        <span
-          className={`text-sm ${completed ? "text-neutral-500 line-through" : "text-neutral-200"}`}
-        >
-          {habit.name}
-        </span>
-        {!manageMode && habit.category && (
-          <span className="ml-auto text-xs text-neutral-600">{habit.category}</span>
-        )}
-      </button>
-      {manageMode && archiveAction ? (
-        <button
-          onClick={handleArchive}
-          disabled={archivePending}
-          className="ml-2 text-xs text-neutral-600 hover:text-red-400 px-1 py-3 transition-colors disabled:opacity-40"
-          title="Archive habit"
-        >
-          ✕
-        </button>
-      ) : null}
+    <div className={`flex items-center ${isPending || archivePending || editPending ? "opacity-60" : ""}`}>
+      {editing ? (
+        <div className="flex-1 flex flex-wrap items-center gap-2 py-2 px-1">
+          <input
+            type="text"
+            value={editEmoji}
+            onChange={(e) => setEditEmoji(e.target.value)}
+            maxLength={4}
+            className="w-10 bg-neutral-800 text-neutral-100 text-sm rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-neutral-600"
+            placeholder="😀"
+          />
+          <input
+            type="text"
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            className="flex-1 min-w-[100px] bg-neutral-800 text-neutral-100 text-sm rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-neutral-600"
+            placeholder="Habit name"
+          />
+          <input
+            type="text"
+            value={editCategory}
+            onChange={(e) => setEditCategory(e.target.value)}
+            className="w-24 bg-neutral-800 text-neutral-100 text-sm rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-neutral-600"
+            placeholder="Category"
+          />
+          <button
+            disabled={!editName.trim() || editPending}
+            onClick={() => {
+              startEditTransition(async () => {
+                await updateAction?.(habit.id, editName, editEmoji, editCategory);
+                setEditing(false);
+              });
+            }}
+            className="text-xs px-2 py-1 bg-neutral-700 text-neutral-100 rounded hover:bg-neutral-600 disabled:opacity-40"
+          >
+            Save
+          </button>
+          <button
+            onClick={() => {
+              setEditName(habit.name);
+              setEditEmoji(habit.emoji ?? "");
+              setEditCategory(habit.category ?? "");
+              setEditing(false);
+            }}
+            className="text-xs px-2 py-1 text-neutral-500 hover:text-neutral-300"
+          >
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <>
+          <button
+            onClick={handleToggle}
+            disabled={isPending || archivePending}
+            className="flex-1 flex items-center gap-3 py-3 px-1 text-left hover:bg-neutral-800/50 rounded-lg transition-colors"
+          >
+            <span
+              className={`w-5 h-5 rounded-md border flex items-center justify-center flex-shrink-0 transition-colors ${
+                completed ? "bg-blue-500 border-blue-500" : "border-neutral-600"
+              }`}
+            >
+              {completed && (
+                <svg className="w-3 h-3 text-white" viewBox="0 0 12 12" fill="none">
+                  <path
+                    d="M2 6l3 3 5-5"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              )}
+            </span>
+            <span className="text-lg leading-none">{habit.emoji}</span>
+            <span
+              className={`text-sm ${completed ? "text-neutral-500 line-through" : "text-neutral-200"}`}
+            >
+              {habit.name}
+            </span>
+            {!manageMode && habit.category && (
+              <span className="ml-auto text-xs text-neutral-600">{habit.category}</span>
+            )}
+          </button>
+          {manageMode ? (
+            <>
+              {updateAction && (
+                <button
+                  onClick={() => setEditing(true)}
+                  disabled={archivePending}
+                  className="ml-1 text-xs text-neutral-600 hover:text-neutral-300 px-1 py-3 transition-colors disabled:opacity-40"
+                  title="Edit habit"
+                >
+                  Edit
+                </button>
+              )}
+              {archiveAction && (
+                <button
+                  onClick={handleArchive}
+                  disabled={archivePending}
+                  className="ml-1 text-xs text-neutral-600 hover:text-red-400 px-1 py-3 transition-colors disabled:opacity-40"
+                  title="Archive habit"
+                >
+                  ✕
+                </button>
+              )}
+            </>
+          ) : null}
+        </>
+      )}
     </div>
   );
 }

--- a/web/src/components/meals/MealsClient.tsx
+++ b/web/src/components/meals/MealsClient.tsx
@@ -168,6 +168,43 @@ function TodayTab({
   const [logCarbs, setLogCarbs] = useState("");
   const [logFat, setLogFat] = useState("");
   const [logging, setLogging] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editFields, setEditFields] = useState<{
+    notes: string; meal_type: string; calories: string; protein_g: string; carbs_g: string; fat_g: string;
+  }>({ notes: "", meal_type: "breakfast", calories: "", protein_g: "", carbs_g: "", fat_g: "" });
+  const [editSaving, setEditSaving] = useState(false);
+
+  function startEdit(m: MealRow) {
+    setEditingId(m.id);
+    setEditFields({
+      notes: m.notes ?? "",
+      meal_type: m.meal_type,
+      calories: m.calories != null ? String(m.calories) : "",
+      protein_g: m.protein_g != null ? String(m.protein_g) : "",
+      carbs_g: m.carbs_g != null ? String(m.carbs_g) : "",
+      fat_g: m.fat_g != null ? String(m.fat_g) : "",
+    });
+  }
+
+  async function saveEdit(id: string) {
+    setEditSaving(true);
+    await fetch("/api/meals/log", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id,
+        notes: editFields.notes || null,
+        meal_type: editFields.meal_type,
+        calories: editFields.calories ? Number(editFields.calories) : null,
+        protein_g: editFields.protein_g ? Number(editFields.protein_g) : null,
+        carbs_g: editFields.carbs_g ? Number(editFields.carbs_g) : null,
+        fat_g: editFields.fat_g ? Number(editFields.fat_g) : null,
+      }),
+    });
+    setEditSaving(false);
+    setEditingId(null);
+    router.refresh();
+  }
 
   const hasAnyGoal =
     macroGoals.calories !== null ||
@@ -281,28 +318,82 @@ function TodayTab({
                     .join(" · ")
                 : null;
               return (
-                <div key={m.id} className="flex items-baseline gap-3">
-                  <span
-                    style={{
-                      fontSize: 11,
-                      fontWeight: 500,
-                      color: "var(--color-text-muted)",
-                      textTransform: "capitalize",
-                      minWidth: 64,
-                    }}
-                  >
-                    {m.meal_type}
-                  </span>
-                  <div>
-                    <span style={{ fontSize: 14, color: "var(--color-text)" }}>
-                      {m.recipes?.name ?? m.notes ?? "—"}
-                    </span>
-                    {macroStr && (
-                      <span style={{ fontSize: 11, color: "var(--color-text-faint)", marginLeft: 8 }}>
-                        {macroStr}
+                <div key={m.id}>
+                  {editingId === m.id ? (
+                    <div className="space-y-2 py-1">
+                      <div className="flex gap-2">
+                        <select
+                          value={editFields.meal_type}
+                          onChange={(e) => setEditFields((f) => ({ ...f, meal_type: e.target.value }))}
+                          style={{ ...inputStyle, width: "auto", minWidth: 110, flexShrink: 0 }}
+                        >
+                          {MEAL_TYPES.map((t) => <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>)}
+                        </select>
+                        <input
+                          type="text"
+                          value={editFields.notes}
+                          onChange={(e) => setEditFields((f) => ({ ...f, notes: e.target.value }))}
+                          placeholder="Food name"
+                          style={{ ...inputStyle, flex: 1 }}
+                        />
+                      </div>
+                      <div className="flex gap-2">
+                        {(["calories", "protein_g", "carbs_g", "fat_g"] as const).map((field) => (
+                          <input
+                            key={field}
+                            type="number"
+                            value={editFields[field]}
+                            onChange={(e) => setEditFields((f) => ({ ...f, [field]: e.target.value }))}
+                            placeholder={{ calories: "Cal", protein_g: "P(g)", carbs_g: "C(g)", fat_g: "F(g)" }[field]}
+                            style={{ ...inputStyle, width: 68 }}
+                          />
+                        ))}
+                      </div>
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => saveEdit(m.id)}
+                          disabled={editSaving}
+                          style={{ fontSize: 13, padding: "4px 12px", background: "var(--color-primary)", color: "var(--color-primary-foreground)", border: "none", borderRadius: 6, cursor: "pointer", opacity: editSaving ? 0.5 : 1 }}
+                        >
+                          {editSaving ? "Saving…" : "Save"}
+                        </button>
+                        <button
+                          onClick={() => setEditingId(null)}
+                          style={{ fontSize: 13, padding: "4px 12px", color: "var(--color-text-muted)", background: "none", border: "none", cursor: "pointer" }}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div
+                      className="flex items-baseline gap-3"
+                      onClick={() => startEdit(m)}
+                      style={{ cursor: "pointer" }}
+                    >
+                      <span
+                        style={{
+                          fontSize: 11,
+                          fontWeight: 500,
+                          color: "var(--color-text-muted)",
+                          textTransform: "capitalize",
+                          minWidth: 64,
+                        }}
+                      >
+                        {m.meal_type}
                       </span>
-                    )}
-                  </div>
+                      <div>
+                        <span style={{ fontSize: 14, color: "var(--color-text)" }}>
+                          {m.recipes?.name ?? m.notes ?? "—"}
+                        </span>
+                        {macroStr && (
+                          <span style={{ fontSize: 11, color: "var(--color-text-faint)", marginLeft: 8 }}>
+                            {macroStr}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  )}
                 </div>
               );
             })}
@@ -919,12 +1010,51 @@ function fmtDate(d: string) {
 }
 
 function PastMeals({ pastMeals }: { pastMeals: MealRow[] }) {
+  const router = useRouter();
   const byDate = new Map<string, MealRow[]>();
   for (const meal of pastMeals) {
     if (!byDate.has(meal.date)) byDate.set(meal.date, []);
     byDate.get(meal.date)!.push(meal);
   }
   const dates = Array.from(byDate.keys());
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editFields, setEditFields] = useState<{
+    notes: string; meal_type: string; calories: string; protein_g: string; carbs_g: string; fat_g: string;
+  }>({ notes: "", meal_type: "breakfast", calories: "", protein_g: "", carbs_g: "", fat_g: "" });
+  const [editSaving, setEditSaving] = useState(false);
+
+  function startEdit(m: MealRow) {
+    setEditingId(m.id);
+    setEditFields({
+      notes: m.notes ?? "",
+      meal_type: m.meal_type,
+      calories: m.calories != null ? String(m.calories) : "",
+      protein_g: m.protein_g != null ? String(m.protein_g) : "",
+      carbs_g: m.carbs_g != null ? String(m.carbs_g) : "",
+      fat_g: m.fat_g != null ? String(m.fat_g) : "",
+    });
+  }
+
+  async function saveEdit(id: string) {
+    setEditSaving(true);
+    await fetch("/api/meals/log", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id,
+        notes: editFields.notes || null,
+        meal_type: editFields.meal_type,
+        calories: editFields.calories ? Number(editFields.calories) : null,
+        protein_g: editFields.protein_g ? Number(editFields.protein_g) : null,
+        carbs_g: editFields.carbs_g ? Number(editFields.carbs_g) : null,
+        fat_g: editFields.fat_g ? Number(editFields.fat_g) : null,
+      }),
+    });
+    setEditSaving(false);
+    setEditingId(null);
+    router.refresh();
+  }
 
   return (
     <div className="space-y-4">
@@ -964,28 +1094,82 @@ function PastMeals({ pastMeals }: { pastMeals: MealRow[] }) {
                       .join(" · ")
                   : null;
                 return (
-                  <div key={m.id} className="flex items-baseline gap-3">
-                    <span
-                      style={{
-                        fontSize: 11,
-                        fontWeight: 500,
-                        color: "var(--color-text-muted)",
-                        textTransform: "capitalize",
-                        minWidth: 64,
-                      }}
-                    >
-                      {m.meal_type}
-                    </span>
-                    <div>
-                      <span style={{ fontSize: 14, color: "var(--color-text)" }}>
-                        {m.recipes?.name ?? m.notes ?? "—"}
-                      </span>
-                      {macroStr && (
-                        <span style={{ fontSize: 11, color: "var(--color-text-faint)", marginLeft: 8 }}>
-                          {macroStr}
+                  <div key={m.id}>
+                    {editingId === m.id ? (
+                      <div className="space-y-2 py-1">
+                        <div className="flex gap-2">
+                          <select
+                            value={editFields.meal_type}
+                            onChange={(e) => setEditFields((f) => ({ ...f, meal_type: e.target.value }))}
+                            style={{ ...inputStyle, width: "auto", minWidth: 110, flexShrink: 0 }}
+                          >
+                            {MEAL_TYPES.map((t) => <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>)}
+                          </select>
+                          <input
+                            type="text"
+                            value={editFields.notes}
+                            onChange={(e) => setEditFields((f) => ({ ...f, notes: e.target.value }))}
+                            placeholder="Food name"
+                            style={{ ...inputStyle, flex: 1 }}
+                          />
+                        </div>
+                        <div className="flex gap-2">
+                          {(["calories", "protein_g", "carbs_g", "fat_g"] as const).map((field) => (
+                            <input
+                              key={field}
+                              type="number"
+                              value={editFields[field]}
+                              onChange={(e) => setEditFields((f) => ({ ...f, [field]: e.target.value }))}
+                              placeholder={{ calories: "Cal", protein_g: "P(g)", carbs_g: "C(g)", fat_g: "F(g)" }[field]}
+                              style={{ ...inputStyle, width: 68 }}
+                            />
+                          ))}
+                        </div>
+                        <div className="flex gap-2">
+                          <button
+                            onClick={() => saveEdit(m.id)}
+                            disabled={editSaving}
+                            style={{ fontSize: 13, padding: "4px 12px", background: "var(--color-primary)", color: "var(--color-primary-foreground)", border: "none", borderRadius: 6, cursor: "pointer", opacity: editSaving ? 0.5 : 1 }}
+                          >
+                            {editSaving ? "Saving…" : "Save"}
+                          </button>
+                          <button
+                            onClick={() => setEditingId(null)}
+                            style={{ fontSize: 13, padding: "4px 12px", color: "var(--color-text-muted)", background: "none", border: "none", cursor: "pointer" }}
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div
+                        className="flex items-baseline gap-3"
+                        onClick={() => startEdit(m)}
+                        style={{ cursor: "pointer" }}
+                      >
+                        <span
+                          style={{
+                            fontSize: 11,
+                            fontWeight: 500,
+                            color: "var(--color-text-muted)",
+                            textTransform: "capitalize",
+                            minWidth: 64,
+                          }}
+                        >
+                          {m.meal_type}
                         </span>
-                      )}
-                    </div>
+                        <div>
+                          <span style={{ fontSize: 14, color: "var(--color-text)" }}>
+                            {m.recipes?.name ?? m.notes ?? "—"}
+                          </span>
+                          {macroStr && (
+                            <span style={{ fontSize: 11, color: "var(--color-text-faint)", marginLeft: 8 }}>
+                              {macroStr}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    )}
                   </div>
                 );
               })}

--- a/web/src/components/tasks/task-item.tsx
+++ b/web/src/components/tasks/task-item.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition, useRef, useEffect } from "react";
 import { Archive, ChevronDown, ChevronRight, Pencil, X } from "lucide-react";
 import type { Task, Subtask } from "@/lib/types";
+import { todayString } from "@/lib/timezone";
 
 const PRIORITY_COLOR: Record<string, string> = {
   high:   "var(--color-danger)",
@@ -11,10 +12,11 @@ const PRIORITY_COLOR: Record<string, string> = {
 };
 
 function relativeDue(dateStr: string): { label: string; urgent: boolean } {
+  const today = todayString();
   const diff = Math.round(
-    (new Date(dateStr + "T00:00:00").getTime() - Date.now()) / 86_400_000
+    (new Date(dateStr + "T00:00:00").getTime() - new Date(today + "T00:00:00").getTime()) / 86_400_000
   );
-  if (diff < 0)  return { label: `${Math.abs(diff)}d overdue`, urgent: true };
+  if (diff < 0)   return { label: `${Math.abs(diff)}d overdue`, urgent: true  };
   if (diff === 0) return { label: "Today",    urgent: true  };
   if (diff === 1) return { label: "Tomorrow", urgent: false };
   if (diff <= 7)  return { label: `${diff}d`, urgent: false };


### PR DESCRIPTION
## Summary
- **#176** — adds a 90-second deduplication window to `add_task` to prevent double-inserts from `retryOnOverload` stream retries
- **#175** — adds `updateHabit` server action and inline edit form on `HabitToggle`; all three fields (name, emoji, category) pre-filled and updatable in-place
- **#174** — replaces the plain emoji text input on the Add Habit form with an `emoji-picker-react` popover
- **#173** — adds a `PATCH /api/meals/log` endpoint (user-scoped) and inline edit UI on both today's and past meal rows in `MealsClient.tsx`

## Test plan
- [ ] Ask Bridge to add a task; confirm exactly one row appears in Tasks tab and Supabase
- [ ] Edit a habit name, emoji, and category; confirm changes persist after page reload
- [ ] Open Add Habit form; click emoji button; pick from picker; confirm emoji populates and picker closes
- [ ] Tap a meal log entry; edit food name and macros; save; confirm row updates without full reload
- [ ] Cancel meal edit; confirm no change to database
- [ ] PATCH with no auth returns 401
- [ ] `cd web && npx tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)