### PR TITLE
fix: scanner opens camera directly on mobile (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (nutrition scanner opens camera directly — issue #186)
+- **`web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx`** — added `capture="environment"` to the hidden file input so mobile browsers open the rear camera directly instead of showing the file picker
+
 ### Fixed (deduplicate add_task inserts — issue #176)
 - **`web/src/app/api/chat/route.ts`** — added 90-second deduplication window to `add_task` execute; before inserting, queries for an active task with the same title (case-insensitive) and due_date created in the last 90 seconds; returns the existing row instead of inserting a duplicate (guards against `retryOnOverload` stream-retry double-inserts)
 

--- a/web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx
+++ b/web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx
@@ -392,6 +392,7 @@ export default function FoodPhotoAnalyzer() {
             ref={fileInputRef}
             type="file"
             accept="image/*"
+            capture="environment"
             className="hidden"
             onChange={handleFileChange}
           />


### PR DESCRIPTION
## Summary
- Added `capture="environment"` to the hidden file input in `FoodPhotoAnalyzer.tsx`
- Mobile browsers (iOS Safari, Android Chrome) now open the rear camera directly when the scan button is tapped, instead of showing a file picker
- Desktop browsers ignore the `capture` attribute — behavior unchanged

## Test plan
- [ ] Tap Scanner button on iOS Safari → camera opens directly (no picker sheet)
- [ ] Tap Scanner button on Android Chrome → camera opens directly
- [ ] On desktop, file picker still opens normally
- [ ] `cd web && npx tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)