### PR TITLE
fix: bypass Next.js fetch cache on /chat SSR (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (chat SSR fetch cache — issue #208)
+- **`web/src/app/(protected)/chat/page.tsx`** — added `export const fetchCache = "force-no-store"` so Supabase queries on the chat route bypass Next.js Data Cache; SSR was replaying cached rows from an earlier render, causing `/chat` to render messages from old positions in the same session. `force-dynamic` alone does not disable sub-request fetch caching.
+
 ### Fixed (chat stale session on tab return — issue #206)
 - **`web/src/components/chat/chat-page-client.tsx`** — visibility-change handler now re-fetches `/api/chat/sessions` and switches to the most recent session before loading messages, mirroring the mount-time correction; fixes residual stale-conversation bug from #195 when `activeSessionId` itself was stale
 

--- a/web/src/app/(protected)/chat/page.tsx
+++ b/web/src/app/(protected)/chat/page.tsx
@@ -1,4 +1,5 @@
 export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
 
 import { createClient } from "@/lib/supabase/server";
 import ChatPageClient from "@/components/chat/chat-page-client";


### PR DESCRIPTION
## Summary
- Real root cause behind #195 / #206. Next.js Data Cache was serving stale Supabase rows to SSR: `supabase.from().select()` uses `fetch()` internally, Next caches GET responses by URL, writes use different URLs (POST/PATCH) and don't invalidate the cached GET, so new messages never appeared.
- `force-dynamic` opts the route out of static generation but does NOT disable sub-request fetch caching — a common misconception.
- Fix: `export const fetchCache = "force-no-store"` on `/chat` page → every fetch in the render passes `cache: 'no-store'` → Supabase queries hit the live DB every time.

Closes #208.

## Test plan
- [ ] Hard refresh `/chat` — most recent messages of the current session render (not stale ones from an old position)
- [ ] Send a message, hard refresh — it persists
- [ ] `npx tsc --noEmit` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)