### PR TITLE
fix: /chat SSR loads latest messages, not oldest (#210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (chat SSR loaded oldest messages, not latest — issue #210)
+- **`web/src/app/(protected)/chat/page.tsx`** — SSR query was `order("created_at", asc).limit(50)`, returning the **oldest** 50 messages; for long sessions (86+ messages) this rendered positions 1–50 instead of the latest 20. Now mirrors the `/api/chat/sessions/[id]` API: `order("position", desc).limit(20)`, reversed for display. Also passes `initialHasMore` / `initialOldestPosition` to `ChatPageClient` so "Load older" pagination works from first paint.
+- **`web/src/components/chat/chat-page-client.tsx`** — accepts `initialHasMore` / `initialOldestPosition` props and seeds the corresponding state from SSR.
+
 ### Fixed (chat SSR fetch cache — issue #208)
 - **`web/src/app/(protected)/chat/page.tsx`** — added `export const fetchCache = "force-no-store"` so Supabase queries on the chat route bypass Next.js Data Cache; SSR was replaying cached rows from an earlier render, causing `/chat` to render messages from old positions in the same session. `force-dynamic` alone does not disable sub-request fetch caching.
 

--- a/web/src/app/(protected)/chat/page.tsx
+++ b/web/src/app/(protected)/chat/page.tsx
@@ -19,22 +19,28 @@ export default async function ChatPage() {
     .maybeSingle();
 
   let initialMessages: Message[] = [];
+  let initialHasMore = false;
+  let initialOldestPosition: number | null = null;
   if (session?.id) {
+    const LIMIT = 20;
     const { data: msgs } = await supabase
       .from("chat_messages")
-      .select("id, role, content, created_at")
+      .select("id, role, content, created_at, position")
       .eq("session_id", session.id)
       .in("role", ["user", "assistant"])
-      .order("created_at", { ascending: true })
-      .limit(50);
+      .order("position", { ascending: false })
+      .limit(LIMIT);
 
     if (msgs) {
-      initialMessages = (msgs as ChatMessage[]).map((m) => ({
+      const ordered = [...(msgs as (ChatMessage & { position: number })[])].reverse();
+      initialMessages = ordered.map((m) => ({
         id: m.id,
         role: m.role as "user" | "assistant",
         content: m.content,
         createdAt: new Date(m.created_at),
       }));
+      initialHasMore = msgs.length === LIMIT;
+      initialOldestPosition = ordered[0]?.position ?? null;
     }
   }
 
@@ -43,6 +49,8 @@ export default async function ChatPage() {
       <ChatPageClient
         initialSessionId={(session as ChatSession | null)?.id ?? null}
         initialMessages={initialMessages}
+        initialHasMore={initialHasMore}
+        initialOldestPosition={initialOldestPosition}
       />
     </div>
   );

--- a/web/src/components/chat/chat-page-client.tsx
+++ b/web/src/components/chat/chat-page-client.tsx
@@ -11,19 +11,26 @@ import type { SessionPreview } from "@/app/api/chat/sessions/route";
 interface Props {
   initialSessionId: string | null;
   initialMessages: Message[];
+  initialHasMore?: boolean;
+  initialOldestPosition?: number | null;
 }
 
 function newSessionId(): string {
   return crypto.randomUUID();
 }
 
-export default function ChatPageClient({ initialSessionId, initialMessages }: Props) {
+export default function ChatPageClient({
+  initialSessionId,
+  initialMessages,
+  initialHasMore = false,
+  initialOldestPosition = null,
+}: Props) {
   const [activeSessionId, setActiveSessionId] = useState<string>(
     initialSessionId ?? newSessionId()
   );
   const [activeMessages, setActiveMessages] = useState<Message[]>(initialMessages);
-  const [hasMore, setHasMore] = useState(false);
-  const [oldestPosition, setOldestPosition] = useState<number | null>(null);
+  const [hasMore, setHasMore] = useState(initialHasMore);
+  const [oldestPosition, setOldestPosition] = useState<number | null>(initialOldestPosition);
   const [loadingMore, setLoadingMore] = useState(false);
   // Incrementing this key forces ChatInterface to remount with fresh initialMessages
   const [refreshKey, setRefreshKey] = useState(0);


### PR DESCRIPTION
## Summary
- Actual root cause of the stale-chat symptom. SSR query was `.order("created_at", asc).limit(50)` — that's the **oldest** 50, not the latest. For long sessions (86+ msgs), SSR rendered positions 1–50 while the API correctly returns positions 67–86 — which is why switching sessions + coming back "fixed" it (that path uses the API).
- Fix mirrors the API: `order("position", desc).limit(20)`, reversed for display. Pass `initialHasMore` / `initialOldestPosition` through so "Load older" works from first paint.
- #208's fetchCache fix was a red herring — the Data Cache wasn't involved.

Closes #210.

## Test plan
- [ ] Hard refresh `/chat` — shows the most recent messages of the active session
- [ ] "Load older" paginates correctly from the first paint
- [ ] `npx tsc --noEmit` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)