### PR TITLE
chore: Claude config improvements from best-practices review

### DIFF
--- a/.claude/agents/journal-reminder.md
+++ b/.claude/agents/journal-reminder.md
@@ -6,6 +6,7 @@ tools:
 model: haiku
 permissionMode: acceptEdits
 maxTurns: 5
+color: blue
 ---
 
 ## Purpose

--- a/.claude/agents/morning-nudge.md
+++ b/.claude/agents/morning-nudge.md
@@ -6,6 +6,7 @@ tools:
 model: haiku
 permissionMode: acceptEdits
 maxTurns: 3
+color: yellow
 ---
 
 ## Purpose

--- a/.claude/agents/nightly-postmortem.md
+++ b/.claude/agents/nightly-postmortem.md
@@ -6,6 +6,7 @@ tools:
 model: haiku
 permissionMode: acceptEdits
 maxTurns: 5
+color: purple
 ---
 
 ## Purpose

--- a/.claude/agents/study-timer.md
+++ b/.claude/agents/study-timer.md
@@ -6,6 +6,7 @@ tools:
 model: haiku
 permissionMode: acceptEdits
 maxTurns: 6
+color: green
 ---
 
 ## Purpose

--- a/.claude/agents/weekly-review.md
+++ b/.claude/agents/weekly-review.md
@@ -6,6 +6,7 @@ tools:
 model: haiku
 permissionMode: acceptEdits
 maxTurns: 8
+color: orange
 ---
 
 ## Purpose

--- a/.claude/commands/session-briefing.md
+++ b/.claude/commands/session-briefing.md
@@ -1,8 +1,9 @@
 ---
 name: session-briefing
-description: Re-run the full Mr. Bridge session briefing on demand — schedule, important emails, pending tasks, and habit accountability.
+description: Re-run the full Mr. Bridge session briefing on demand — weather, schedule, emails, pending tasks, and habit accountability.
 user-invocable: true
 allowed-tools:
+  - Bash(bash *)
   - Read
   - mcp__claude_ai_Google_Calendar__*
   - mcp__claude_ai_Gmail__*
@@ -11,13 +12,14 @@ model: sonnet
 
 Re-run the full session briefing as defined in `.claude/rules/mr-bridge-rules.md`.
 
-Load all memory files, fetch today's calendar events and important emails, then output the briefing in the standard format:
+Execute the following in order:
 
-```
-## Mr. Bridge — [Day, Date]
-
-### Schedule Today
-### Important Emails
-### Pending Tasks
-### Accountability — Last 7 Days
-```
+1. Fetch briefing data from Supabase:
+   ```bash
+   python3 scripts/fetch_briefing_data.py
+   ```
+2. Issue these three fetches **in parallel** (single message turn):
+   - **Weather**: fetch current conditions and today's forecast for the location in the profile (use `location_lat`/`location_lon`, then `location_city`, then `Identity/Location` as fallback)
+   - **Calendar events**: List Calendar Events for today (primary + secondary calendars)
+   - **Important unread emails**: Search Gmail for unread messages with subjects containing: meeting / urgent / invoice / action required / deadline
+3. Output the full briefing in the standard format from `.claude/rules/mr-bridge-rules.md`.

--- a/.claude/commands/stop-timer.md
+++ b/.claude/commands/stop-timer.md
@@ -3,9 +3,7 @@ name: stop-timer
 description: Stop the active study timer, optionally adjust the logged duration, and insert the entry into the Supabase study_log table.
 user-invocable: true
 allowed-tools:
-  - Read
-  - Write
-  - Edit
+  - Bash(bash *)
 model: haiku
 ---
 

--- a/.claude/commands/weekly-review.md
+++ b/.claude/commands/weekly-review.md
@@ -2,10 +2,8 @@
 name: weekly-review
 description: Run the weekly habit and accountability review on demand. Shows last 7 days of habits, study time, tasks, and fires a push notification with headline stats.
 user-invocable: true
