### PR TITLE
fix: auto-correct stale session on mount caused by router cache (#195)

### DIFF
--- a/web/src/components/chat/chat-page-client.tsx
+++ b/web/src/components/chat/chat-page-client.tsx
@@ -67,9 +67,51 @@ export default function ChatPageClient({ initialSessionId, initialMessages }: Pr
     }
   }, []);
 
+  // On mount: fetch the real session list and auto-correct if the Next.js router
+  // cache (staleTimes.dynamic: 300s) served a stale initialSessionId. API calls
+  // always bypass the router cache, so this gives us the authoritative Supabase state.
   useEffect(() => {
-    fetchSessions();
-  }, [fetchSessions]);
+    const initSessions = async () => {
+      try {
+        const res = await fetch("/api/chat/sessions");
+        if (!res.ok) return;
+        const data = await res.json();
+        const list: SessionPreview[] = data.sessions ?? [];
+        setSessions(list);
+
+        const mostRecent = list[0];
+        if (mostRecent && mostRecent.id !== activeSessionIdRef.current) {
+          // Server gave us a stale session — silently switch to the real latest one
+          setLoadingSession(true);
+          try {
+            const msgRes = await fetch(`/api/chat/sessions/${mostRecent.id}`);
+            if (msgRes.ok) {
+              const msgData = await msgRes.json();
+              const msgs: Message[] = (
+                msgData.messages as { id: string; role: string; content: string; created_at: string }[]
+              ).map((m) => ({
+                id: m.id,
+                role: m.role as "user" | "assistant",
+                content: m.content,
+                createdAt: new Date(m.created_at),
+              }));
+              setActiveSessionId(mostRecent.id);
+              setActiveMessages(msgs);
+              setHasMore(msgData.hasMore ?? false);
+              setOldestPosition(msgData.oldestPosition ?? null);
+              setRefreshKey((k) => k + 1);
+            }
+          } finally {
+            setLoadingSession(false);
+          }
+        }
+      } catch {
+        // non-fatal
+      }
+    };
+    initSessions();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Re-fetch messages when the user returns to this tab so stale router-cache
   // data doesn't leave the chat a few conversations behind.


### PR DESCRIPTION
## Summary
- On mount of `ChatPageClient`, fetch the authoritative session list from `/api/chat/sessions` (API calls bypass the Next.js router cache)
- If the most recent session in Supabase differs from what the server component provided, silently switch to the correct session before the user sees anything
- Fixes the root cause: `next.config.ts` sets `staleTimes.dynamic: 300` (5-minute client-side router cache), so SPA navigation to `/chat` within that window served yesterday's `initialSessionId` without re-running the server component

## Why the previous fix didn't cover this
PR #196 added a `visibilitychange` listener — that handles the case where you're already on `/chat`, send messages, switch to another tab, and come back. It does **not** fire on the initial mount triggered by tapping "Chat" in the nav (SPA navigation). Those two fixes now cover both scenarios together.

## Test plan
- [ ] Navigate away from chat to another page, wait, tap Chat in the nav — shows the correct most-recent session immediately
- [ ] Open the app fresh on mobile — shows the correct session
- [ ] Switch tabs and return — still works (visibilitychange fix from #196)
- [ ] Start a brand-new chat (no session yet) — no spurious fetch or flash
- [ ] `npx tsc --noEmit` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)