### PR TITLE
fix: meal scanner UX — upload vs scan, editable dish name, inline chat (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (meal scanner UX — issue #203)
+- **`web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx`** — split scan trigger into "Take Photo" (camera) and "From Library" (gallery) buttons across all three trigger locations: empty state, add-another row, and error recovery
+- **`web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx`** — re-estimation now applies `food_name` from API response to the item label; dish name field added to expanded edit panel for direct manual editing
+- **`web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx`** — replaced chat redirect with inline ephemeral Mr. Bridge panel; session is deleted on close so it never appears in chat history
+- **`web/src/app/(protected)/meals/InlineMealChat.tsx`** — new ephemeral inline chat component; prepends scanned nutrition context to first message, streams response via Vercel AI SDK data stream protocol
+- **`web/src/app/api/chat/sessions/[id]/route.ts`** — added DELETE handler; verifies ownership, deletes session row (messages cascade via ON DELETE CASCADE)
+
 ### Changed
 - **`README.md`** — replaced Mermaid architecture diagram with D2-rendered SVG (`docs/architecture.svg`); diagram now includes Renpho, Polygon.io/stocks pipeline, Notifications page, ntfy.sh alert scripts, and all 10 pages (#182)
 

--- a/web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx
+++ b/web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx
@@ -4,15 +4,17 @@ import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   Camera,
+  ImageIcon,
   Loader2,
+  MessageSquare,
   X,
   AlertCircle,
   ChevronDown,
   ChevronUp,
   RefreshCw,
-  Send,
   Trash2,
 } from "lucide-react";
+import InlineMealChat from "./InlineMealChat";
 
 type MealType = "breakfast" | "lunch" | "dinner" | "snack";
 type ScanPhase = "idle" | "loading" | "error" | "manual";
@@ -67,7 +69,8 @@ interface FoodPhotoAnalyzerProps {
 
 export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerProps) {
   const router = useRouter();
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const cameraInputRef = useRef<HTMLInputElement>(null);
+  const libraryInputRef = useRef<HTMLInputElement>(null);
 
   // ── Session state ─────────────────────────────────────────────────────────
   const [items, setItems] = useState<ScanItem[]>([]);
@@ -96,8 +99,8 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
   const [mealPrepType, setMealPrepType] = useState<MealType>("lunch");
   const [prepping, setPrepping] = useState(false);
 
-  // ── Chat handoff state ────────────────────────────────────────────────────
-  const [chatQuestion, setChatQuestion] = useState("");
+  // ── Inline chat state ────────────────────────────────────────────────────
+  const [showInlineChat, setShowInlineChat] = useState(false);
 
   // ── Derived totals ────────────────────────────────────────────────────────
   const combined = items.reduce(
@@ -183,7 +186,8 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
     const file = e.target.files?.[0];
     if (!file) return;
     // Reset so the same file can be scanned again
-    if (fileInputRef.current) fileInputRef.current.value = "";
+    if (cameraInputRef.current) cameraInputRef.current.value = "";
+    if (libraryInputRef.current) libraryInputRef.current.value = "";
 
     if (file.type === "image/heic" || file.name.toLowerCase().endsWith(".heic")) {
       setErrorMsg("In your iPhone Camera settings, set format to 'Most Compatible' and try again.");
@@ -275,6 +279,7 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
           item.id === id
             ? {
                 ...item,
+                label: data.food_name ?? item.label,
                 calories: data.calories ?? item.calories,
                 protein_g: data.protein_g ?? item.protein_g,
                 carbs_g: data.carbs_g ?? item.carbs_g,
@@ -376,17 +381,12 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
     }
   }
 
-  // ── Chat handoff ──────────────────────────────────────────────────────────
-  function handleSendToChat() {
-    if (!chatQuestion.trim() && items.length === 0) return;
-    const nutritionLines = items
+  // ── Inline chat context ───────────────────────────────────────────────────
+  function buildNutritionContext(): string {
+    const lines = items
       .map((i) => `- ${i.label}: ${Math.round(i.calories)} cal, ${Math.round(i.protein_g)}g protein, ${Math.round(i.carbs_g)}g carbs, ${Math.round(i.fat_g)}g fat`)
       .join("\n");
-    const prefillText = items.length > 0
-      ? `${chatQuestion.trim()}\n\n--- Scanned nutrition data ---\n${nutritionLines}\nCombined: ${Math.round(combined.calories)} cal, ${Math.round(combined.protein_g)}g protein, ${Math.round(combined.carbs_g)}g carbs, ${Math.round(combined.fat_g)}g fat`
-      : chatQuestion.trim();
-    sessionStorage.setItem("chatPrefill", prefillText);
-    router.push("/chat");
+    return `--- Scanned nutrition data ---\n${lines}\nCombined: ${Math.round(combined.calories)} cal, ${Math.round(combined.protein_g)}g protein, ${Math.round(combined.carbs_g)}g carbs, ${Math.round(combined.fat_g)}g fat`;
   }
 
   // ── Mode toggle ───────────────────────────────────────────────────────────
@@ -430,15 +430,9 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
       {/* Mode toggle — always visible */}
       {ModeToggle}
 
-      {/* Hidden file input */}
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept="image/*"
-        capture="environment"
-        className="hidden"
-        onChange={handleFileChange}
-      />
+      {/* Hidden file inputs — camera and library */}
+      <input ref={cameraInputRef}  type="file" accept="image/*" capture="environment" className="hidden" onChange={handleFileChange} />
+      <input ref={libraryInputRef} type="file" accept="image/*"                        className="hidden" onChange={handleFileChange} />
 
       {/* ── LOADING overlay ─────────────────────────────────────────────── */}
       {scanPhase === "loading" && (
@@ -471,7 +465,7 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
               onClick={() => {
                 setScanPhase("idle");
                 setErrorMsg("");
-                fileInputRef.current?.click();
+                cameraInputRef.current?.click();
               }}
               className="flex items-center gap-1.5 rounded-lg transition-opacity active:opacity-70"
               style={{
@@ -485,7 +479,26 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
               }}
             >
               <Camera size={13} />
-              Re-scan
+              Camera
+            </button>
+            <button
+              onClick={() => {
+                setScanPhase("idle");
+                setErrorMsg("");
+                libraryInputRef.current?.click();
+              }}
+              className="flex items-center gap-1.5 rounded-lg transition-opacity active:opacity-70"
+              style={{
+                border: "1px solid var(--color-border)",
+                color: "var(--color-text-muted)",
+                fontSize: 13,
+                padding: "8px 14px",
+                background: "transparent",
+                cursor: "pointer",
+              }}
+            >
+              <ImageIcon size={13} />
+              From Library
             </button>
             <button
               onClick={() => {
@@ -585,22 +598,40 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
           <p style={{ fontSize: 14, color: "var(--color-text-muted)", textAlign: "center" }}>
             Scan a nutrition label or food photo to get started.
           </p>
-          <button
-            onClick={() => fileInputRef.current?.click()}
-            className="flex items-center justify-center gap-2 rounded-xl font-medium transition-opacity active:opacity-70"
-            style={{
-              background: "var(--color-primary)",
-              color: "#fff",
-              fontSize: 15,
-              padding: "13px 24px",
-              minHeight: 48,
-              border: "none",
-              cursor: "pointer",
-            }}
-          >
-            <Camera size={17} />
-            Scan
-          </button>
+          <div className="flex gap-2">
+            <button
+              onClick={() => cameraInputRef.current?.click()}
+              className="flex items-center justify-center gap-2 rounded-xl font-medium transition-opacity active:opacity-70"
+              style={{
+                background: "var(--color-primary)",
+                color: "#fff",
+                fontSize: 15,
+                padding: "13px 24px",
+                minHeight: 48,
+                border: "none",
+                cursor: "pointer",
+              }}
+            >
+              <Camera size={17} />
+              Take Photo
+            </button>
+            <button
+              onClick={() => libraryInputRef.current?.click()}
+              className="flex items-center justify-center gap-2 rounded-xl font-medium transition-opacity active:opacity-70"
+              style={{
+                border: "1px solid var(--color-border)",
+                color: "var(--color-text-muted)",
+                fontSize: 15,
+                padding: "13px 24px",
+                minHeight: 48,
+                background: "transparent",
+                cursor: "pointer",
+              }}
+            >
+              <ImageIcon size={17} />
+              From Library
+            </button>
+          </div>
         </div>
       )}
 
@@ -644,9 +675,22 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
                   </div>
                 </div>
 
-                {/* Expand: ingredients + re-estimate */}
+                {/* Expand: dish name + ingredients + re-estimate */}
                 {expanded && item.mode === "food" && (
                   <div className="mt-3 flex flex-col gap-2">
+                    <label style={{ fontSize: 11, color: "var(--color-text-muted)", display: "block", marginBottom: 2 }}>
+                      Dish name
+                    </label>
+                    <input
+                      type="text"
+                      value={item.label}
+                      onChange={(e) =>
+                        setItems((prev) =>
+                          prev.map((i) => i.id === item.id ? { ...i, label: e.target.value } : i)
+                        )
+                      }
+                      style={{ ...inputStyle, fontWeight: 600, fontSize: 14 }}
+                    />
                     <label style={{ fontSize: 11, color: "var(--color-text-muted)", display: "block", marginBottom: 2 }}>
                       Ingredients
                     </label>
@@ -694,22 +738,42 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
 
           {/* Add another scan */}
           {scanPhase === "idle" && (
-            <button
-              onClick={() => fileInputRef.current?.click()}
-              className="flex items-center justify-center gap-2 rounded-xl transition-opacity active:opacity-70"
-              style={{
-                border: "1px solid var(--color-border)",
-                color: "var(--color-text-muted)",
-                fontSize: 14,
-                padding: "10px 16px",
-                minHeight: 44,
-                background: "transparent",
-                cursor: "pointer",
-              }}
-            >
-              <Camera size={14} />
-              Add another scan
-            </button>
+            <div className="flex gap-2">
+              <button
+                onClick={() => cameraInputRef.current?.click()}
+                className="flex items-center justify-center gap-2 rounded-xl transition-opacity active:opacity-70"
+                style={{
+                  border: "1px solid var(--color-border)",
+                  color: "var(--color-text-muted)",
+                  fontSize: 13,
+                  padding: "9px 14px",
+                  minHeight: 40,
+                  background: "transparent",
+                  cursor: "pointer",
+                  flex: 1,
+                }}
+              >
+                <Camera size={13} />
+                Take Photo
+              </button>
+              <button
+                onClick={() => libraryInputRef.current?.click()}
+                className="flex items-center justify-center gap-2 rounded-xl transition-opacity active:opacity-70"
+                style={{
+                  border: "1px solid var(--color-border)",
+                  color: "var(--color-text-muted)",
+                  fontSize: 13,
+                  padding: "9px 14px",
+                  minHeight: 40,
+                  background: "transparent",
+                  cursor: "pointer",
+                  flex: 1,
+                }}
+              >
+                <ImageIcon size={13} />
+                From Library
+              </button>
+            </div>
           )}
         </div>
       )}
@@ -733,51 +797,28 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
           </div>
 
           {/* Ask Mr. Bridge */}
-          <div className="flex flex-col gap-2">
-            <div className="flex gap-2">
-              <input
-                type="text"
-                placeholder="Ask Mr. Bridge…"
-                value={chatQuestion}
-                onChange={(e) => setChatQuestion(e.target.value)}
-                onKeyDown={(e) => { if (e.key === "Enter") handleSendToChat(); }}
-                style={{ ...inputStyle, flex: 1, fontSize: 14 }}
-              />
-              <button
-                onClick={handleSendToChat}
-                disabled={!chatQuestion.trim() && items.length === 0}
-                className="flex items-center justify-center rounded-xl transition-opacity active:opacity-70 disabled:opacity-40"
-                style={{
-                  background: "var(--color-primary)",
-                  color: "#fff",
-                  padding: "10px 14px",
-                  border: "none",
-                  cursor: "pointer",
-                  flexShrink: 0,
-                }}
-                title="Send to Chat"
-              >
-                <Send size={15} />
-              </button>
-            </div>
-            <div className="flex gap-2 flex-wrap">
-              {["What can I make with these?", "Calculate my macros"].map((q) => (
-                <button
-                  key={q}
-                  onClick={() => setChatQuestion(q)}
-                  className="rounded-full transition-opacity active:opacity-70"
-                  style={{
-                    ...pillBtnBase,
-                    background: "transparent",
-                    color: "var(--color-text-muted)",
-                    fontSize: 12,
-                  }}
-                >
-                  {q}
-                </button>
-              ))}
-            </div>
-          </div>
+          {!showInlineChat ? (
+            <button
+              onClick={() => setShowInlineChat(true)}
+              className="flex items-center gap-2 rounded-xl transition-opacity active:opacity-70"
+              style={{
+                border: "1px solid var(--color-border)",
+                color: "var(--color-text-muted)",
+                fontSize: 14,
+                padding: "10px 16px",
+                background: "transparent",
+                cursor: "pointer",
+              }}
+            >
+              <MessageSquare size={14} />
+              Ask Mr. Bridge…
+            </button>
+          ) : (
+            <InlineMealChat
+              initialContext={buildNutritionContext()}
+              onClose={() => setShowInlineChat(false)}
+            />
+          )}
 
           {/* Sheet error */}
           {errorMsg && scanPhase === "idle" && (

--- a/web/src/app/(protected)/meals/InlineMealChat.tsx
+++ b/web/src/app/(protected)/meals/InlineMealChat.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Send, X } from "lucide-react";
+
+interface Props {
+  initialContext: string;
+  onClose: () => void;
+}
+
+const inputStyle = {
+  background: "var(--color-bg)",
+  border: "1px solid var(--color-border)",
+  color: "var(--color-text)",
+  outline: "none",
+  fontSize: 16,
+  borderRadius: 8,
+  padding: "10px 12px",
+  width: "100%",
+  WebkitAppearance: "none" as const,
+} as const;
+
+export default function InlineMealChat({ initialContext, onClose }: Props) {
+  const [sessionId] = useState(() => crypto.randomUUID());
+  const [messages, setMessages] = useState<{ role: "user" | "assistant"; content: string }[]>([]);
+  const [input, setInput] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  async function sendMessage(text: string) {
+    if (!text.trim() || isLoading) return;
+
+    const userMsg = { role: "user" as const, content: text };
+    const displayMessages = [...messages, userMsg];
+    setMessages(displayMessages);
+    setInput("");
+    setIsLoading(true);
+
+    // Prepend nutrition context to the first user message in the API payload only.
+    // The UI shows the user's actual text without the prefix.
+    const apiMessages = displayMessages.map((m, i) =>
+      i === 0 && m.role === "user"
+        ? { ...m, content: `${initialContext}\n\n${m.content}` }
+        : m
+    );
+
+    try {
+      const res = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sessionId,
+          messages: apiMessages,
+          model: "auto",
+        }),
+      });
+
+      if (!res.ok || !res.body) throw new Error("Request failed");
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let assistantText = "";
+      setMessages((prev) => [...prev, { role: "assistant", content: "" }]);
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        const chunk = decoder.decode(value, { stream: true });
+        for (const line of chunk.split("\n")) {
+          if (line.startsWith("0:")) {
+            try {
+              const token = JSON.parse(line.slice(2));
+              assistantText += token;
+              setMessages((prev) => [
+                ...prev.slice(0, -1),
+                { role: "assistant", content: assistantText },
+              ]);
+            } catch {
+              // ignore malformed chunks
+            }
+          }
+        }
+      }
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        { role: "assistant", content: "Something went wrong. Try again." },
+      ]);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  function handleClose() {
+    // Fire-and-forget — don't block UI on deletion
+    fetch(`/api/chat/sessions/${sessionId}`, { method: "DELETE" }).catch(() => {});
+    onClose();
+  }
+
+  return (
+    <div
+      className="rounded-xl overflow-hidden flex flex-col"
+      style={{
+        border: "1px solid var(--color-border)",
+        background: "var(--color-surface)",
+        maxHeight: 360,
+      }}
+    >
+      {/* Header */}
+      <div
+        className="flex items-center justify-between px-4 py-2.5"
+        style={{ borderBottom: "1px solid var(--color-border)" }}
+      >
+        <span style={{ fontSize: 13, fontWeight: 600, color: "var(--color-text)" }}>
+          Mr. Bridge
+        </span>
+        <button
+          onClick={handleClose}
+          style={{ background: "none", border: "none", cursor: "pointer", color: "var(--color-text-muted)", padding: 4 }}
+        >
+          <X size={15} />
+        </button>
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3" style={{ minHeight: 120 }}>
+        {messages.length === 0 && (
+          <p style={{ fontSize: 13, color: "var(--color-text-muted)", textAlign: "center" }}>
+            Ask anything about your scanned items.
+          </p>
+        )}
+        {messages.map((m, i) => (
+          <div key={i} className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}>
+            <div
+              className="rounded-2xl px-3 py-2"
+              style={{
+                fontSize: 13,
+                maxWidth: "85%",
+                background: m.role === "user" ? "var(--color-primary)" : "var(--color-bg)",
+                color: m.role === "user" ? "#fff" : "var(--color-text)",
+                border: m.role === "assistant" ? "1px solid var(--color-border)" : "none",
+                whiteSpace: "pre-wrap",
+                lineHeight: 1.5,
+              }}
+            >
+              {m.content || (isLoading && m.role === "assistant" ? "…" : "")}
+            </div>
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Input */}
+      <div
+        className="flex gap-2 px-3 pb-3 pt-2"
+        style={{ borderTop: "1px solid var(--color-border)" }}
+      >
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              sendMessage(input);
+            }
+          }}
+          placeholder="Ask Mr. Bridge…"
+          disabled={isLoading}
+          style={{ ...inputStyle, flex: 1, fontSize: 14 }}
+        />
+        <button
+          onClick={() => sendMessage(input)}
+          disabled={isLoading || !input.trim()}
+          style={{
+            background: "var(--color-primary)",
+            color: "#fff",
+            border: "none",
+            borderRadius: 10,
+            padding: "10px 13px",
+            cursor: "pointer",
+            opacity: isLoading || !input.trim() ? 0.4 : 1,
+            flexShrink: 0,
+          }}
+        >
+          <Send size={14} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/api/chat/sessions/[id]/route.ts
+++ b/web/src/app/api/chat/sessions/[id]/route.ts
@@ -39,3 +39,27 @@ export async function GET(
     oldestPosition: ordered[0]?.position ?? null,
   });
 }
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  // Verify ownership
+  const { data: session } = await supabase
+    .from("chat_sessions")
+    .select("user_id")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (!session || session.user_id !== user.id)
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  await supabase.from("chat_sessions").delete().eq("id", id);
+  // chat_messages deleted automatically via ON DELETE CASCADE
+  return NextResponse.json({ deleted: true });
+}