-allowed-tools:
-  - Read
-  - Bash(bash *)
-model: haiku
+context: fork
+agent: weekly-review
 ---
 
 Run the weekly-review agent to compute and display the weekly summary.

--- a/.claude/hooks/scripts/hooks.py
+++ b/.claude/hooks/scripts/hooks.py
@@ -4,7 +4,8 @@ Mr. Bridge — Claude Code Hooks
 Receives event context via stdin JSON and handles lifecycle events.
 
 Supported hooks:
-  PostToolUse — fires after any tool completes
+  PostToolUse — fires after Write or Edit tool completes
+  Stop        — fires when a session ends
 """
 
 import json
@@ -15,11 +16,11 @@ from datetime import datetime
 
 
 def handle_post_tool_use(event: dict):
-    """After a Write tool call, remind to commit if a memory file was written."""
+    """After a Write or Edit tool call, remind to commit if a memory file was touched."""
     tool_name = event.get("tool_name", "")
     tool_input = event.get("tool_input", {})
 
-    if tool_name != "Write":
+    if tool_name not in ("Write", "Edit"):
         return
 
     file_path = tool_input.get("file_path", "")
@@ -31,6 +32,16 @@ def handle_post_tool_use(event: dict):
     print(
         f"\n[Mr. Bridge] Memory updated ({filename}) — "
         f"run: git add . && git commit -m \"session: {date} — memory update\" && git push",
+        file=sys.stderr
+    )
+
+
+def handle_stop(event: dict):
+    """At session end, remind to commit any pending changes."""
+    date = datetime.now().strftime("%Y-%m-%d")
+    print(
+        f"\n[Mr. Bridge] Session ended — if you made changes, run: "
+        f"git add . && git commit -m \"session: {date} — <summary>\" && git push",
         file=sys.stderr
     )
 
@@ -48,6 +59,8 @@ def main():
 
     if hook_type == "PostToolUse":
         handle_post_tool_use(event)
+    elif hook_type == "Stop":
+        handle_stop(event)
 
 
 if __name__ == "__main__":

--- a/.claude/rules/mr-bridge-rules.md
+++ b/.claude/rules/mr-bridge-rules.md
@@ -208,4 +208,4 @@ All live data is stored in Supabase. Local markdown files are archived originals
 | Resource | Location | Purpose |
 |----------|----------|---------|
 | Claude Code best practices | `.claude/references/best-practice/` | Patterns for agents, skills, commands, hooks, MCP |
-| Update reference: | `git submodule update --remote .claude/references/best-practice` | Pull latest before feature work |
+| Update reference: | `bash scripts/update-references.sh` | Pull latest before feature work |

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,18 @@
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Write",
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/scripts/hooks.py",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

Applied improvements identified by cross-referencing `.claude/references/best-practice/` against the current repo config.

- Fix reference table in `mr-bridge-rules.md`: `git submodule update` → `bash scripts/update-references.sh` (it's a git subtree, not a submodule)
- Add `color:` field to all 5 agents for visual distinction in the task list
- Fix `stop-timer` command: replaced `Read/Write/Edit` with `Bash(bash *)` — required to query Supabase
- Fix `weekly-review` command: now delegates via `context: fork` + `agent: weekly-review` instead of running inline
- Expand hooks: PostToolUse now catches `Write|Edit` (not just `Write`); added `Stop` event for session-end commit reminder
- Fix `session-briefing` command: added `Bash` to allowed-tools and added the missing Supabase data fetch + weather step before outputting the briefing

## Test plan

- [ ] `/stop-timer` — confirm it can read and write Supabase without permission errors
- [ ] `/weekly-review` — confirm it forks the `weekly-review` agent in an isolated context
- [ ] `/session-briefing` — confirm briefing includes weather section alongside schedule/emails
- [ ] Edit a memory file — confirm commit reminder fires (previously only fired on `Write`)
- [ ] End a session — confirm stop hook prints commit reminder

🤖 Generated with [Claude Code](https://claude.com/claude-code)