### PR TITLE
feat: weekly workout program in fitness tab (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (weekly workout program in fitness tab — issue #192)
+- **`supabase/migrations/20260414000000_add_workout_plans.sql`** — new `workout_plans` table: per-user, per-date rows with `warmup`, `workout`, `cooldown` JSONB arrays, optional `notes`, and `calendar_event_id`; RLS policy restricts to owner
+- **`web/src/lib/types.ts`** — added `WorkoutExercise` and `WorkoutPlan` interfaces
+- **`web/src/app/api/chat/route.ts`** — added `get_workout_plan` (fetches current Mon–Sun week), `assign_workout` (upserts one day's plan + creates/updates a timed Google Calendar event), and `update_workout_exercise` (patches a single exercise by name within a phase and refreshes the calendar event); added `buildCalendarDescription` helper; demo mode no-ops for all three tools
+- **`web/src/components/fitness/weekly-workout-plan.tsx`** — new client component; renders Mon–Sun cards with expand/collapse, Today badge, green checkmark for completed days, and three-phase exercise rows (Warm-up / Workout / Cool-down)
+- **`web/src/app/(protected)/fitness/page.tsx`** — queries `workout_plans` for current week; derives `completedDates` from existing `allWorkouts`; renders `WeeklyWorkoutPlan` above body composition chart
+
 ### Changed (perf: reduce Anthropic API costs — issue #189)
 - **`web/src/app/api/chat/route.ts`** — `maxSteps` reduced from 25 to 12; system prompt split into static (cached with `cacheControl: ephemeral`) + dynamic (date + name, uncached) content blocks to prevent daily cache busts; context window trimmed from 20 to 10 messages; top-level `providerOptions` cacheControl block removed (now inline on static block); `selectModel` accepts optional `model` override from request body; system prompt adds graceful step-limit rule and `get_session_history` consent rule
 - **`web/src/app/api/chat/route.ts`** — new `get_session_history` tool: fetches up to 40 earlier messages from the current session on demand; model asks user before calling

--- a/supabase/migrations/20260414000000_add_workout_plans.sql
+++ b/supabase/migrations/20260414000000_add_workout_plans.sql
@@ -1,0 +1,18 @@
+create table if not exists workout_plans (
+  id                uuid primary key default gen_random_uuid(),
+  user_id           uuid not null references auth.users(id),
+  date              date not null,
+  warmup            jsonb not null default '[]',
+  workout           jsonb not null default '[]',
+  cooldown          jsonb not null default '[]',
+  notes             text,
+  calendar_event_id text,
+  created_at        timestamptz default now(),
+  updated_at        timestamptz default now(),
+  unique (user_id, date)
+);
+create index on workout_plans (user_id, date);
+alter table workout_plans enable row level security;
+create policy "users manage own workout plans"
+  on workout_plans for all to authenticated
+  using (user_id = auth.uid()) with check (user_id = auth.uid());

--- a/web/src/app/(protected)/fitness/page.tsx
+++ b/web/src/app/(protected)/fitness/page.tsx
@@ -10,14 +10,25 @@ import { ActiveCalGoalChart } from "@/components/fitness/active-cal-goal-chart";
 import { WeightGoalChart } from "@/components/fitness/weight-goal-chart";
 import { BodyFatGoalChart } from "@/components/fitness/body-fat-goal-chart";
 import { WorkoutHistoryTable } from "@/components/fitness/workout-history-table";
-import type { FitnessLog, WorkoutSession, RecoveryMetrics } from "@/lib/types";
+import { WeeklyWorkoutPlan } from "@/components/fitness/weekly-workout-plan";
+import type { FitnessLog, WorkoutSession, RecoveryMetrics, WorkoutPlan } from "@/lib/types";
 
 export default async function FitnessPage() {
   const supabase = await createClient();
   const { key: windowKey, days } = await getWindow();
   const weekCount = Math.ceil(days / 7);
 
-  const [fitnessRes, workoutsRes, recoveryRes, profileRes] = await Promise.all([
+  // Current ISO week bounds (Mon–Sun)
+  const today = new Date();
+  const dow = (today.getDay() + 6) % 7; // 0=Mon, 6=Sun
+  const monday = new Date(today);
+  monday.setDate(today.getDate() - dow);
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  const mondayStr = monday.toISOString().slice(0, 10);
+  const sundayStr = sunday.toISOString().slice(0, 10);
+
+  const [fitnessRes, workoutsRes, recoveryRes, profileRes, weeklyPlansRes] = await Promise.all([
     supabase
       .from("fitness_log")
       .select("*")
@@ -43,11 +54,21 @@ export default async function FitnessPage() {
         "weight_goal_lbs",
         "body_fat_goal_pct",
       ]),
+    supabase
+      .from("workout_plans")
+      .select("*")
+      .gte("date", mondayStr)
+      .lte("date", sundayStr)
+      .order("date", { ascending: true }),
   ]);
 
   const fitnessData = (fitnessRes.data ?? []) as FitnessLog[];
   const allWorkouts = (workoutsRes.data ?? []) as WorkoutSession[];
   const recoveryData = (recoveryRes.data ?? []) as Pick<RecoveryMetrics, "date" | "active_cal">[];
+  const weeklyPlans = (weeklyPlansRes.data ?? []) as WorkoutPlan[];
+  const completedDates = allWorkouts
+    .filter((w) => w.date >= mondayStr && w.date <= sundayStr)
+    .map((w) => w.date);
 
   const workouts     = allWorkouts.filter((w) => !/walk/i.test(w.activity));
   const walkSessions = allWorkouts.filter((w) => /walk/i.test(w.activity));
@@ -87,6 +108,9 @@ export default async function FitnessPage() {
         </div>
         <WindowSelector current={windowKey} />
       </div>
+
+      {/* Weekly workout program */}
+      <WeeklyWorkoutPlan plans={weeklyPlans} completedDates={completedDates} />
 
       {/* Body composition trend */}
       <BodyCompDualChart data={fitnessData} windowLabel={windowKey.toUpperCase()} windowKey={windowKey} />

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -315,7 +315,8 @@ Tools available:
 - get_profile, update_profile
 - search_gmail, get_email_body (returns demo emails)
 - list_calendar_events, create_calendar_event, delete_calendar_event, update_calendar_event (demo mode — no real changes)
-- get_recipes, get_today_meals`;
+- get_recipes, get_today_meals
+- get_workout_plan, assign_workout, update_workout_exercise`;
 
   const dynamicPromptBlock = `You are Mr. Bridge, ${userLabel}'s personal AI assistant.
 Today's date is ${todayString()}.
@@ -329,6 +330,33 @@ ${userName ? `Address the user as "${userName}" — use their name naturally in 
       content: m.content,
     }))
     .filter((m: { role: "user" | "assistant"; content: string }) => m.content.trim() !== "");
+
+  interface WorkoutExercise {
+    exercise: string;
+    sets?: number;
+    reps?: string;
+    weight_lbs?: number | null;
+    notes?: string | null;
+  }
+
+  function buildCalendarDescription(
+    warmup: WorkoutExercise[],
+    workout: WorkoutExercise[],
+    cooldown: WorkoutExercise[]
+  ): string {
+    const fmt = (ex: WorkoutExercise) => {
+      const parts = [ex.exercise];
+      if (ex.sets) parts.push(`${ex.sets} sets`);
+      if (ex.reps) parts.push(`× ${ex.reps}`);
+      if (ex.weight_lbs) parts.push(`@ ${ex.weight_lbs} lbs`);
+      return parts.join(" ");
+    };
+    const sections: string[] = [];
+    if (warmup.length) sections.push("Warm-up:\n" + warmup.map(fmt).join("\n"));
+    if (workout.length) sections.push("Workout:\n" + workout.map(fmt).join("\n"));
+    if (cooldown.length) sections.push("Cool-down:\n" + cooldown.map(fmt).join("\n"));
+    return sections.join("\n\n");
+  }
 
   const tools = {
     get_tasks: tool({
@@ -1082,6 +1110,195 @@ ${userName ? `Address the user as "${userName}" — use their name naturally in 
           .order("position", { ascending: true, nullsFirst: false })
           .limit(Math.min(limit, 40));
         return data ?? [];
+      },
+    }),
+
+    get_workout_plan: tool({
+      description: "Fetch the workout plan for the current Mon–Sun week. No parameters. Call this before making any adjustment or suggestion to the user's workout program.",
+      parameters: jsonSchema<Record<string, never>>({
+        type: "object",
+        properties: {},
+      }),
+      execute: async () => {
+        if (!userId) return { error: "Not authenticated" };
+        if (isDemo) return { demo: true, note: "Demo mode — no real workout plans." };
+        const today = new Date();
+        const dow = (today.getDay() + 6) % 7; // 0=Mon, 6=Sun
+        const monday = new Date(today);
+        monday.setDate(today.getDate() - dow);
+        const sunday = new Date(monday);
+        sunday.setDate(monday.getDate() + 6);
+        const fmt = (d: Date) => d.toISOString().slice(0, 10);
+        const { data, error } = await supabase
+          .from("workout_plans")
+          .select("*")
+          .eq("user_id", userId)
+          .gte("date", fmt(monday))
+          .lte("date", fmt(sunday))
+          .order("date", { ascending: true });
+        if (error) return { error: error.message };
+        return { week: `${fmt(monday)} – ${fmt(sunday)}`, plans: data ?? [] };
+      },
+    }),
+
+    assign_workout: tool({
+      description: "Assign or replace one day's workout plan. Upserts to workout_plans and optionally creates/updates the matching Google Calendar event. When update_calendar is true and no start_time is provided, ask the user what time their workout will be before calling.",
+      parameters: jsonSchema<{
+        date: string;
+        warmup: WorkoutExercise[];
+        workout: WorkoutExercise[];
+        cooldown: WorkoutExercise[];
+        notes?: string;
+        start_time?: string;
+        end_time?: string;
+        update_calendar?: boolean;
+      }>({
+        type: "object",
+        required: ["date", "warmup", "workout", "cooldown"],
+        properties: {
+          date: { type: "string", description: "Date in YYYY-MM-DD format." },
+          warmup: { type: "array", items: { type: "object" }, description: "Warm-up exercises." },
+          workout: { type: "array", items: { type: "object" }, description: "Main workout exercises." },
+          cooldown: { type: "array", items: { type: "object" }, description: "Cool-down exercises." },
+          notes: { type: "string", description: "Optional plan notes." },
+          start_time: { type: "string", description: "Workout start time in HH:MM (24h) format. Ask the user if not provided and update_calendar is true." },
+          end_time: { type: "string", description: "Workout end time in HH:MM (24h) format. Defaults to start_time + 1 hour." },
+          update_calendar: { type: "boolean", description: "Create/update a Google Calendar event. Default true." },
+        },
+      }),
+      execute: async ({ date, warmup, workout, cooldown, notes, start_time, end_time, update_calendar = true }) => {
+        if (!userId) return { error: "Not authenticated" };
+        if (isDemo) return { demo: true, note: "Demo mode — plan not saved." };
+
+        const { data: upserted, error } = await supabase
+          .from("workout_plans")
+          .upsert(
+            { user_id: userId, date, warmup, workout, cooldown, notes: notes ?? null, updated_at: new Date().toISOString() },
+            { onConflict: "user_id,date" }
+          )
+          .select()
+          .single();
+        if (error) return { error: error.message };
+
+        if (update_calendar) {
+          try {
+            const auth = getGoogleAuthClient();
+            const calendar = google.calendar({ version: "v3", auth });
+            const description = buildCalendarDescription(warmup, workout, cooldown);
+            const title = `Workout — ${new Date(date + "T00:00:00").toLocaleDateString("en-US", { weekday: "long" })}`;
+            const tz = process.env.USER_TIMEZONE ?? "America/Los_Angeles";
+
+            let startObj: object;
+            let endObj: object;
+            if (start_time) {
+              const computedEnd = end_time ?? (() => {
+                const [h, m] = start_time.split(":").map(Number);
+                return `${String((h + 1) % 24).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+              })();
+              startObj = { dateTime: `${date}T${start_time}:00`, timeZone: tz };
+              endObj = { dateTime: `${date}T${computedEnd}:00`, timeZone: tz };
+            } else {
+              startObj = { date };
+              endObj = { date };
+            }
+
+            let eventId: string | null = upserted.calendar_event_id ?? null;
+            if (eventId) {
+              await calendar.events.patch({
+                calendarId: "primary",
+                eventId,
+                requestBody: { summary: title, description, start: startObj, end: endObj },
+              });
+            } else {
+              const res = await calendar.events.insert({
+                calendarId: "primary",
+                requestBody: { summary: title, start: startObj, end: endObj, description },
+              });
+              eventId = res.data.id ?? null;
+              await supabase
+                .from("workout_plans")
+                .update({ calendar_event_id: eventId })
+                .eq("user_id", userId)
+                .eq("date", date);
+              upserted.calendar_event_id = eventId;
+            }
+          } catch (calErr) {
+            return { ...upserted, calendar_warning: calErr instanceof Error ? calErr.message : "Calendar sync failed" };
+          }
+        }
+
+        return upserted;
+      },
+    }),
+
+    update_workout_exercise: tool({
+      description: "Patch a single exercise in one phase of an existing workout plan. Fetches the row, finds the exercise by name (case-insensitive), merges the updates, upserts back, and refreshes the calendar event description.",
+      parameters: jsonSchema<{
+        date: string;
+        phase: "warmup" | "workout" | "cooldown";
+        exercise_name: string;
+        updates: { sets?: number; reps?: string; weight_lbs?: number; notes?: string };
+      }>({
+        type: "object",
+        required: ["date", "phase", "exercise_name", "updates"],
+        properties: {
+          date: { type: "string", description: "YYYY-MM-DD date of the plan to edit." },
+          phase: { type: "string", enum: ["warmup", "workout", "cooldown"], description: "Which phase the exercise is in." },
+          exercise_name: { type: "string", description: "Exercise name to match (case-insensitive)." },
+          updates: {
+            type: "object",
+            description: "Fields to merge into the matched exercise object.",
+            properties: {
+              sets: { type: "number" },
+              reps: { type: "string" },
+              weight_lbs: { type: "number" },
+              notes: { type: "string" },
+            },
+          },
+        },
+      }),
+      execute: async ({ date, phase, exercise_name, updates }) => {
+        if (!userId) return { error: "Not authenticated" };
+        if (isDemo) return { demo: true, note: "Demo mode — not saved." };
+
+        const { data: row, error: fetchErr } = await supabase
+          .from("workout_plans")
+          .select("*")
+          .eq("user_id", userId)
+          .eq("date", date)
+          .single();
+        if (fetchErr || !row) return { error: fetchErr?.message ?? "No plan found for that date." };
+
+        const arr: WorkoutExercise[] = [...(row[phase] as WorkoutExercise[])];
+        const idx = arr.findIndex((e) => e.exercise.toLowerCase() === exercise_name.toLowerCase());
+        if (idx === -1) return { error: `Exercise "${exercise_name}" not found in ${phase}.` };
+        arr[idx] = { ...arr[idx], ...updates };
+
+        const { data: updated, error: upErr } = await supabase
+          .from("workout_plans")
+          .update({ [phase]: arr, updated_at: new Date().toISOString() })
+          .eq("user_id", userId)
+          .eq("date", date)
+          .select()
+          .single();
+        if (upErr) return { error: upErr.message };
+
+        if (updated.calendar_event_id) {
+          try {
+            const auth = getGoogleAuthClient();
+            const calendar = google.calendar({ version: "v3", auth });
+            const description = buildCalendarDescription(updated.warmup, updated.workout, updated.cooldown);
+            await calendar.events.patch({
+              calendarId: "primary",
+              eventId: updated.calendar_event_id,
+              requestBody: { description },
+            });
+          } catch {
+            // Non-fatal — plan is already saved
+          }
+        }
+
+        return updated;
       },
     }),
   };