### PR DESCRIPTION
## Summary

- **Upload vs scan**: split single camera-only button into "Take Photo" (camera) and "From Library" (gallery picker) across all three trigger locations — empty state, add-another row, and error recovery
- **Editable dish name**: added dish name input field in the expanded edit panel; re-estimation now also applies `food_name` from the API response to the item label (was always returned, never applied)
- **Inline Mr. Bridge chat**: replaced chat redirect with an ephemeral inline panel; nutrition context is silently prepended to the first message; session is deleted on close so it never shows in chat history

Inline chat is advisory — user discusses the food with Mr. Bridge, then manually applies any corrections via the ingredients field + Re-estimate button.

## Files changed

- `web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx` — all three fixes
- `web/src/app/(protected)/meals/InlineMealChat.tsx` — new ephemeral chat component
- `web/src/app/api/chat/sessions/[id]/route.ts` — added DELETE handler (ownership check + cascade delete)
- `CHANGELOG.md`

## Test plan

- [ ] On mobile: empty state shows "Take Photo" + "From Library" buttons; camera button opens camera; library button opens gallery picker
- [ ] After scan error: "Camera" and "From Library" side by side in recovery panel
- [ ] After items exist: "Take Photo" / "From Library" row replaces the old single button
- [ ] Re-estimate a food item — label updates to `food_name` returned by the API
- [ ] Edit dish name directly in the expanded panel — label updates immediately
- [ ] With items scanned, tap "Ask Mr. Bridge…" — inline panel opens without navigating away
- [ ] Send a message — streams response correctly
- [ ] Tap X — panel closes; `DELETE /api/chat/sessions/:id` fires (Network tab: expect `{"deleted":true}`)
- [ ] After close: session does NOT appear in `/chat` history
- [ ] `npx tsc --noEmit` — zero errors

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)