### PR TITLE
feat: sports dashboard widget with ESPN provider (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (sports dashboard widget — issue #141)
+- **`supabase/migrations/20260415000001_add_sports_cache.sql`** — `sports_cache` table (`user_id`, `team_id`, `league`, `data jsonb`, `fetched_at`) with `unique(user_id, team_id)` and RLS on `auth.uid()`.
+- **`web/src/lib/sync/sports/provider.ts`** — `SportsProvider` interface + normalized `Team`, `Game`, `Standing`, `SportsCacheData` types. Sport-agnostic shape so swapping providers is a one-file change.
+- **`web/src/lib/sync/sports/thesportsdb.ts`** — TheSportsDB implementation. Maps raw API shapes into normalized types; computes current season heuristically per league.
+- **`web/src/lib/sync/sports/index.ts`** — `syncSports(db, userId, favorites)`: per-team try/catch, upserts one row per team, evicts cache for teams no longer favorited.
+- **`web/src/app/api/sports/search/route.ts`** — authenticated GET proxy → provider search; keeps API key server-side.
+- **`web/src/app/api/sports/refresh/route.ts`** — authenticated POST → live sync for the user's favorites.
+- **`web/src/components/dashboard/sports-card.tsx`** — dashboard widget. Collapsed row shows team + next game + last result (W/L color-coded); expand reveals standings + last 3 results. Empty-state links to `/settings#sports`. `var(--color-*)` only.
+- **`web/src/components/settings/sports-settings.tsx`** — Settings section with debounced (300ms) team search via the proxy route, picker, and remove buttons.
+- **`web/src/lib/types.ts`** — added `SportsCache` interface.
+
+### Changed (sports dashboard widget — issue #141)
+- **`web/src/app/api/cron/sync/route.ts`** — appended sports step after stocks; reads `sports_favorites`, calls `syncSports` with try/catch, no skip window.
+- **`web/src/app/(protected)/dashboard/page.tsx`** — queries `sports_cache` + `sports_favorites`, renders `<SportsCard>`, exposes `refreshSports` server action.
+- **`web/src/app/(protected)/settings/page.tsx`** — mounts `<SportsSettings>`; `saveSportsFavorites` persists JSON to `profile` and evicts orphaned `sports_cache` rows.
+- **`web/src/app/api/chat/route.ts`** — registered `get_sports_data` tool inline next to `get_stock_quote`. Cache-first; live-fetches when cache is >12h old or the queried game is within 24h of now.
+- **`web/.env.local.example`** + **`README.md`** — documented `SPORTSDB_API_KEY` (defaults to public test key `3` if unset).
+- **`supabase/migrations/20260415000002_sports_cache_unique_per_league.sql`** — re-keys the unique constraint on `sports_cache` to `(user_id, team_id, league)`. ESPN team IDs are only unique within a league (Celtics NBA id=2 ≠ Bills NFL id=2); the previous `(user_id, team_id)` constraint would have merged cross-league rows.
+- **`web/src/lib/sync/sports/espn.ts`** — ESPN unofficial-API provider (NBA/NFL/MLB/NHL/F1). Free, no key, no rate limit. Becomes the default; TheSportsDB stays as opt-in fallback via `SPORTS_PROVIDER=thesportsdb`.
+- **`web/src/lib/sync/sports/provider.ts`** — `SportsProvider.getUpcoming/getRecent/getStandings` now take a `TeamRef` (carrying `league_id`) instead of a bare `teamId` so providers can dispatch per-sport endpoints. `Team` gains a nullable `color` (hex) for fallback badges when no logo is available (e.g. F1 constructors).
+- **F1 special-casing in `sports-card.tsx`** — race name + date in place of "vs/@ opponent"; W/L coloring suppressed; standings line shows constructor rank + championship points without W-L record. Initials-on-color fallback badge for teams without logo URLs.
+- **Smart-stale auto-refresh on dashboard load** — `watchlist-widget.tsx` and `sports-card.tsx` fire their refresh action in a non-blocking `useEffect` when the cache is stale (stocks: >1h during US market hours M-F 9:30am–4pm ET, >12h otherwise; sports: >6h, or any favorite missing a row). Keeps page render fast — auto-refresh hydrates after first paint.
+- **Polygon rate-limit surfacing** — `syncStocks` now returns `{ rateLimited }`; `WatchlistWidget` shows an amber banner with `AlertTriangle` when a *manual* refresh hits the 5/min free-tier limit. Auto-refresh failures stay silent so the banner isn't persistent.
+- **Watchlist sparkline 30-day window** — was 7 trading days (visually flat for stable tickers); now 30. Same Polygon call count, just a wider date range.
+- **Dashboard layout reorder** — Schedule (full width) → Habits + Tasks → Watchlist + Sports → Important Emails. Stock + sports cards now sit together in their own row instead of bracketing Habits/Tasks.
+- **`important-emails.tsx`** — emails received before today now show `Mon 4/13 9:47 AM` instead of just `9:47 AM`; today's emails still show only the time.
+
 ### Added (chat UX — issue #205)
 - **`supabase/migrations/20260415000000_chat_sessions_soft_delete.sql`** — adds `deleted_at timestamptz` column + index to `chat_sessions`; enables archive with 30-day restore window.
 - **`web/src/lib/relative-time.ts`** — dep-free helpers (`formatRelative`, `formatDaySeparator`, `isSameDay`, `daysUntilPurge`) for sidebar and thread timestamps.

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Fill in each file using the values collected in steps 2–6. Every variable has 
 | `CRON_SECRET` | Generate a random string, e.g. `openssl rand -hex 32` |
 | `APP_URL` | Your Vercel deployment URL *(optional — enables notification tap-to-open)* |
 | `POLYGON_API_KEY` | [polygon.io](https://polygon.io) → Dashboard → API Keys *(optional — stock watchlist widget + `get_stock_quote` chat tool; free tier supports EOD data)* |
+| `SPORTSDB_API_KEY` | [thesportsdb.com](https://www.thesportsdb.com/api.php) → personal key *(optional — sports dashboard widget + `get_sports_data` chat tool; defaults to public test key `3` if unset)* |
 
 ### Step 8 — Deploy to Vercel
 

--- a/supabase/migrations/20260415000001_add_sports_cache.sql
+++ b/supabase/migrations/20260415000001_add_sports_cache.sql
@@ -1,0 +1,14 @@
+create table if not exists sports_cache (
+  id          uuid primary key default gen_random_uuid(),
+  user_id     uuid not null references auth.users(id),
+  team_id     text not null,
+  league      text not null,
+  data        jsonb not null,
+  fetched_at  timestamptz not null default now(),
+  unique (user_id, team_id)
+);
+create index on sports_cache (user_id, team_id);
+alter table sports_cache enable row level security;
+create policy "users manage own sports cache"
+  on sports_cache for all to authenticated
+  using (user_id = auth.uid()) with check (user_id = auth.uid());

--- a/supabase/migrations/20260415000002_sports_cache_unique_per_league.sql
+++ b/supabase/migrations/20260415000002_sports_cache_unique_per_league.sql
@@ -1,0 +1,8 @@
+-- ESPN team IDs are only unique within a league (Celtics NBA id=2, Bills NFL id=2).
+-- Re-key the unique constraint to include league so cross-league collisions don't merge rows.
+alter table sports_cache
+  drop constraint if exists sports_cache_user_id_team_id_key;
+
+alter table sports_cache
+  add constraint sports_cache_user_id_team_id_league_key
+  unique (user_id, team_id, league);

--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -60,6 +60,13 @@ CRON_SECRET=<generate-with-openssl-rand-hex-32>
 # Get your key at: https://polygon.io → Dashboard → API Keys
 POLYGON_API_KEY=<your-polygon-api-key>
 
+# ── Sports widget (optional) ──────────────────────────────────────────────────
+# TheSportsDB API key — covers NBA, NFL, MLB, NHL, EPL, and most global leagues
+# Used by the dashboard sports widget and the `get_sports_data` chat tool
+# The public test key "3" works for low-volume use; sign up for a personal key at:
+# https://www.thesportsdb.com/api.php
+SPORTSDB_API_KEY=3
+
 # ── Web app URL (optional) ────────────────────────────────────────────────────
 # Your deployed Vercel URL — when set, push notification tap-to-open links
 # will point to the relevant page in your web app

--- a/web/src/app/(protected)/dashboard/page.tsx
+++ b/web/src/app/(protected)/dashboard/page.tsx
@@ -14,14 +14,16 @@ import ScheduleToday from "@/components/dashboard/schedule-today";
 import ImportantEmails from "@/components/dashboard/important-emails";
 import TasksSummary from "@/components/dashboard/tasks-summary";
 import { WatchlistWidget } from "@/components/dashboard/watchlist-widget";
+import { SportsCard } from "@/components/dashboard/sports-card";
 import { syncStocks } from "@/lib/sync/stocks";
-import type { HabitLog, HabitRegistry, FitnessLog, RecoveryMetrics, Task, StocksCache } from "@/lib/types";
+import { syncSports, type SportsFavorite } from "@/lib/sync/sports";
+import type { HabitLog, HabitRegistry, FitnessLog, RecoveryMetrics, Task, StocksCache, SportsCache } from "@/lib/types";
 
-async function refreshStocks() {
+async function refreshStocks(): Promise<{ rateLimited: boolean }> {
   "use server";
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return;
+  if (!user) return { rateLimited: false };
 
   const { data: profileRow } = await supabase
     .from("profile")
@@ -34,8 +36,35 @@ async function refreshStocks() {
     ? (JSON.parse(profileRow.value) as string[])
     : [];
 
+  let rateLimited = false;
   if (tickers.length > 0) {
-    await syncStocks(supabase, user.id, tickers);
+    const result = await syncStocks(supabase, user.id, tickers);
+    rateLimited = !!result.rateLimited;
+  }
+
+  revalidatePath("/dashboard");
+  return { rateLimited };
+}
+
+async function refreshSports() {
+  "use server";
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return;
+
+  const { data: profileRow } = await supabase
+    .from("profile")
+    .select("value")
+    .eq("user_id", user.id)
+    .eq("key", "sports_favorites")
+    .single();
+
+  const favorites: SportsFavorite[] = profileRow?.value
+    ? (JSON.parse(profileRow.value) as SportsFavorite[])
+    : [];
+
+  if (favorites.length > 0) {
+    await syncSports(supabase, user.id, favorites);
   }
 
   revalidatePath("/dashboard");
@@ -69,6 +98,8 @@ export default async function DashboardPage() {
     profileRes,
     tasksRes,
     stocksRes,
+    sportsRes,
+    sportsFavoritesRes,
   ] = await Promise.all([
     // Latest 2 rows with body fat (for delta calculations)
     supabase
@@ -121,6 +152,14 @@ export default async function DashboardPage() {
       .from("stocks_cache")
       .select("*")
       .order("ticker", { ascending: true }),
+    supabase
+      .from("sports_cache")
+      .select("*"),
+    supabase
+      .from("profile")
+      .select("value")
+      .eq("key", "sports_favorites")
+      .maybeSingle(),
   ]);
 
   // ── Wrangling ──────────────────────────────────────────────────────────────
@@ -149,6 +188,10 @@ export default async function DashboardPage() {
   );
 
   const stocksRows = (stocksRes.data ?? []) as StocksCache[];
+  const sportsRows = (sportsRes.data ?? []) as SportsCache[];
+  const sportsFavorites: SportsFavorite[] = sportsFavoritesRes.data?.value
+    ? (JSON.parse(sportsFavoritesRes.data.value) as SportsFavorite[])
+    : [];
 
   const nameRows = (profileRes.data ?? []) as { key: string; value: string }[];
   const userName =
@@ -186,15 +229,8 @@ export default async function DashboardPage() {
         windowLabel={windowKey.toUpperCase()}
       />
 
-      {/* ── Schedule + Watchlist: live time-bounded data ─────────────── */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <ScheduleToday />
-        <WatchlistWidget
-          rows={stocksRows}
-          hasApiKey={!!process.env.POLYGON_API_KEY}
-          refreshAction={refreshStocks}
-        />
-      </div>
+      {/* ── Schedule today (full width) ──────────────────────────────── */}
+      <ScheduleToday />
 
       {/* ── Habits + Tasks: fixed height, scrollable ─────────────────── */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -206,6 +242,26 @@ export default async function DashboardPage() {
           date={today}
         />
         <TasksSummary tasks={tasks} />
+      </div>
+
+      {/* ── Watchlist + Sports: market + favorite teams ──────────────── */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <WatchlistWidget
+          rows={stocksRows}
+          hasApiKey={!!process.env.POLYGON_API_KEY}
+          refreshAction={refreshStocks}
+        />
+        <SportsCard
+          rows={sportsRows}
+          favorites={sportsFavorites.map((f) => ({
+            team_id: f.team_id,
+            name: f.name,
+            league: f.league,
+            badge: f.badge,
+            color: f.color,
+          }))}
+          refreshAction={refreshSports}
+        />
       </div>
 
       {/* ── Emails ───────────────────────────────────────────────────── */}

--- a/web/src/app/(protected)/settings/page.tsx
+++ b/web/src/app/(protected)/settings/page.tsx
@@ -4,6 +4,8 @@ import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 import { ProfileForm } from "@/components/settings/profile-form";
 import { WatchlistSettings } from "@/components/settings/watchlist-settings";
+import { SportsSettings } from "@/components/settings/sports-settings";
+import type { SportsFavorite } from "@/lib/sync/sports";
 
 async function updateProfile(key: string, value: string) {
   "use server";
@@ -23,6 +25,33 @@ async function deleteProfile(key: string) {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return;
   await supabase.from("profile").delete().eq("user_id", user.id).eq("key", key);
+  revalidatePath("/settings");
+  revalidatePath("/dashboard");
+}
+
+async function saveSportsFavorites(favorites: SportsFavorite[]) {
+  "use server";
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return;
+  await supabase
+    .from("profile")
+    .upsert(
+      { user_id: user.id, key: "sports_favorites", value: JSON.stringify(favorites) },
+      { onConflict: "user_id,key" },
+    );
+  // Drop cached rows for any (team_id, league) pair no longer favorited
+  const keep = new Set(favorites.map((f) => `${f.team_id}|${f.league}`));
+  const { data: existing } = await supabase
+    .from("sports_cache")
+    .select("id,team_id,league")
+    .eq("user_id", user.id);
+  const orphanIds = (existing ?? [])
+    .filter((r) => !keep.has(`${r.team_id}|${r.league}`))
+    .map((r) => r.id);
+  if (orphanIds.length > 0) {
+    await supabase.from("sports_cache").delete().in("id", orphanIds);
+  }
   revalidatePath("/settings");
   revalidatePath("/dashboard");
 }
@@ -51,6 +80,7 @@ export default async function SettingsPage() {
   }
 
   const watchlist = JSON.parse(values["stock_watchlist"] ?? "[]") as string[];
+  const sportsFavorites = JSON.parse(values["sports_favorites"] ?? "[]") as SportsFavorite[];
 
   return (
     <div className="space-y-6 max-w-2xl">
@@ -73,6 +103,11 @@ export default async function SettingsPage() {
         watchlist={watchlist}
         saveAction={saveWatchlist}
         hasApiKey={!!process.env.POLYGON_API_KEY}
+      />
+
+      <SportsSettings
+        favorites={sportsFavorites}
+        saveAction={saveSportsFavorites}
       />
     </div>
   );

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -5,6 +5,8 @@ import { streamText, tool, jsonSchema, wrapLanguageModel } from "ai";
 import type { LanguageModelV1Middleware } from "ai";
 import { createServiceClient } from "@/lib/supabase/service";
 import { createClient } from "@/lib/supabase/server";
+import { syncSports } from "@/lib/sync/sports";
+import type { SportsCacheData } from "@/lib/sync/sports/provider";
 import { google } from "googleapis";
 import { getGoogleAuthClient } from "@/lib/google-auth";
 
@@ -1386,6 +1388,99 @@ ${userName ? `Address the user as "${userName}" — use their name naturally in 
           fetched_at: new Date().toISOString(),
           source: "live",
         };
+      },
+    }),
+
+    get_sports_data: tool({
+      description: "Get next game, last result, or standings for one of the user's favorite sports teams. Reads sports_cache first; falls back to a live TheSportsDB fetch when the cache is older than 12h or when the requested game is within 24h of now. Use when the user asks about a team's schedule, recent result, or standings.",
+      parameters: jsonSchema<{
+        team_name?: string;
+        team_id?: string;
+        query_type: "next_game" | "last_result" | "standings";
+      }>({
+        type: "object",
+        required: ["query_type"],
+        properties: {
+          team_name: { type: "string", description: "Team name as the user said it (e.g. 'Warriors'). Matched case-insensitively against the user's favorites." },
+          team_id: { type: "string", description: "TheSportsDB team_id, if known (preferred over team_name)." },
+          query_type: { type: "string", enum: ["next_game", "last_result", "standings"] },
+        },
+      }),
+      execute: async ({ team_name, team_id, query_type }) => {
+        const { data: favRow } = await supabase
+          .from("profile")
+          .select("value")
+          .eq("user_id", userId)
+          .eq("key", "sports_favorites")
+          .maybeSingle();
+
+        type Fav = { team_id: string; name: string; league: string; league_id: string; badge: string | null; color: string | null };
+        const favorites: Fav[] = favRow?.value ? (JSON.parse(favRow.value) as Fav[]) : [];
+        if (favorites.length === 0) {
+          return { error: "No favorite teams configured. Add some in Settings." };
+        }
+
+        const fav = team_id
+          ? favorites.find((f) => f.team_id === team_id)
+          : favorites.find((f) => f.name.toLowerCase().includes((team_name ?? "").toLowerCase()));
+        if (!fav) {
+          return { error: `Team not in favorites. Available: ${favorites.map((f) => f.name).join(", ")}` };
+        }
+
+        const { data: cached } = await supabase
+          .from("sports_cache")
+          .select("data,fetched_at")
+          .eq("user_id", userId)
+          .eq("team_id", fav.team_id)
+          .maybeSingle();
+
+        const now = Date.now();
+        const cacheAgeHrs = cached ? (now - new Date(cached.fetched_at).getTime()) / 3_600_000 : Infinity;
+
+        // Decide whether to live-fetch
+        let needsLive = !cached || cacheAgeHrs > 12;
+        if (cached && !needsLive) {
+          const data = cached.data as SportsCacheData;
+          if (query_type === "next_game") {
+            const next = data.upcoming?.[0];
+            if (next && Math.abs(new Date(next.start_time).getTime() - now) < 24 * 3_600_000) needsLive = true;
+          }
+          if (query_type === "last_result") {
+            const last = data.recent?.[0];
+            if (last && now - new Date(last.start_time).getTime() < 24 * 3_600_000) needsLive = true;
+          }
+        }
+
+        let data: SportsCacheData;
+        let source: "cache" | "live" | "stale-cache" = "cache";
+
+        if (needsLive) {
+          try {
+            await syncSports(supabase, userId, [fav]);
+            const { data: fresh } = await supabase
+              .from("sports_cache")
+              .select("data")
+              .eq("user_id", userId)
+              .eq("team_id", fav.team_id)
+              .maybeSingle();
+            data = (fresh?.data ?? cached?.data) as SportsCacheData;
+            source = "live";
+          } catch (e) {
+            if (!cached) return { error: `Live fetch failed and no cache: ${(e as Error).message}` };
+            data = cached.data as SportsCacheData;
+            source = "stale-cache";
+          }
+        } else {
+          data = cached!.data as SportsCacheData;
+        }
+
+        if (query_type === "next_game") {
+          return { team: fav.name, league: fav.league, next_game: data.upcoming?.[0] ?? null, source };
+        }
+        if (query_type === "last_result") {
+          return { team: fav.name, league: fav.league, last_result: data.recent?.[0] ?? null, source };
+        }
+        return { team: fav.name, league: fav.league, standings: data.standings ?? null, source };
       },
     }),
   };

--- a/web/src/app/api/cron/sync/route.ts
+++ b/web/src/app/api/cron/sync/route.ts
@@ -4,6 +4,7 @@ import { syncOura } from "@/lib/sync/oura";
 import { syncFitbit } from "@/lib/sync/fitbit";
 import { syncGoogleFit } from "@/lib/sync/googlefit";
 import { syncStocks } from "@/lib/sync/stocks";
+import { syncSports, type SportsFavorite } from "@/lib/sync/sports";
 import { lastSyncAgeSecs } from "@/lib/sync/log";
 
 const SKIP_WINDOW_SECS = 30 * 60; // 30 minutes — same as run-syncs.py
@@ -90,6 +91,28 @@ export async function GET(request: NextRequest) {
     }
   } else {
     results.stocks = { skipped: true, reason: "empty watchlist" };
+  }
+
+  // Sports sync — no skip window; daily refresh of schedules + standings
+  const { data: sportsRow } = await db
+    .from("profile")
+    .select("value")
+    .eq("user_id", ownerUserId)
+    .eq("key", "sports_favorites")
+    .single();
+
+  const sportsFavorites: SportsFavorite[] = sportsRow?.value
+    ? (JSON.parse(sportsRow.value) as SportsFavorite[])
+    : [];
+
+  if (sportsFavorites.length > 0) {
+    try {
+      results.sports = await syncSports(db, ownerUserId, sportsFavorites);
+    } catch (e) {
+      results.sports = { error: (e as Error).message };
+    }
+  } else {
+    results.sports = { skipped: true, reason: "no favorites" };
   }
 
   return NextResponse.json({ success: true, results });

--- a/web/src/app/api/sports/refresh/route.ts
+++ b/web/src/app/api/sports/refresh/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { syncSports, type SportsFavorite } from "@/lib/sync/sports";
+
+export async function POST() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: profileRow } = await supabase
+    .from("profile")
+    .select("value")
+    .eq("user_id", user.id)
+    .eq("key", "sports_favorites")
+    .single();
+
+  const favorites: SportsFavorite[] = profileRow?.value
+    ? (JSON.parse(profileRow.value) as SportsFavorite[])
+    : [];
+
+  const result = await syncSports(supabase, user.id, favorites);
+  return NextResponse.json(result);
+}

--- a/web/src/app/api/sports/search/route.ts
+++ b/web/src/app/api/sports/search/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getSportsProvider } from "@/lib/sync/sports";
+
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const q = request.nextUrl.searchParams.get("q")?.trim();
+  if (!q) return NextResponse.json({ teams: [] });
+
+  try {
+    const teams = await getSportsProvider().searchTeams(q);
+    return NextResponse.json({ teams });
+  } catch (e) {
+    return NextResponse.json(
+      { error: (e as Error).message, teams: [] },
+      { status: 502 },
+    );
+  }
+}

--- a/web/src/components/dashboard/important-emails.tsx
+++ b/web/src/components/dashboard/important-emails.tsx
@@ -51,11 +51,17 @@ export default function ImportantEmails() {
                 </p>
                 {email.receivedAt && (
                   <p className="text-[10px] text-neutral-600 shrink-0">
-                    {new Date(email.receivedAt).toLocaleTimeString("en-US", {
-                      hour: "numeric",
-                      minute: "2-digit",
-                      hour12: true,
-                    })}
+                    {(() => {
+                      const d = new Date(email.receivedAt);
+                      const today = new Date();
+                      const sameDay = d.toDateString() === today.toDateString();
+                      const time = d.toLocaleTimeString("en-US", {
+                        hour: "numeric", minute: "2-digit", hour12: true,
+                      });
+                      if (sameDay) return time;
+                      const wd = d.toLocaleDateString("en-US", { weekday: "short" });
+                      return `${wd} ${d.getMonth() + 1}/${d.getDate()} ${time}`;
+                    })()}
                   </p>
                 )}
               </div>

--- a/web/src/components/dashboard/sports-card.tsx
+++ b/web/src/components/dashboard/sports-card.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef, useState, useTransition } from "react";
+import { RefreshCw, Loader2, ChevronDown, ChevronRight } from "lucide-react";
+import type { SportsCache } from "@/lib/types";
+import type { Game, Standing } from "@/lib/sync/sports/provider";
+
+interface Props {
+  rows: SportsCache[];
+  favorites: { team_id: string; name: string; league: string; badge: string | null; color: string | null }[];
+  refreshAction: () => Promise<void>;
+}
+
+const WIN_COLOR = "#22c55e";
+const LOSS_COLOR = "#ef4444";
+
+function fmtDay(iso: string): string {
+  const d = new Date(iso);
+  const wd = d.toLocaleDateString("en-US", { weekday: "short" });
+  return `${wd} ${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+function fmtDayTime(iso: string): string {
+  const d = new Date(iso);
+  const wd = d.toLocaleDateString("en-US", { weekday: "short" });
+  const time = d.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  }).replace(":00", "");
+  return `${wd} ${d.getMonth() + 1}/${d.getDate()} ${time}`;
+}
+
+function nextGameLabel(g: Game | undefined, league: string): string {
+  if (!g) return "—";
+  if (league === "F1") return `${g.opponent} · ${fmtDayTime(g.start_time)}`;
+  const prefix = g.home_away === "home" ? "vs" : "@";
+  return `${prefix} ${g.opponent} · ${fmtDayTime(g.start_time)}`;
+}
+
+function lastResultLabel(g: Game | undefined, league: string): { text: string; color: string } | null {
+  if (!g) return null;
+  if (league === "F1") {
+    return {
+      text: `${g.opponent} · ${fmtDay(g.start_time)}`,
+      color: "var(--color-text-muted)",
+    };
+  }
+  if (!g.score || !g.result) return null;
+  const prefix = g.home_away === "home" ? "vs" : "@";
+  return {
+    text: `${g.result} ${g.score.team}-${g.score.opponent} ${prefix} ${g.opponent}`,
+    color: g.result === "W" ? WIN_COLOR : g.result === "L" ? LOSS_COLOR : "var(--color-text-muted)",
+  };
+}
+
+function StandingLine({ s }: { s: Standing }) {
+  const hasRecord = s.wins > 0 || s.losses > 0 || (s.ties ?? 0) > 0;
+  const record = hasRecord
+    ? (s.ties != null ? `${s.wins}-${s.losses}-${s.ties}` : `${s.wins}-${s.losses}`)
+    : "";
+  const trailing = s.points != null
+    ? `${s.points} pts`
+    : s.pct != null
+      ? `(.${Math.round(s.pct * 1000).toString().padStart(3, "0")})`
+      : "";
+  const rank = s.rank ? `${s.rank}${ordinal(s.rank)} · ` : "";
+  return (
+    <div style={{ fontSize: 12, color: "var(--color-text-muted)" }}>
+      <span>{rank}{s.group}</span>
+      {record && <span style={{ marginLeft: 8, color: "var(--color-text)" }}>{record}</span>}
+      {trailing && <span style={{ marginLeft: 6 }}>{trailing}</span>}
+    </div>
+  );
+}
+
+function ordinal(n: number): string {
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return s[(v - 20) % 10] || s[v] || s[0];
+}
+
+function TeamLogo({ src, name, color }: { src: string | null; name: string; color?: string | null }) {
+  if (src) {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img src={src} alt={name} width={24} height={24} style={{ borderRadius: 4, objectFit: "contain" }} />;
+  }
+  const initials = name.split(/\s+/).slice(0, 2).map((w) => w[0]).join("").toUpperCase();
+  return (
+    <div
+      style={{
+        width: 24,
+        height: 24,
+        borderRadius: 4,
+        background: color || "var(--color-surface-raised)",
+        color: color ? "#fff" : "var(--color-text-muted)",
+        fontSize: 10,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontWeight: 700,
+      }}
+    >
+      {initials}
+    </div>
+  );
+}
+
+function TeamRow({ row, favorite }: {
+  row: SportsCache;
+  favorite: Props["favorites"][number];
+}) {
+  const [open, setOpen] = useState(false);
+  const next = row.data.upcoming?.[0];
+  const last = row.data.recent?.[0];
+  const lastLabel = lastResultLabel(last, favorite.league);
+
+  return (
+    <div style={{ borderBottom: "1px solid var(--color-border)" }}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center gap-3 px-5 py-3 cursor-pointer text-left"
+        style={{ background: "transparent" }}
+      >
+        <TeamLogo src={favorite.badge ?? null} name={favorite.name} color={favorite.color} />
+        <div className="flex-1 min-w-0">
+          <p
+            className="font-heading font-semibold truncate"
+            style={{ fontSize: 14, color: "var(--color-text)", letterSpacing: "0.02em" }}
+          >
+            {favorite.name}
+          </p>
+          <p className="sports-card-league" style={{ fontSize: 10, color: "var(--color-text-faint)", marginTop: 2 }}>
+            {favorite.league}
+          </p>
+        </div>
+        <div className="flex-shrink-0 text-right" style={{ minWidth: 130 }}>
+          <p style={{ fontSize: 12, color: "var(--color-text)" }}>
+            {nextGameLabel(next, favorite.league)}
+          </p>
+          <p style={{ fontSize: 11, color: lastLabel?.color ?? "var(--color-text-faint)", marginTop: 2 }}>
+            {lastLabel?.text ?? "No recent result"}
+          </p>
+        </div>
+        <span style={{ color: "var(--color-text-faint)" }}>
+          {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        </span>
+      </button>
+
+      {open && (
+        <div className="px-5 pb-4" style={{ paddingLeft: 56 }}>
+          {row.data.standings && (
+            <div style={{ marginBottom: 10 }}>
+              <p className="text-xs uppercase tracking-widest" style={{ color: "var(--color-text-faint)", letterSpacing: "0.07em", marginBottom: 4 }}>
+                Standings
+              </p>
+              <StandingLine s={row.data.standings} />
+            </div>
+          )}
+          {row.data.recent && row.data.recent.length > 0 && (
+            <div>
+              <p className="text-xs uppercase tracking-widest" style={{ color: "var(--color-text-faint)", letterSpacing: "0.07em", marginBottom: 4 }}>
+                Last 3
+              </p>
+              {row.data.recent.map((g) => {
+                const r = lastResultLabel(g, favorite.league);
+                if (!r) return null;
+                return (
+                  <div key={g.game_id} className="flex items-center justify-between" style={{ fontSize: 12, padding: "2px 0" }}>
+                    <span style={{ color: r.color }}>{r.text}</span>
+                    <span style={{ color: "var(--color-text-faint)" }}>{fmtDay(g.start_time)}</span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+          {!row.data.standings && (!row.data.recent || row.data.recent.length === 0) && (
+            <p style={{ fontSize: 12, color: "var(--color-text-faint)" }}>No additional data available.</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const SPORTS_STALE_MS = 6 * 60 * 60 * 1000;
+
+export function SportsCard({ rows, favorites, refreshAction }: Props) {
+  const [isPending, startTransition] = useTransition();
+  const autoRanRef = useRef(false);
+
+  function handleRefresh() {
+    startTransition(async () => {
+      await refreshAction();
+    });
+  }
+
+  // Auto-refresh on mount when cache is stale (>6h) or any favorite is missing a row
+  useEffect(() => {
+    if (autoRanRef.current || favorites.length === 0) return;
+    autoRanRef.current = true;
+    const missingRow = favorites.some((f) => !rows.some((r) => r.team_id === f.team_id && r.league === f.league));
+    const latest = rows.reduce<string | null>(
+      (acc, r) => (acc == null || r.fetched_at > acc ? r.fetched_at : acc),
+      null,
+    );
+    const stale = !latest || (Date.now() - new Date(latest).getTime()) > SPORTS_STALE_MS;
+    if (missingRow || stale) handleRefresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const rowsByTeamId = new Map(rows.map((r) => [`${r.team_id}|${r.league}`, r]));
+
+  return (
+    <>
+      <style>{`
+        @media (max-width: 480px) {
+          .sports-card-league { display: none; }
+        }
+      `}</style>
+
+      <div
+        className="rounded-xl overflow-hidden"
+        style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+      >
+        <div
+          className="flex items-center justify-between px-5 py-3.5"
+          style={{ borderBottom: "1px solid var(--color-border)" }}
+        >
+          <p
+            className="text-xs uppercase tracking-widest"
+            style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}
+          >
+            Sports
+          </p>
+          {favorites.length > 0 && (
+            <button
+              onClick={handleRefresh}
+              disabled={isPending}
+              className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs transition-colors duration-150 cursor-pointer disabled:opacity-40 disabled:cursor-default"
+              style={{
+                background: "var(--color-surface-raised)",
+                border: "1px solid var(--color-border)",
+                color: isPending ? "var(--color-primary)" : "var(--color-text-muted)",
+              }}
+            >
+              {isPending ? <Loader2 size={11} className="animate-spin" /> : <RefreshCw size={11} />}
+              {isPending ? "Refreshing…" : "Refresh"}
+            </button>
+          )}
+        </div>
+
+        {favorites.length === 0 ? (
+          <div className="px-5 py-6 text-center" style={{ fontSize: 13, color: "var(--color-text-faint)" }}>
+            No teams —{" "}
+            <Link href="/settings#sports" style={{ color: "var(--color-primary)", textDecoration: "underline" }}>
+              add favorites in Settings
+            </Link>
+          </div>
+        ) : (
+          <div style={{ opacity: isPending ? 0.5 : 1, transition: "opacity 0.15s" }}>
+            {favorites.map((fav) => {
+              const row = rowsByTeamId.get(`${fav.team_id}|${fav.league}`);
+              if (!row) {
+                return (
+                  <div
+                    key={`${fav.league}-${fav.team_id}`}
+                    className="flex items-center gap-3 px-5 py-3"
+                    style={{ borderBottom: "1px solid var(--color-border)" }}
+                  >
+                    <TeamLogo src={fav.badge} name={fav.name} color={fav.color} />
+                    <div className="flex-1">
+                      <p style={{ fontSize: 14, color: "var(--color-text)" }}>{fav.name}</p>
+                      <p style={{ fontSize: 11, color: "var(--color-text-faint)", marginTop: 2 }}>
+                        Awaiting first sync — hit Refresh
+                      </p>
+                    </div>
+                  </div>
+                );
+              }
+              return <TeamRow key={`${fav.league}-${fav.team_id}`} row={row} favorite={fav} />;
+            })}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/web/src/components/dashboard/watchlist-widget.tsx
+++ b/web/src/components/dashboard/watchlist-widget.tsx
@@ -1,14 +1,29 @@
 "use client";
 
-import { useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { LineChart, Line, ResponsiveContainer } from "recharts";
-import { RefreshCw, Loader2 } from "lucide-react";
+import { RefreshCw, Loader2, AlertTriangle } from "lucide-react";
 import type { StocksCache } from "@/lib/types";
 
 interface Props {
   rows: StocksCache[];
   hasApiKey: boolean;
-  refreshAction: () => Promise<void>;
+  refreshAction: () => Promise<{ rateLimited: boolean }>;
+}
+
+// Stocks staleness: 1h during US market hours (M-F 9:30am-4pm ET), 12h otherwise
+function isStocksStale(latest: string | null): boolean {
+  if (!latest) return true;
+  const ageMs = Date.now() - new Date(latest).getTime();
+  const nyParts = new Date().toLocaleString("en-US", {
+    timeZone: "America/New_York",
+    weekday: "short", hour: "numeric", minute: "2-digit", hour12: false,
+  });
+  const isWeekday = !/^Sat|^Sun/.test(nyParts);
+  const [, hh, mm] = nyParts.match(/(\d{1,2}):(\d{2})/) ?? [];
+  const minutesSinceMidnight = (parseInt(hh ?? "0", 10) * 60) + parseInt(mm ?? "0", 10);
+  const marketOpen = isWeekday && minutesSinceMidnight >= 570 && minutesSinceMidnight < 960; // 9:30–16:00
+  return ageMs > (marketOpen ? 60 * 60 * 1000 : 12 * 60 * 60 * 1000);
 }
 
 function formatTime(isoString: string): string {
@@ -94,12 +109,30 @@ function TickerRow({ row }: { row: StocksCache }) {
 
 export function WatchlistWidget({ rows, hasApiKey, refreshAction }: Props) {
   const [isPending, startTransition] = useTransition();
+  const [rateLimited, setRateLimited] = useState(false);
+  const autoRanRef = useRef(false);
 
   function handleRefresh() {
+    setRateLimited(false);
     startTransition(async () => {
-      await refreshAction();
+      const result = await refreshAction();
+      if (result.rateLimited) setRateLimited(true);
     });
   }
+
+  // Auto-refresh on mount if cache is stale (silent — no rate-limit banner)
+  useEffect(() => {
+    if (autoRanRef.current || !hasApiKey || rows.length === 0) return;
+    autoRanRef.current = true;
+    const latest = rows.reduce<string | null>(
+      (acc, r) => (acc == null || r.fetched_at > acc ? r.fetched_at : acc),
+      null,
+    );
+    if (isStocksStale(latest)) {
+      startTransition(async () => { await refreshAction(); });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <>
@@ -166,6 +199,22 @@ export function WatchlistWidget({ rows, hasApiKey, refreshAction }: Props) {
               POLYGON_API_KEY
             </code>{" "}
             to your environment to enable stock data.
+          </div>
+        )}
+
+        {/* Rate limit warning */}
+        {rateLimited && (
+          <div
+            className="flex items-center gap-2 px-5 py-2.5"
+            style={{
+              fontSize: 12,
+              color: "var(--color-warning)",
+              background: "rgba(245,158,11,0.08)",
+              borderBottom: "1px solid rgba(245,158,11,0.16)",
+            }}
+          >
+            <AlertTriangle size={12} />
+            Polygon rate limit hit (5/min on free tier). Showing cached data — wait a minute and refresh.
           </div>
         )}
 

--- a/web/src/components/settings/sports-settings.tsx
+++ b/web/src/components/settings/sports-settings.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useEffect, useRef, useState, useTransition } from "react";
+import { Search, X, Loader2 } from "lucide-react";
+import type { SportsFavorite } from "@/lib/sync/sports";
+import type { Team } from "@/lib/sync/sports/provider";
+
+interface Props {
+  favorites: SportsFavorite[];
+  saveAction: (favorites: SportsFavorite[]) => Promise<void>;
+}
+
+export function SportsSettings({ favorites, saveAction }: Props) {
+  const [list, setList] = useState<SportsFavorite[]>(favorites);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<Team[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!query.trim()) {
+      setResults([]);
+      setError(null);
+      return;
+    }
+    debounceRef.current = setTimeout(async () => {
+      setSearching(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/sports/search?q=${encodeURIComponent(query.trim())}`);
+        const json = await res.json() as { teams?: Team[]; error?: string };
+        if (json.error) setError(json.error);
+        setResults(json.teams ?? []);
+      } catch (e) {
+        setError((e as Error).message);
+        setResults([]);
+      } finally {
+        setSearching(false);
+      }
+    }, 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query]);
+
+  function handleAdd(team: Team) {
+    if (list.some((f) => f.team_id === team.team_id && f.league === team.league)) {
+      setError(`${team.name} is already in your favorites`);
+      return;
+    }
+    const fav: SportsFavorite = {
+      team_id: team.team_id,
+      name: team.name,
+      league: team.league,
+      league_id: team.league_id,
+      badge: team.badge,
+      color: team.color,
+    };
+    const next = [...list, fav];
+    setList(next);
+    setQuery("");
+    setResults([]);
+    startTransition(async () => {
+      await saveAction(next);
+    });
+  }
+
+  function handleRemove(teamId: string, league: string) {
+    const next = list.filter((f) => !(f.team_id === teamId && f.league === league));
+    setList(next);
+    startTransition(async () => {
+      await saveAction(next);
+    });
+  }
+
+  return (
+    <div
+      id="sports"
+      className="rounded-xl overflow-hidden"
+      style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+    >
+      <div className="px-5 py-4" style={{ borderBottom: "1px solid var(--color-border)" }}>
+        <p
+          className="text-xs uppercase tracking-widest"
+          style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}
+        >
+          Favorite Teams
+        </p>
+      </div>
+
+      {/* Search */}
+      <div className="px-5 py-4" style={{ borderBottom: "1px solid var(--color-border)" }}>
+        <div className="flex gap-2 items-center">
+          <Search size={14} style={{ color: "var(--color-text-faint)" }} />
+          <input
+            value={query}
+            onChange={(e) => { setQuery(e.target.value); setError(null); }}
+            placeholder="Search teams (e.g. Warriors, 49ers, Arsenal)"
+            className="flex-1 rounded-lg px-3 py-2 text-sm transition-colors duration-150 focus:outline-none"
+            style={{
+              background: "var(--color-surface-raised)",
+              border: `1px solid ${error ? "var(--color-danger)" : "var(--color-border)"}`,
+              color: "var(--color-text)",
+            }}
+          />
+          {searching && <Loader2 size={14} className="animate-spin" style={{ color: "var(--color-text-faint)" }} />}
+        </div>
+        {error && (
+          <p className="mt-1.5" style={{ fontSize: 12, color: "var(--color-danger)" }}>{error}</p>
+        )}
+        {results.length > 0 && (
+          <div className="mt-2 rounded-lg overflow-hidden" style={{ border: "1px solid var(--color-border)" }}>
+            {results.slice(0, 8).map((t) => (
+              <button
+                key={`${t.league}-${t.team_id}`}
+                type="button"
+                onClick={() => handleAdd(t)}
+                className="w-full flex items-center gap-3 px-3 py-2 text-left cursor-pointer transition-colors"
+                style={{ background: "var(--color-surface-raised)", borderBottom: "1px solid var(--color-border)" }}
+                onMouseOver={(e) => { e.currentTarget.style.background = "var(--color-surface)"; }}
+                onMouseOut={(e) => { e.currentTarget.style.background = "var(--color-surface-raised)"; }}
+              >
+                {t.badge ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={t.badge} alt="" width={20} height={20} style={{ borderRadius: 3, objectFit: "contain" }} />
+                ) : (
+                  <div style={{ width: 20, height: 20, borderRadius: 3, background: "var(--color-surface)" }} />
+                )}
+                <span style={{ fontSize: 13, color: "var(--color-text)" }}>{t.name}</span>
+                <span style={{ fontSize: 11, color: "var(--color-text-faint)", marginLeft: "auto" }}>{t.league}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Favorites list */}
+      {list.length === 0 ? (
+        <div className="px-5 py-4" style={{ fontSize: 13, color: "var(--color-text-faint)" }}>
+          No teams added yet.
+        </div>
+      ) : (
+        list.map((fav) => (
+          <div
+            key={`${fav.league}-${fav.team_id}`}
+            className="flex items-center gap-3 px-5 py-3"
+            style={{ borderBottom: "1px solid var(--color-border)" }}
+          >
+            {fav.badge ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={fav.badge} alt="" width={20} height={20} style={{ borderRadius: 3, objectFit: "contain" }} />
+            ) : (
+              <div style={{ width: 20, height: 20, borderRadius: 3, background: "var(--color-surface-raised)" }} />
+            )}
+            <span style={{ fontSize: 13, color: "var(--color-text)", flex: 1 }}>{fav.name}</span>
+            <span style={{ fontSize: 11, color: "var(--color-text-faint)" }}>{fav.league}</span>
+            <button
+              onClick={() => handleRemove(fav.team_id, fav.league)}
+              disabled={isPending}
+              className="flex items-center justify-center w-6 h-6 rounded transition-colors cursor-pointer disabled:opacity-40"
+              style={{ color: "var(--color-text-faint)" }}
+              onMouseOver={(e) => { e.currentTarget.style.color = "var(--color-danger)"; }}
+              onMouseOut={(e) => { e.currentTarget.style.color = "var(--color-text-faint)"; }}
+              title={`Remove ${fav.name}`}
+            >
+              <X size={13} />
+            </button>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/sync/sports/espn.ts
+++ b/web/src/lib/sync/sports/espn.ts
@@ -1,0 +1,336 @@
+import type { Game, SportsProvider, Standing, Team } from "./provider";
+
+const SITE_BASE = "https://site.api.espn.com/apis/site/v2";
+const CORE_BASE = "https://site.api.espn.com/apis/v2";
+
+// Supported leagues. league_id is ESPN's "{sport}/{league}" path.
+const LEAGUES: { league_id: string; display: string }[] = [
+  { league_id: "basketball/nba", display: "NBA" },
+  { league_id: "football/nfl", display: "NFL" },
+  { league_id: "baseball/mlb", display: "MLB" },
+  { league_id: "hockey/nhl", display: "NHL" },
+  { league_id: "racing/f1", display: "F1" },
+];
+
+function displayFor(leagueId: string): string {
+  return LEAGUES.find((l) => l.league_id === leagueId)?.display ?? leagueId;
+}
+
+function isF1(leagueId: string): boolean {
+  return leagueId === "racing/f1";
+}
+
+async function get<T>(url: string): Promise<T | null> {
+  const res = await fetch(url, { cache: "no-store" });
+  if (!res.ok) {
+    console.error(`[sports/espn] ${url} → ${res.status}`);
+    return null;
+  }
+  return res.json() as Promise<T>;
+}
+
+// ── Types (only the fields we use) ───────────────────────────────────────────
+type RawTeamsResponse = {
+  sports: {
+    leagues: {
+      teams: { team: { id: string; displayName: string; abbreviation?: string; color?: string; logos?: { href: string }[] } }[];
+    }[];
+  }[];
+};
+
+type RawCompetitor = {
+  id: string;
+  homeAway?: "home" | "away";
+  winner?: boolean;
+  score?: string | { value?: number; displayValue?: string };
+  team?: { id: string; displayName: string; abbreviation?: string; logo?: string; logos?: { href: string }[] };
+  athlete?: { displayName: string };
+};
+
+type RawEvent = {
+  id: string;
+  date: string;
+  name: string;
+  shortName?: string;
+  competitions: {
+    competitors: RawCompetitor[];
+    status: { type: { state: "pre" | "in" | "post"; completed: boolean } };
+  }[];
+};
+
+type RawStandingEntry = {
+  team: { id: string; displayName: string };
+  stats: { name: string; value?: number; displayValue?: string }[];
+};
+
+type RawStandingNode = {
+  name?: string;
+  abbreviation?: string;
+  standings?: { entries?: RawStandingEntry[] };
+  children?: RawStandingNode[];
+};
+
+// Helpers
+function parseScore(s: RawCompetitor["score"]): number | null {
+  if (s == null) return null;
+  if (typeof s === "string") {
+    const n = parseInt(s, 10);
+    return Number.isFinite(n) ? n : null;
+  }
+  if (typeof s === "object") {
+    if (typeof s.value === "number") return s.value;
+    if (s.displayValue) {
+      const n = parseInt(s.displayValue, 10);
+      return Number.isFinite(n) ? n : null;
+    }
+  }
+  return null;
+}
+
+function teamLogo(t: NonNullable<RawCompetitor["team"]>): string | null {
+  return t.logo ?? t.logos?.[0]?.href ?? null;
+}
+
+function statValue(stats: RawStandingEntry["stats"], name: string): number | null {
+  const s = stats.find((x) => x.name === name);
+  if (!s) return null;
+  if (typeof s.value === "number") return s.value;
+  if (s.displayValue) {
+    const n = parseFloat(s.displayValue);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function findStandingEntry(
+  root: RawStandingNode,
+  teamId: string,
+): { entry: RawStandingEntry; group: string } | null {
+  const stack: { node: RawStandingNode; group: string }[] = [{ node: root, group: root.name ?? "" }];
+  while (stack.length) {
+    const { node, group } = stack.pop()!;
+    if (node.standings?.entries) {
+      const entry = node.standings.entries.find((e) => e.team.id === teamId);
+      if (entry) return { entry, group: node.name ?? group };
+    }
+    for (const child of node.children ?? []) {
+      stack.push({ node: child, group: child.name ?? group });
+    }
+  }
+  return null;
+}
+
+// ── Season helpers ───────────────────────────────────────────────────────────
+function currentSeason(leagueId: string): number {
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth() + 1;
+  switch (leagueId) {
+    case "basketball/nba": // ESPN uses END year (Oct'24-Jun'25 = season=2025)
+    case "hockey/nhl":
+      return m >= 7 ? y + 1 : y;
+    case "football/nfl": // ESPN uses START year (Sep'25-Feb'26 = season=2025)
+      return m >= 8 ? y : y - 1;
+    case "baseball/mlb":
+    case "racing/f1":
+    default:
+      return y;
+  }
+}
+
+// ── Game mapping for stick-and-ball leagues ─────────────────────────────────
+function toGame(e: RawEvent, teamId: string): Game | null {
+  const c = e.competitions?.[0];
+  if (!c) return null;
+  const me = c.competitors.find((x) => x.team?.id === teamId);
+  const opp = c.competitors.find((x) => x.team?.id !== teamId);
+  if (!me || !opp || !opp.team) return null;
+
+  const completed = c.status.type.completed;
+  const myScore = parseScore(me.score);
+  const oppScore = parseScore(opp.score);
+  const isFinal = completed && myScore != null && oppScore != null;
+
+  let result: Game["result"] = null;
+  if (isFinal) {
+    if (me.winner === true) result = "W";
+    else if (opp.winner === true) result = "L";
+    else result = myScore > oppScore ? "W" : myScore < oppScore ? "L" : "T";
+  }
+
+  return {
+    game_id: e.id,
+    opponent: opp.team.displayName,
+    opponent_badge: teamLogo(opp.team),
+    home_away: (me.homeAway ?? "home") === "home" ? "home" : "away",
+    start_time: e.date,
+    status: c.status.type.state === "in" ? "in_progress" : isFinal ? "final" : "scheduled",
+    score: isFinal ? { team: myScore!, opponent: oppScore! } : null,
+    result,
+  };
+}
+
+// ── F1 mapping: races as Games (no opponent/score) ──────────────────────────
+function toRaceGame(e: RawEvent): Game {
+  const c = e.competitions?.[0];
+  return {
+    game_id: e.id,
+    opponent: e.name, // race name (e.g. "Australian Grand Prix")
+    opponent_badge: null,
+    home_away: "home", // suppressed in UI when league=F1
+    start_time: e.date,
+    status: c?.status.type.state === "in" ? "in_progress" : c?.status.type.completed ? "final" : "scheduled",
+    score: null,
+    result: null,
+  };
+}
+
+// ── Fetch all teams across all supported leagues (used for search) ──────────
+async function fetchAllTeams(): Promise<Team[]> {
+  const lists = await Promise.all(
+    LEAGUES.map(async ({ league_id, display }) => {
+      const json = await get<RawTeamsResponse>(`${SITE_BASE}/sports/${league_id}/teams`);
+      const teams = json?.sports?.[0]?.leagues?.[0]?.teams ?? [];
+      return teams.map<Team>((t) => ({
+        team_id: t.team.id,
+        name: t.team.displayName,
+        league: display,
+        league_id,
+        badge: t.team.logos?.[0]?.href ?? null,
+        color: t.team.color ? `#${t.team.color.replace(/^#/, "")}` : null,
+      }));
+    }),
+  );
+  return lists.flat();
+}
+
+export const ESPN: SportsProvider = {
+  async searchTeams(query: string): Promise<Team[]> {
+    const q = query.toLowerCase();
+    const all = await fetchAllTeams();
+    return all
+      .filter((t) => t.name.toLowerCase().includes(q))
+      .slice(0, 20);
+  },
+
+  async getUpcoming({ team_id, league_id }, limit = 3): Promise<Game[]> {
+    return espnGetUpcoming(team_id, league_id, limit);
+  },
+
+  async getRecent({ team_id, league_id }, limit = 3): Promise<Game[]> {
+    return espnGetRecent(team_id, league_id, limit);
+  },
+
+  async getStandings({ team_id, league_id }): Promise<Standing | null> {
+    const json = await get<RawStandingNode>(`${CORE_BASE}/sports/${league_id}/standings`);
+    if (!json) return null;
+
+    if (isF1(league_id)) {
+      // F1: find the Constructor Standings group
+      const groups = json.children ?? [];
+      const constructors = groups.find((g) =>
+        (g.name ?? "").toLowerCase().includes("constructor") ||
+        (g.name ?? "").toLowerCase().includes("manufacturer"),
+      );
+      if (!constructors?.standings?.entries) return null;
+      const entry = constructors.standings.entries.find((e) => e.team.id === team_id);
+      if (!entry) return null;
+      return {
+        rank: statValue(entry.stats, "rank"),
+        group: "Constructors",
+        wins: 0,
+        losses: 0,
+        ties: null,
+        points: statValue(entry.stats, "points") ?? statValue(entry.stats, "championshipPts"),
+        pct: null,
+      };
+    }
+
+    const found = findStandingEntry(json, team_id);
+    if (!found) return null;
+    const { entry, group } = found;
+    const wins = statValue(entry.stats, "wins") ?? 0;
+    const losses = statValue(entry.stats, "losses") ?? 0;
+    const ties = statValue(entry.stats, "ties");
+    const points = statValue(entry.stats, "points");
+    const pct = statValue(entry.stats, "winPercent");
+    const rank = statValue(entry.stats, "playoffSeed") ?? statValue(entry.stats, "rank") ?? statValue(entry.stats, "divisionRank");
+
+    return {
+      rank: rank != null ? Math.round(rank) : null,
+      group,
+      wins: Math.round(wins),
+      losses: Math.round(losses),
+      ties: ties != null ? Math.round(ties) : null,
+      points: points != null ? Math.round(points) : null,
+      pct,
+    };
+  },
+};
+
+// Extra helpers used by syncSports — these need league context that the
+// SportsProvider interface doesn't currently carry on getUpcoming/getRecent.
+// We expose league-aware variants and let syncSports call them directly.
+export async function espnGetUpcoming(
+  team_id: string,
+  league_id: string,
+  limit = 3,
+): Promise<Game[]> {
+  if (isF1(league_id)) {
+    const json = await get<{ events: RawEvent[] | null }>(
+      `${SITE_BASE}/sports/racing/f1/scoreboard?dates=${currentSeason(league_id)}`,
+    );
+    const events = (json?.events ?? []).filter((e) => e.competitions?.[0]?.status.type.state !== "post");
+    return events
+      .sort((a, b) => a.date.localeCompare(b.date))
+      .slice(0, limit)
+      .map(toRaceGame);
+  }
+
+  const season = currentSeason(league_id);
+  const json = await get<{ events: RawEvent[] | null }>(
+    `${SITE_BASE}/sports/${league_id}/teams/${team_id}/schedule?season=${season}&seasontype=2`,
+  );
+  const events = (json?.events ?? []).filter(
+    (e) => !e.competitions?.[0]?.status.type.completed,
+  );
+  const games: Game[] = [];
+  for (const e of events) {
+    const g = toGame(e, team_id);
+    if (g) games.push(g);
+  }
+  return games.sort((a, b) => a.start_time.localeCompare(b.start_time)).slice(0, limit);
+}
+
+export async function espnGetRecent(
+  team_id: string,
+  league_id: string,
+  limit = 3,
+): Promise<Game[]> {
+  if (isF1(league_id)) {
+    const json = await get<{ events: RawEvent[] | null }>(
+      `${SITE_BASE}/sports/racing/f1/scoreboard?dates=${currentSeason(league_id)}`,
+    );
+    const events = (json?.events ?? []).filter((e) => e.competitions?.[0]?.status.type.state === "post");
+    return events
+      .sort((a, b) => b.date.localeCompare(a.date))
+      .slice(0, limit)
+      .map(toRaceGame);
+  }
+
+  const season = currentSeason(league_id);
+  const json = await get<{ events: RawEvent[] | null }>(
+    `${SITE_BASE}/sports/${league_id}/teams/${team_id}/schedule?season=${season}&seasontype=2`,
+  );
+  const events = (json?.events ?? []).filter(
+    (e) => e.competitions?.[0]?.status.type.completed,
+  );
+  const games: Game[] = [];
+  for (const e of events) {
+    const g = toGame(e, team_id);
+    if (g) games.push(g);
+  }
+  return games.sort((a, b) => b.start_time.localeCompare(a.start_time)).slice(0, limit);
+}
+
+export { displayFor as espnLeagueDisplay };

--- a/web/src/lib/sync/sports/index.ts
+++ b/web/src/lib/sync/sports/index.ts
@@ -1,0 +1,85 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { SportsCacheData, SportsProvider } from "./provider";
+import { ESPN } from "./espn";
+import { TheSportsDB } from "./thesportsdb";
+
+export type SportsFavorite = {
+  team_id: string;
+  name: string;
+  league: string;
+  league_id: string;
+  badge: string | null;
+  color: string | null;
+};
+
+export interface SportsSyncResult {
+  updated: number;
+  failed: { team_id: string; error: string }[];
+  removed: number;
+}
+
+export function getSportsProvider(): SportsProvider {
+  // Default to ESPN (free, no key, no rate limit). Set SPORTS_PROVIDER=thesportsdb
+  // to fall back to TheSportsDB (requires SPORTSDB_API_KEY for non-trivial use).
+  if (process.env.SPORTS_PROVIDER === "thesportsdb") return TheSportsDB;
+  return ESPN;
+}
+
+export async function syncSports(
+  db: SupabaseClient,
+  userId: string,
+  favorites: SportsFavorite[],
+): Promise<SportsSyncResult> {
+  const provider = getSportsProvider();
+  const failed: SportsSyncResult["failed"] = [];
+  const rows: { user_id: string; team_id: string; league: string; data: SportsCacheData; fetched_at: string }[] = [];
+
+  for (const fav of favorites) {
+    try {
+      const ref = { team_id: fav.team_id, league: fav.league, league_id: fav.league_id };
+      const [upcoming, recent, standings] = await Promise.all([
+        provider.getUpcoming(ref, 3),
+        provider.getRecent(ref, 3),
+        provider.getStandings(ref),
+      ]);
+      rows.push({
+        user_id: userId,
+        team_id: fav.team_id,
+        league: fav.league,
+        data: { upcoming, recent, standings },
+        fetched_at: new Date().toISOString(),
+      });
+    } catch (e) {
+      failed.push({ team_id: fav.team_id, error: (e as Error).message });
+    }
+  }
+
+  if (rows.length > 0) {
+    const { error } = await db
+      .from("sports_cache")
+      .upsert(rows, { onConflict: "user_id,team_id,league" });
+    if (error) throw new Error(error.message);
+  }
+
+  // Evict cache rows for (team_id, league) pairs no longer in favorites
+  const keep = new Set(favorites.map((f) => `${f.team_id}|${f.league}`));
+  const { data: existing } = await db
+    .from("sports_cache")
+    .select("id,team_id,league")
+    .eq("user_id", userId);
+  const orphanIds = (existing ?? [])
+    .filter((r: { id: string; team_id: string; league: string }) => !keep.has(`${r.team_id}|${r.league}`))
+    .map((r: { id: string }) => r.id);
+  let removed = 0;
+  if (orphanIds.length > 0) {
+    const { count } = await db
+      .from("sports_cache")
+      .delete({ count: "exact" })
+      .in("id", orphanIds);
+    removed = count ?? 0;
+  }
+
+  return { updated: rows.length, failed, removed };
+}
+
+export type { SportsCacheData } from "./provider";

--- a/web/src/lib/sync/sports/provider.ts
+++ b/web/src/lib/sync/sports/provider.ts
@@ -1,0 +1,44 @@
+export type Team = {
+  team_id: string;
+  name: string;
+  league: string;
+  league_id: string;
+  badge: string | null;
+  color: string | null; // hex, used for fallback badge when no logo (e.g. F1)
+};
+
+export type Game = {
+  game_id: string;
+  opponent: string;
+  opponent_badge: string | null;
+  home_away: "home" | "away";
+  start_time: string;
+  status: "scheduled" | "final" | "in_progress";
+  score: { team: number; opponent: number } | null;
+  result: "W" | "L" | "T" | null;
+};
+
+export type Standing = {
+  rank: number | null;
+  group: string;
+  wins: number;
+  losses: number;
+  ties: number | null;
+  points: number | null;
+  pct: number | null;
+};
+
+export type SportsCacheData = {
+  upcoming: Game[];
+  recent: Game[];
+  standings: Standing | null;
+};
+
+export type TeamRef = { team_id: string; league: string; league_id: string };
+
+export interface SportsProvider {
+  searchTeams(query: string): Promise<Team[]>;
+  getUpcoming(team: TeamRef, limit?: number): Promise<Game[]>;
+  getRecent(team: TeamRef, limit?: number): Promise<Game[]>;
+  getStandings(team: TeamRef): Promise<Standing | null>;
+}

--- a/web/src/lib/sync/sports/thesportsdb.ts
+++ b/web/src/lib/sync/sports/thesportsdb.ts
@@ -1,0 +1,188 @@
+import type { Game, SportsProvider, Standing, Team } from "./provider";
+
+const BASE = "https://www.thesportsdb.com/api/v1/json";
+
+type RawTeam = {
+  idTeam: string;
+  strTeam: string;
+  strLeague: string;
+  idLeague: string;
+  strBadge?: string | null;
+  strTeamBadge?: string | null;
+};
+
+type RawEvent = {
+  idEvent: string;
+  strHomeTeam: string;
+  strAwayTeam: string;
+  idHomeTeam: string;
+  idAwayTeam: string;
+  strHomeTeamBadge?: string | null;
+  strAwayTeamBadge?: string | null;
+  intHomeScore: string | null;
+  intAwayScore: string | null;
+  strTimestamp: string | null;
+  dateEvent: string | null;
+  strTime: string | null;
+  strStatus?: string | null;
+};
+
+type RawStanding = {
+  idTeam: string;
+  intRank: string | null;
+  strGroup?: string | null;
+  strDivision?: string | null;
+  intWin: string | null;
+  intLoss: string | null;
+  intDraw: string | null;
+  intPoints: string | null;
+};
+
+function apiKey(): string {
+  return process.env.SPORTSDB_API_KEY || "3"; // "3" is the public test key
+}
+
+async function get<T>(path: string): Promise<T | null> {
+  const url = `${BASE}/${apiKey()}${path}`;
+  const res = await fetch(url, { cache: "no-store" });
+  if (!res.ok) {
+    console.error(`[sports] thesportsdb ${path} returned ${res.status}`);
+    return null;
+  }
+  return res.json() as Promise<T>;
+}
+
+function badge(t: Pick<RawTeam, "strBadge" | "strTeamBadge">): string | null {
+  return t.strBadge ?? t.strTeamBadge ?? null;
+}
+
+function startTime(e: RawEvent): string {
+  if (e.strTimestamp) return new Date(e.strTimestamp).toISOString();
+  if (e.dateEvent) {
+    const time = e.strTime ?? "00:00:00";
+    return new Date(`${e.dateEvent}T${time}Z`).toISOString();
+  }
+  return new Date().toISOString();
+}
+
+function toGame(e: RawEvent, teamId: string): Game {
+  const isHome = e.idHomeTeam === teamId;
+  const opponent = isHome ? e.strAwayTeam : e.strHomeTeam;
+  const opponentBadge = isHome ? (e.strAwayTeamBadge ?? null) : (e.strHomeTeamBadge ?? null);
+  const homeScore = e.intHomeScore != null ? parseInt(e.intHomeScore, 10) : null;
+  const awayScore = e.intAwayScore != null ? parseInt(e.intAwayScore, 10) : null;
+  const isFinal = homeScore != null && awayScore != null;
+
+  let teamScore: number | null = null;
+  let oppScore: number | null = null;
+  let result: Game["result"] = null;
+  if (isFinal) {
+    teamScore = isHome ? homeScore : awayScore;
+    oppScore = isHome ? awayScore : homeScore;
+    result = teamScore > oppScore ? "W" : teamScore < oppScore ? "L" : "T";
+  }
+
+  return {
+    game_id: e.idEvent,
+    opponent,
+    opponent_badge: opponentBadge,
+    home_away: isHome ? "home" : "away",
+    start_time: startTime(e),
+    status: isFinal ? "final" : "scheduled",
+    score: isFinal ? { team: teamScore!, opponent: oppScore! } : null,
+    result,
+  };
+}
+
+function currentSeason(league: string): string {
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth() + 1;
+  const upper = league.toUpperCase();
+  // Cross-year leagues — split season string "YYYY-YYYY"
+  if (upper.includes("NBA") || upper.includes("NHL") || upper.includes("NFL") ||
+      upper.includes("PREMIER") || upper.includes("LIGA") || upper.includes("BUNDES") ||
+      upper.includes("SERIE A") || upper.includes("LIGUE 1")) {
+    // Most start ~Aug-Oct, end ~Apr-Jun
+    if (m >= 7) return `${y}-${y + 1}`;
+    return `${y - 1}-${y}`;
+  }
+  // Single-year (MLB, MLS)
+  return `${y}`;
+}
+
+export const TheSportsDB: SportsProvider = {
+  async searchTeams(query: string): Promise<Team[]> {
+    const json = await get<{ teams: RawTeam[] | null }>(
+      `/searchteams.php?t=${encodeURIComponent(query)}`,
+    );
+    const teams = json?.teams ?? [];
+    return teams.map((t) => ({
+      team_id: t.idTeam,
+      name: t.strTeam,
+      league: t.strLeague,
+      league_id: t.idLeague,
+      badge: badge(t),
+      color: null,
+    }));
+  },
+
+  async getUpcoming({ team_id }, limit = 3): Promise<Game[]> {
+    const json = await get<{ events: RawEvent[] | null }>(
+      `/eventsnext.php?id=${encodeURIComponent(team_id)}`,
+    );
+    const events = (json?.events ?? []).filter(
+      (e) => e.idHomeTeam === team_id || e.idAwayTeam === team_id,
+    );
+    return events.slice(0, limit).map((e) => toGame(e, team_id));
+  },
+
+  async getRecent({ team_id }, limit = 3): Promise<Game[]> {
+    const json = await get<{ results: RawEvent[] | null }>(
+      `/eventslast.php?id=${encodeURIComponent(team_id)}`,
+    );
+    const events = (json?.results ?? []).filter(
+      (e) => e.idHomeTeam === team_id || e.idAwayTeam === team_id,
+    );
+    return events
+      .map((e) => toGame(e, team_id))
+      .sort((a, b) => b.start_time.localeCompare(a.start_time))
+      .slice(0, limit);
+  },
+
+  async getStandings({ team_id, league, league_id }): Promise<Standing | null> {
+    const seasons = [currentSeason(league)];
+    // Fallback: try previous season if current returns nothing (off-season)
+    const fallback = currentSeason(league).includes("-")
+      ? null
+      : `${parseInt(currentSeason(league), 10) - 1}`;
+    if (fallback) seasons.push(fallback);
+
+    for (const season of seasons) {
+      const json = await get<{ table: RawStanding[] | null }>(
+        `/lookuptable.php?l=${encodeURIComponent(league_id)}&s=${encodeURIComponent(season)}`,
+      );
+      const row = json?.table?.find((r) => r.idTeam === team_id);
+      if (row) {
+        const wins = parseInt(row.intWin ?? "0", 10) || 0;
+        const losses = parseInt(row.intLoss ?? "0", 10) || 0;
+        const ties = row.intDraw != null ? parseInt(row.intDraw, 10) : null;
+        const points = row.intPoints != null ? parseInt(row.intPoints, 10) : null;
+        const games = wins + losses + (ties ?? 0);
+        const pct = games > 0 && (points == null || ties == null)
+          ? wins / games
+          : null;
+        return {
+          rank: row.intRank != null ? parseInt(row.intRank, 10) : null,
+          group: row.strGroup ?? row.strDivision ?? league,
+          wins,
+          losses,
+          ties,
+          points,
+          pct,
+        };
+      }
+    }
+    return null;
+  },
+};

--- a/web/src/lib/sync/stocks.ts
+++ b/web/src/lib/sync/stocks.ts
@@ -5,6 +5,7 @@ const POLYGON_BASE = "https://api.polygon.io";
 export interface StocksSyncResult {
   updated: number;
   tickers: string[];
+  rateLimited?: boolean;
 }
 
 interface PolygonBar {
@@ -13,10 +14,18 @@ interface PolygonBar {
   t: number; // timestamp ms
 }
 
+class RateLimitError extends Error {
+  constructor() { super("Polygon rate limit"); this.name = "RateLimitError"; }
+}
+
 async function polygonGet(path: string, apiKey: string): Promise<Record<string, unknown> | null> {
   const sep = path.includes("?") ? "&" : "?";
   const url = `${POLYGON_BASE}${path}${sep}apiKey=${apiKey}`;
   const res = await fetch(url, { cache: "no-store" });
+  if (res.status === 429) {
+    console.error(`[stocks] Polygon ${path} returned 429 (rate limit)`);
+    throw new RateLimitError();
+  }
   if (!res.ok) {
     console.error(`[stocks] Polygon ${path} returned ${res.status}`);
     return null;
@@ -32,15 +41,17 @@ export async function syncStocks(
   const apiKey = process.env.POLYGON_API_KEY;
   if (!apiKey) throw new Error("POLYGON_API_KEY not configured");
 
-  // Sparkline range: 14 calendar days back to guarantee ≥7 trading days
+  // Sparkline range: 45 calendar days back to guarantee ≥30 trading days
   const now = new Date();
   const fromDate = new Date(now);
-  fromDate.setDate(fromDate.getDate() - 14);
+  fromDate.setDate(fromDate.getDate() - 45);
   const from = fromDate.toISOString().slice(0, 10);
   const to = now.toISOString().slice(0, 10);
 
+  let rateLimited = false;
   const rows = await Promise.all(
     tickers.map(async (ticker) => {
+      try {
       const [prevData, rangeData] = await Promise.all([
         polygonGet(`/v2/aggs/ticker/${ticker}/prev`, apiKey),
         polygonGet(`/v2/aggs/ticker/${ticker}/range/1/day/${from}/${to}`, apiKey),
@@ -54,8 +65,8 @@ export async function syncStocks(
         : null;
 
       const rangeBars = (rangeData?.results as PolygonBar[] | undefined) ?? [];
-      // Keep last 7 trading days
-      const sparkline = rangeBars.slice(-7).map((bar) => ({
+      // Keep last 30 trading days (~6 weeks of context)
+      const sparkline = rangeBars.slice(-30).map((bar) => ({
         date: new Date(bar.t).toISOString().slice(0, 10),
         close: bar.c,
       }));
@@ -69,14 +80,20 @@ export async function syncStocks(
         sparkline: sparkline.length > 0 ? sparkline : null,
         fetched_at: new Date().toISOString(),
       };
+      } catch (e) {
+        if (e instanceof RateLimitError) { rateLimited = true; return null; }
+        throw e;
+      }
     }),
   );
 
-  const { error } = await db
-    .from("stocks_cache")
-    .upsert(rows, { onConflict: "user_id,ticker" });
+  const validRows = rows.filter((r): r is NonNullable<typeof r> => r !== null);
+  if (validRows.length > 0) {
+    const { error } = await db
+      .from("stocks_cache")
+      .upsert(validRows, { onConflict: "user_id,ticker" });
+    if (error) throw new Error(error.message);
+  }
 
-  if (error) throw new Error(error.message);
-
-  return { updated: rows.length, tickers };
+  return { updated: validRows.length, tickers, rateLimited };
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -172,3 +172,12 @@ export interface StocksCache {
   sparkline: { date: string; close: number }[] | null;
   fetched_at: string;
 }
+
+export interface SportsCache {
+  id: string;
+  user_id: string;
+  team_id: string;
+  league: string;
+  data: import("./sync/sports/provider").SportsCacheData;
+  fetched_at: string;
+}


### PR DESCRIPTION
## Summary
- Adds a Sports card to the dashboard with each favorite team's next game, last result, and standings — backed by a new `sports_cache` Supabase table populated by daily cron and on-demand refresh.
- Provider abstraction (`SportsProvider`) defaults to ESPN's free unofficial API (NBA, NFL, MLB, NHL, F1) with TheSportsDB available as opt-in fallback (`SPORTS_PROVIDER=thesportsdb`).
- F1 special-cased: race name + date instead of head-to-head, constructor rank + championship points in standings.
- Bridge chat tool `get_sports_data` (cache-first, live fallback when stale or game within 24h).
- Smart-stale auto-refresh on dashboard load for both Watchlist and Sports — non-blocking after first paint, thresholds tuned per data type.
- Polygon rate-limit banner on manual stock refresh (auto-refresh stays silent).
- Sparkline widened from 7 → 30 trading days (same Polygon call count).
- Dashboard layout reordered: Schedule → Habits + Tasks → Watchlist + Sports → Important Emails.
- Important Emails now show date + time on pre-today messages.

Closes #141.

## Test plan
- [x] `npx tsc --noEmit` exits 0
- [x] Migrations applied to remote Supabase (`sports_cache` table + per-league unique constraint)
- [x] Settings → Favorite Teams → search returns ESPN teams; add/remove persists to `profile.sports_favorites`
- [x] Dashboard SportsCard renders next game + last result; expand shows standings + last 3 results; F1 row hides W/L coloring
- [x] Manual refresh button updates `sports_cache` immediately
- [x] Auto-refresh hydrates stale data on page load without blocking render
- [x] Polygon 429 surfaces amber banner only on manual refresh, not silent auto-refresh
- [ ] Mobile layout check (single-column stack) — to verify post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)