--- a/web/src/components/fitness/weekly-workout-plan.tsx
+++ b/web/src/components/fitness/weekly-workout-plan.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronUp, ChevronDown } from "lucide-react";
+import type { WorkoutPlan, WorkoutExercise } from "@/lib/types";
+
+interface Props {
+  plans: WorkoutPlan[];
+  completedDates: string[];
+}
+
+interface DaySlot {
+  label: string;
+  date: string;
+  plan: WorkoutPlan | undefined;
+  isToday: boolean;
+  isCompleted: boolean;
+}
+
+function buildWeekDays(plans: WorkoutPlan[], completedDates: string[]): DaySlot[] {
+  const today = new Date();
+  const todayStr = today.toISOString().slice(0, 10);
+  const dow = (today.getDay() + 6) % 7; // 0=Mon, 6=Sun
+  const monday = new Date(today);
+  monday.setDate(today.getDate() - dow);
+
+  const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+  return DAY_LABELS.map((label, i) => {
+    const d = new Date(monday);
+    d.setDate(monday.getDate() + i);
+    const date = d.toISOString().slice(0, 10);
+    return {
+      label,
+      date,
+      plan: plans.find((p) => p.date === date),
+      isToday: date === todayStr,
+      isCompleted: completedDates.includes(date),
+    };
+  });
+}
+
+function fmtShortDate(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00");
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function fmtWeekRange(days: DaySlot[]): string {
+  if (days.length === 0) return "";
+  return `${fmtShortDate(days[0].date)} – ${fmtShortDate(days[6].date)}`;
+}
+
+function ExerciseRow({ ex }: { ex: WorkoutExercise }) {
+  const details: string[] = [];
+  if (ex.sets) details.push(`${ex.sets} sets`);
+  if (ex.reps) details.push(`× ${ex.reps}`);
+  if (ex.weight_lbs) details.push(`@ ${ex.weight_lbs} lbs`);
+
+  return (
+    <div className="flex items-baseline gap-1.5" style={{ padding: "3px 0" }}>
+      <span style={{ fontSize: 13, fontWeight: 500, color: "var(--color-text)" }}>{ex.exercise}</span>
+      {details.length > 0 && (
+        <>
+          <span style={{ fontSize: 11, color: "var(--color-text-faint, var(--color-text-muted))" }}>·</span>
+          <span style={{ fontSize: 12, color: "var(--color-text-muted)", fontVariantNumeric: "tabular-nums" }}>
+            {details.join(" ")}
+          </span>
+        </>
+      )}
+    </div>
+  );
+}
+
+function PhaseSection({ label, exercises }: { label: string; exercises: WorkoutExercise[] }) {
+  if (exercises.length === 0) return null;
+  return (
+    <div style={{ marginBottom: 14 }}>
+      <div
+        className="text-xs uppercase tracking-widest"
+        style={{
+          fontSize: 10,
+          fontWeight: 500,
+          letterSpacing: "0.07em",
+          color: "var(--color-text-faint, var(--color-text-muted))",
+          paddingBottom: 5,
+          marginBottom: 6,
+          borderBottom: "1px solid var(--color-border)",
+        }}
+      >
+        {label}
+      </div>
+      {exercises.map((ex, i) => (
+        <ExerciseRow key={i} ex={ex} />
+      ))}
+    </div>
+  );
+}
+
+export function WeeklyWorkoutPlan({ plans, completedDates }: Props) {
+  const days = buildWeekDays(plans, completedDates);
+  const todayDate = new Date().toISOString().slice(0, 10);
+
+  const [open, setOpen] = useState<Record<string, boolean>>(() => ({
+    [todayDate]: true,
+  }));
+
+  function toggle(date: string) {
+    setOpen((prev) => ({ ...prev, [date]: !prev[date] }));
+  }
+
+  if (days.length === 0) return null;
+
+  return (
+    <div
+      className="rounded-xl p-5"
+      style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+    >
+      {/* Header */}
+      <div className="flex items-baseline justify-between mb-4">
+        <p
+          className="text-xs uppercase tracking-widest"
+          style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}
+        >
+          Weekly Program
+        </p>
+        <span style={{ fontSize: 11, color: "var(--color-text-faint, var(--color-text-muted))" }}>
+          {fmtWeekRange(days)}
+        </span>
+      </div>
+
+      {/* Day rows */}
+      <div className="flex flex-col gap-1.5">
+        {days.map((day) => {
+          const isOpen = !!open[day.date];
+
+          if (!day.plan) {
+            // Rest day — plain row, no toggle
+            return (
+              <div
+                key={day.date}
+                className="flex items-center gap-3 rounded-lg px-3.5 py-2.5"
+                style={{
+                  background: "var(--color-surface-raised, rgba(255,255,255,0.03))",
+                  border: "1px solid var(--color-border)",
+                }}
+              >
+                <span style={{ fontSize: 12, fontWeight: 600, color: "var(--color-text-muted)", width: 28, flexShrink: 0 }}>
+                  {day.label}
+                </span>
+                <span style={{ fontSize: 12, color: "var(--color-text-faint, var(--color-text-muted))" }}>
+                  {fmtShortDate(day.date)}
+                </span>
+                {day.isToday && (
+                  <span
+                    className="text-xs uppercase font-semibold tracking-wide px-2 py-0.5 rounded-full"
+                    style={{ fontSize: 10, background: "var(--color-accent, #6366f1)", color: "#fff" }}
+                  >
+                    Today
+                  </span>
+                )}
+                <span
+                  style={{
+                    marginLeft: "auto",
+                    fontSize: 12,
+                    fontStyle: "italic",
+                    color: "var(--color-text-faint, var(--color-text-muted))",
+                  }}
+                >
+                  Rest
+                </span>
+              </div>
+            );
+          }
+
+          // Plan day — expandable card
+          return (
+            <div
+              key={day.date}
+              className="rounded-lg overflow-hidden"
+              style={{ border: "1px solid var(--color-border)" }}
+            >
+              {/* Card header */}
+              <button
+                onClick={() => toggle(day.date)}
+                className="w-full flex items-center gap-3 px-3.5 py-2.5 text-left cursor-pointer transition-colors duration-150"
+                style={{
+                  background: "var(--color-surface-raised, rgba(255,255,255,0.04))",
+                  border: "none",
+                }}
+              >
+                <span style={{ fontSize: 12, fontWeight: 600, color: "var(--color-text-muted)", width: 28, flexShrink: 0 }}>
+                  {day.label}
+                </span>
+                <span style={{ fontSize: 12, color: "var(--color-text-muted)" }}>
+                  {fmtShortDate(day.date)}
+                </span>
+                {day.isToday && (
+                  <span
+                    className="text-xs uppercase font-semibold tracking-wide px-2 py-0.5 rounded-full"
+                    style={{ fontSize: 10, background: "var(--color-accent, #6366f1)", color: "#fff", flexShrink: 0 }}
+                  >
+                    Today
+                  </span>
+                )}
+                <span
+                  style={{
+                    fontSize: 13,
+                    fontWeight: 500,
+                    color: "var(--color-text)",
+                    flex: 1,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {/* No plan name stored in DB — show nothing here; exercises speak for themselves */}
+                </span>
+                {day.isCompleted && (
+                  <span style={{ color: "#34d399", fontSize: 14, marginLeft: 4, flexShrink: 0 }}>✓</span>
+                )}
+                <span style={{ color: "var(--color-text-faint, var(--color-text-muted))", flexShrink: 0 }}>
+                  {isOpen ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                </span>
+              </button>
+
+              {/* Card body */}
+              {isOpen && (
+                <div
+                  style={{
+                    padding: "12px 14px 14px",
+                    borderTop: "1px solid var(--color-border)",
+                    background: "var(--color-bg, var(--color-surface))",
+                  }}
+                >
+                  <PhaseSection label="Warm-up" exercises={day.plan.warmup} />
+                  <PhaseSection label="Workout" exercises={day.plan.workout} />
+                  <div style={{ marginBottom: 0 }}>
+                    <PhaseSection label="Cool-down" exercises={day.plan.cooldown} />
+                  </div>
+                  {day.plan.notes && (
+                    <p style={{ fontSize: 12, color: "var(--color-text-muted)", marginTop: 8, fontStyle: "italic" }}>
+                      {day.plan.notes}
+                    </p>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -139,3 +139,24 @@ export interface JournalEntry {
   created_at: string;
   updated_at: string;
 }
+
+export interface WorkoutExercise {
+  exercise: string;
+  sets?: number;
+  reps?: string;
+  weight_lbs?: number | null;
+  notes?: string | null;
+}
+
+export interface WorkoutPlan {
+  id: string;
+  user_id: string;
+  date: string;
+  warmup: WorkoutExercise[];
+  workout: WorkoutExercise[];
+  cooldown: WorkoutExercise[];
+  notes: string | null;
+  calendar_event_id: string | null;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary
- Adds `workout_plans` Supabase table (per-user, per-date; warmup/workout/cooldown JSONB arrays + calendar_event_id)
- Three new chat tools: `get_workout_plan` (fetches current week), `assign_workout` (upserts plan + creates/updates timed Google Calendar event), `update_workout_exercise` (patches one exercise by name and refreshes calendar)
- New `WeeklyWorkoutPlan` client component: Mon–Sun cards with expand/collapse, Today badge, green checkmark for completed days
- Fitness page renders the component above the body comp chart; completed dates derived from existing workout_sessions query

## Test plan
- [ ] Apply migration: `supabase db push` — confirm `workout_plans` table exists
- [ ] Chat: "Assign me a push day workout for tomorrow at 6pm" — verify Supabase row + timed calendar event created
- [ ] Chat: "Update the bench press to 185 lbs" — verify `update_workout_exercise` patches the row and calendar description updates
- [ ] Visit `/fitness` — verify `WeeklyWorkoutPlan` renders above body comp chart, today's card expanded, completed days show ✓
- [ ] `cd web && npx tsc --noEmit` — zero errors ✓ (already verified)

Closes #192

🤖 Generated with [Claude Code](https://claude.ai/claude-code)