### PR TITLE
fix: re-check active session on tab return (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (chat stale session on tab return — issue #206)
+- **`web/src/components/chat/chat-page-client.tsx`** — visibility-change handler now re-fetches `/api/chat/sessions` and switches to the most recent session before loading messages, mirroring the mount-time correction; fixes residual stale-conversation bug from #195 when `activeSessionId` itself was stale
+
 ### Fixed (meal scanner UX — issue #203)
 - **`web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx`** — split scan trigger into "Take Photo" (camera) and "From Library" (gallery) buttons across all three trigger locations: empty state, add-another row, and error recovery
 - **`web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx`** — re-estimation now applies `food_name` from API response to the item label; dish name field added to expanded edit panel for direct manual editing

--- a/web/src/components/chat/chat-page-client.tsx
+++ b/web/src/components/chat/chat-page-client.tsx
@@ -131,10 +131,22 @@ export default function ChatPageClient({ initialSessionId, initialMessages }: Pr
   useEffect(() => {
     const handleVisibility = async () => {
       if (document.visibilityState !== "visible") return;
-      const sessionId = activeSessionIdRef.current;
       // Skip if this is a brand-new unsaved session (nothing to fetch yet)
       if (!initialSessionId && activeMessages.length === 0) return;
       try {
+        // Re-check which session should be active — router cache may have given us
+        // a stale activeSessionId, so trust the authoritative sessions list.
+        const listRes = await fetch("/api/chat/sessions");
+        let sessionId = activeSessionIdRef.current;
+        if (listRes.ok) {
+          const listData = await listRes.json();
+          const list: SessionPreview[] = listData.sessions ?? [];
+          setSessions(list);
+          if (list[0] && list[0].id !== sessionId) {
+            sessionId = list[0].id;
+            setActiveSessionId(sessionId);
+          }
+        }
         const res = await fetch(`/api/chat/sessions/${sessionId}`);
         if (!res.ok) return;
         const data = await res.json();


### PR DESCRIPTION
## Summary
- Follow-up to #195. The visibility-change handler re-fetched messages for `activeSessionIdRef.current` but never re-checked whether that session was still the most recent — so if the router cache had seeded a stale `activeSessionId`, tab-return kept reloading the same stale session.
- `handleVisibility` now hits `/api/chat/sessions` first; if `list[0].id` differs from the current active session, it switches before fetching messages (mirrors the mount-time `initSessions` correction).

Closes #206.

## Test plan
- [ ] Start a conversation, leave the tab for >5 min, return — chat shows the most recent session
- [ ] Brand-new unsaved session still skips the fetch
- [ ] Switching sessions via sidebar still works
- [ ] `npx tsc --noEmit` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)