### PR TITLE
UI/UX audit + dark/light theme toggle (#214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (dark/light theme toggle — issue #214)
+- **`web/src/components/theme-provider.tsx`** — wraps `next-themes` `ThemeProvider` with `attribute="data-theme"` and `enableSystem`.
+- **`web/src/components/theme-toggle.tsx`** — header icon button (System/Light/Dark cycle), Lucide `Sun` / `Moon` / `Monitor`. Rendered in the desktop sidebar header and the mobile More sheet header.
+- **`web/src/components/settings/appearance-settings.tsx`** — Settings "Appearance" radio group (System / Light / Dark) synced bidirectionally with the header toggle via `useTheme()`.
+- **`web/src/lib/theme.ts`** — `getServerThemePreference()` reads `profile.theme_preference` (K/V key) so SSR emits the correct `data-theme` on `<html>` and avoids FOUC.
+- **`web/src/lib/theme-actions.ts`** — `setThemePreference()` server action that upserts (or deletes, for `system`) the profile row.
+- **`web/src/lib/chart-colors.ts`** — `useChartColors()` hook reads CSS variables at runtime via `getComputedStyle()` so Recharts responds to theme switches.
+- **Audit deliverable** at `.claude/plans/snappy-twirling-cookie.md`.
+
+### Changed (issue #214)
+- **`web/src/app/globals.css`** — dark tokens aligned to MASTER.md (`--color-primary` now `#3B82F6`, not `#6366F1`); added `:root[data-theme="light"]` with MASTER.md light column values; added global `:focus-visible` outline rule; `html { color-scheme: dark light; }`.
+- **Color migration** — replaced ~200 hardcoded hex values and ~30 Tailwind `neutral-*`/`rose-*`/`blue-*` utilities with CSS vars across dashboard + fitness + habits + chat + nav + settings + login. Chart components now consume `useChartColors()`.
+- **`web/src/components/dashboard/dashboard-header.tsx`** — replaced emoji WMO weather map with Lucide icons (`Sun`, `CloudSun`, `CloudRain`, etc.).
+- **`design-system/mr-bridge/MASTER.md`** — §Typography now documents DM Sans + Inter (intentional deviation from original Fira spec).
+
 ### Added (ui-ux-pro-max skill + design system — prep for issue #10)
 - **`.claude/skills/ui-ux-pro-max/`** — installed via `uipro init --ai claude` (uipro-cli@2.2.3). Provides design intelligence (67 styles, 96 palettes, 57 font pairings, 13 stacks) with a CLI for generating design systems and running domain searches (style, ux, typography, color, chart, stack-specific guidelines).
 - **`design-system/mr-bridge/MASTER.md`** — persisted design system: Dark Mode (OLED) style, Fira Code + Fira Sans typography, blue+amber palette with dark/light tokens, spacing/shadow scales, component specs, anti-patterns, pre-delivery checklist. Page Pattern hand-edited to "Sidebar + Main (Chat/Dashboard App Shell)" after the generator's output was unusable (landing-page layouts + raw CSV leak). Will serve as the source of truth for the web interface work in issue #10.

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ You only need to do this once. Claude Code will remember the auth for future ses
 
 Mr. Bridge reads a flat key-value `profile` table in Supabase. Fill in your details one of two ways:
 
-- **Web app** → open the web interface → **Settings** → fill in Display Name, Home Location, Target Weight, nutrition goals, and fitness goals, then save each field.
+- **Web app** → open the web interface → **Settings** → fill in Display Name, Home Location, Target Weight, nutrition goals, and fitness goals, then save each field. The Appearance section lets you pick System / Light / Dark (persisted to `profile.theme_preference`; header toggle and Settings radio stay in sync).
 - **Chat** → ask Mr. Bridge: *"Set my weight goal to 160 lbs"* or *"My name is Jason"* — the AI writes these directly to Supabase.
 
 ### Step 11 — First session

--- a/design-system/mr-bridge/MASTER.md
+++ b/design-system/mr-bridge/MASTER.md
@@ -33,14 +33,14 @@ Dark mode is the default (per style: Dark Mode OLED). Light mode tokens provided
 
 ### Typography
 
-- **Heading Font:** Fira Code
-- **Body Font:** Fira Sans
-- **Mood:** dashboard, data, analytics, code, technical, precise
-- **Google Fonts:** [Fira Code + Fira Sans](https://fonts.google.com/share?selection.family=Fira+Code:wght@400;500;600;700|Fira+Sans:wght@300;400;500;600;700)
+- **Heading Font:** DM Sans
+- **Body Font:** Inter
+- **Mood:** dashboard, data, analytics, technical, precise (deviation from original Fira spec — cleaner geometric sans preferred)
+- **Google Fonts:** [DM Sans + Inter](https://fonts.google.com/share?selection.family=DM+Sans:wght@400;500;600;700|Inter:wght@300;400;500;600)
 
 **CSS Import:**
 ```css
-@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&family=Fira+Sans:wght@300;400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Inter:wght@300;400;500;600&display=swap');
 ```
 
 ### Spacing Variables

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,6 +17,7 @@
         "googleapis": "^171.4.0",
         "lucide-react": "^0.511.0",
         "next": "^15.3.1",
+        "next-themes": "^0.4.6",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
@@ -3687,6 +3688,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
     "googleapis": "^171.4.0",
     "lucide-react": "^0.511.0",
     "next": "^15.3.1",
+    "next-themes": "^0.4.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",

--- a/web/src/app/(protected)/settings/page.tsx
+++ b/web/src/app/(protected)/settings/page.tsx
@@ -5,6 +5,7 @@ import { revalidatePath } from "next/cache";
 import { ProfileForm } from "@/components/settings/profile-form";
 import { WatchlistSettings } from "@/components/settings/watchlist-settings";
 import { SportsSettings } from "@/components/settings/sports-settings";
+import { AppearanceSettings } from "@/components/settings/appearance-settings";
 import type { SportsFavorite } from "@/lib/sync/sports";
 
 async function updateProfile(key: string, value: string) {
@@ -92,6 +93,8 @@ export default async function SettingsPage() {
           Edit and save changes inline. Press Enter or click Save on any field.
         </p>
       </div>
+
+      <AppearanceSettings />
 
       <ProfileForm
         values={values}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -2,26 +2,57 @@
 @import "tailwindcss";
 
 /* ─── Design Tokens ─────────────────────────────────────────────────── */
-:root {
-  --color-bg:             #0A0B0F;
-  --color-surface:        #111318;
+:root,
+:root[data-theme="dark"] {
+  --color-bg:             #0B0F19;
+  --color-surface:        #111827;
   --color-surface-raised: #181B24;
-  --color-border:         #1E2130;
+  --color-border:         #1F2937;
   --color-border-subtle:  #161925;
-  --color-primary:        #6366F1;
-  --color-primary-dim:    rgba(99, 102, 241, 0.13);
+  --color-primary:        #3B82F6;
+  --color-primary-dim:    rgba(59, 130, 246, 0.15);
+  --color-secondary:      #60A5FA;
+  --color-cta:            #F59E0B;
   --color-positive:       #10B981;
   --color-warning:        #F59E0B;
   --color-danger:         #EF4444;
   --color-info:           #38BDF8;
-  --color-text:           #E2E8F0;
-  --color-text-muted:     #64748B;
-  --color-text-faint:     #334155;
+  --color-text:           #F8FAFC;
+  --color-text-muted:     #94A3B8;
+  --color-text-faint:     #64748B;
 
   --shadow-sm:   0 1px 3px rgba(0,0,0,0.4);
   --shadow-md:   0 4px 12px rgba(0,0,0,0.5);
   --shadow-lg:   0 8px 24px rgba(0,0,0,0.6);
   --shadow-glow: 0 0 0 3px var(--color-primary-dim);
+}
+
+:root[data-theme="light"] {
+  --color-bg:             #F8FAFC;
+  --color-surface:        #FFFFFF;
+  --color-surface-raised: #F1F5F9;
+  --color-border:         #E2E8F0;
+  --color-border-subtle:  #EEF2F7;
+  --color-primary:        #1E40AF;
+  --color-primary-dim:    rgba(30, 64, 175, 0.12);
+  --color-secondary:      #3B82F6;
+  --color-cta:            #F59E0B;
+  --color-positive:       #059669;
+  --color-warning:        #B45309;
+  --color-danger:         #B91C1C;
+  --color-info:           #0369A1;
+  --color-text:           #0F172A;
+  --color-text-muted:     #475569;
+  --color-text-faint:     #64748B;
+
+  --shadow-sm:   0 1px 2px rgba(15,23,42,0.06);
+  --shadow-md:   0 4px 6px rgba(15,23,42,0.08);
+  --shadow-lg:   0 10px 15px rgba(15,23,42,0.10);
+  --shadow-glow: 0 0 0 3px var(--color-primary-dim);
+}
+
+html {
+  color-scheme: dark light;
 }
 
 /* ─── Base ────────────────────────────────────────────────────────────── */
@@ -40,6 +71,13 @@ body {
 
 .font-heading {
   font-family: 'DM Sans', system-ui, sans-serif;
+}
+
+/* ─── Focus visible (global) ──────────────────────────────────────────── */
+:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 /* ─── Scrollbar ───────────────────────────────────────────────────────── */

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import "./globals.css";
+import { ThemeProvider } from "@/components/theme-provider";
+import { getServerThemePreference } from "@/lib/theme";
 
 export const metadata: Metadata = {
   title: "Mr. Bridge",
@@ -11,13 +13,17 @@ export const viewport: Viewport = {
   viewportFit: "cover",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const themePref = await getServerThemePreference();
+  const htmlThemeAttr =
+    themePref === "light" || themePref === "dark" ? { "data-theme": themePref } : {};
+
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning {...htmlThemeAttr}>
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
@@ -27,7 +33,7 @@ export default function RootLayout({
         />
       </head>
       <body style={{ background: "var(--color-bg)", color: "var(--color-text)" }}>
-        {children}
+        <ThemeProvider defaultTheme={themePref}>{children}</ThemeProvider>
       </body>
     </html>
   );

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -45,26 +45,42 @@ function LoginForm() {
     await signIn(DEMO_EMAIL, DEMO_PASSWORD);
   }
 
+  const inputStyle: React.CSSProperties = {
+    background: "var(--color-surface)",
+    border: "1px solid var(--color-border)",
+    color: "var(--color-text)",
+  };
+
   return (
-    <div className="min-h-screen bg-neutral-950 flex items-center justify-center px-4">
+    <div
+      className="min-h-screen flex items-center justify-center px-4"
+      style={{ background: "var(--color-bg)" }}
+    >
       <div className="w-full max-w-sm space-y-8">
         <div className="flex items-center gap-3">
           <Logo size={36} />
           <div>
-            <h1 className="text-2xl font-semibold text-neutral-100">Mr. Bridge</h1>
-            <p className="mt-0.5 text-sm text-neutral-500">Personal assistant</p>
+            <h1 className="text-2xl font-semibold" style={{ color: "var(--color-text)" }}>Mr. Bridge</h1>
+            <p className="mt-0.5 text-sm" style={{ color: "var(--color-text-muted)" }}>Personal assistant</p>
           </div>
         </div>
 
         {hasAuthError && (
-          <div className="rounded-lg bg-red-950 border border-red-800 px-4 py-3 text-sm text-red-300">
+          <div
+            className="rounded-lg px-4 py-3 text-sm"
+            style={{
+              background: "color-mix(in srgb, var(--color-danger) 15%, transparent)",
+              border: "1px solid color-mix(in srgb, var(--color-danger) 40%, transparent)",
+              color: "var(--color-danger)",
+            }}
+          >
             Session expired. Please sign in again.
           </div>
         )}
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label htmlFor="email" className="block text-sm text-neutral-400 mb-1.5">
+            <label htmlFor="email" className="block text-sm mb-1.5" style={{ color: "var(--color-text-muted)" }}>
               Email
             </label>
             <input
@@ -74,12 +90,14 @@ function LoginForm() {
               onChange={(e) => setEmail(e.target.value)}
               required
               placeholder="you@example.com"
-              className="w-full bg-neutral-900 border border-neutral-700 rounded-lg px-4 py-2.5 text-sm text-neutral-100 placeholder-neutral-600 focus:outline-none focus:border-neutral-500"
+              aria-invalid={state === "error"}
+              className="w-full rounded-lg px-4 py-2.5 text-sm"
+              style={inputStyle}
             />
           </div>
 
           <div>
-            <label htmlFor="password" className="block text-sm text-neutral-400 mb-1.5">
+            <label htmlFor="password" className="block text-sm mb-1.5" style={{ color: "var(--color-text-muted)" }}>
               Password
             </label>
             <input
@@ -89,18 +107,23 @@ function LoginForm() {
               onChange={(e) => setPassword(e.target.value)}
               required
               placeholder="••••••••"
-              className="w-full bg-neutral-900 border border-neutral-700 rounded-lg px-4 py-2.5 text-sm text-neutral-100 placeholder-neutral-600 focus:outline-none focus:border-neutral-500"
+              aria-invalid={state === "error"}
+              className="w-full rounded-lg px-4 py-2.5 text-sm"
+              style={inputStyle}
             />
           </div>
 
           {state === "error" && (
-            <p className="text-sm text-red-400">{errorMsg || "Invalid email or password."}</p>
+            <p className="text-sm" style={{ color: "var(--color-danger)" }}>{errorMsg || "Invalid email or password."}</p>
           )}
 
           <button
             type="submit"
             disabled={state === "loading" || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) || !password.trim()}
-            className="w-full bg-blue-500 text-white rounded-lg px-4 py-2.5 text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:bg-blue-400 transition-colors"
+            className="w-full rounded-lg px-4 py-2.5 text-sm font-medium transition-opacity cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+            style={{ background: "var(--color-primary)", color: "#fff" }}
+            onMouseEnter={(e) => { if (!(e.currentTarget as HTMLButtonElement).disabled) (e.currentTarget as HTMLElement).style.opacity = "0.9"; }}
+            onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.opacity = "1"; }}
           >
             {state === "loading" ? "Signing in..." : "Sign in"}
           </button>
@@ -110,20 +133,25 @@ function LoginForm() {
           <div className="pt-2">
             <div className="relative">
               <div className="absolute inset-0 flex items-center">
-                <div className="w-full border-t border-neutral-800" />
+                <div className="w-full" style={{ borderTop: "1px solid var(--color-border)" }} />
               </div>
               <div className="relative flex justify-center text-xs">
-                <span className="bg-neutral-950 px-3 text-neutral-600">or</span>
+                <span className="px-3" style={{ background: "var(--color-bg)", color: "var(--color-text-faint)" }}>or</span>
               </div>
             </div>
             <button
               onClick={handleDemoLogin}
               disabled={state === "loading"}
-              className="mt-4 w-full border border-neutral-700 text-neutral-300 rounded-lg px-4 py-2.5 text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:border-neutral-500 hover:text-neutral-100 transition-colors"
+              className="mt-4 w-full rounded-lg px-4 py-2.5 text-sm font-medium transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+              style={{
+                border: "1px solid var(--color-border)",
+                color: "var(--color-text-muted)",
+                background: "transparent",
+              }}
             >
               Try the demo
             </button>
-            <p className="mt-2 text-center text-xs text-neutral-600">
+            <p className="mt-2 text-center text-xs" style={{ color: "var(--color-text-faint)" }}>
               Fictional persona · read-write · resets nightly
             </p>
           </div>

--- a/web/src/components/chat/chat-interface.tsx
+++ b/web/src/components/chat/chat-interface.tsx
@@ -387,10 +387,10 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
           style={{ background: "var(--color-primary)", color: "white" }}
           onMouseEnter={(e) => {
             if (!(e.currentTarget as HTMLButtonElement).disabled)
-              (e.currentTarget as HTMLElement).style.background = "#4F52D9";
+              (e.currentTarget as HTMLElement).style.opacity = "0.85";
           }}
           onMouseLeave={(e) => {
-            (e.currentTarget as HTMLElement).style.background = "var(--color-primary)";
+            (e.currentTarget as HTMLElement).style.opacity = "1";
           }}
         >
           <Send size={16} />

--- a/web/src/components/chat/session-sidebar.tsx
+++ b/web/src/components/chat/session-sidebar.tsx
@@ -72,10 +72,10 @@ export default function SessionSidebar({
             minHeight: 48,
           }}
           onMouseEnter={(e) => {
-            (e.currentTarget as HTMLElement).style.background = "#4F52D9";
+            (e.currentTarget as HTMLElement).style.opacity = "0.85";
           }}
           onMouseLeave={(e) => {
-            (e.currentTarget as HTMLElement).style.background = "var(--color-primary)";
+            (e.currentTarget as HTMLElement).style.opacity = "1";
           }}
         >
           <Plus size={15} />

--- a/web/src/components/chat/tool-status-bar.tsx
+++ b/web/src/components/chat/tool-status-bar.tsx
@@ -83,14 +83,20 @@ const ToolStatusBar = memo(function ToolStatusBar({ messages, isLoading }: Props
           return (
             <span
               key={inv.toolCallId}
-              className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs bg-neutral-800 border border-neutral-700 ${
-                isDone ? "text-neutral-500" : "text-neutral-400"
-              }`}
+              className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs"
+              style={{
+                background: "var(--color-surface-raised)",
+                border: "1px solid var(--color-border)",
+                color: isDone ? "var(--color-text-muted)" : "var(--color-text)",
+              }}
             >
               {isDone ? (
-                <span className="text-emerald-600 text-[10px] leading-none">✓</span>
+                <span className="text-[10px] leading-none" style={{ color: "var(--color-positive)" }}>✓</span>
               ) : (
-                <span className="inline-block w-2.5 h-2.5 border border-neutral-400 border-t-transparent rounded-full animate-spin shrink-0" />
+                <span
+                  className="inline-block w-2.5 h-2.5 rounded-full animate-spin shrink-0"
+                  style={{ border: "1px solid var(--color-text-muted)", borderTopColor: "transparent" }}
+                />
               )}
               {toolLabel(inv.toolName)}{isDone ? "" : "..."}
             </span>

--- a/web/src/components/dashboard/dashboard-header.tsx
+++ b/web/src/components/dashboard/dashboard-header.tsx
@@ -1,19 +1,23 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import {
+  Sun, CloudSun, Cloud, Cloudy, CloudFog, CloudRain, CloudSnow, CloudLightning, Thermometer,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import SyncButton from "./sync-button";
 import { WindowSelector } from "@/components/ui/window-selector";
 import type { WeatherData } from "@/app/api/weather/route";
 import type { WindowKey } from "@/lib/window";
 
-const WMO_EMOJI: Record<number, string> = {
-  0: "☀️", 1: "🌤", 2: "⛅", 3: "☁️",
-  45: "🌫", 48: "🌫",
-  51: "🌦", 53: "🌦", 55: "🌧",
-  61: "🌧", 63: "🌧", 65: "🌧",
-  71: "🌨", 73: "🌨", 75: "❄️", 77: "❄️",
-  80: "🌦", 81: "🌦", 82: "⛈",
-  95: "⛈", 96: "⛈", 99: "⛈",
+const WMO_ICON: Record<number, LucideIcon> = {
+  0: Sun, 1: CloudSun, 2: CloudSun, 3: Cloud,
+  45: CloudFog, 48: CloudFog,
+  51: CloudRain, 53: CloudRain, 55: CloudRain,
+  61: CloudRain, 63: CloudRain, 65: CloudRain,
+  71: CloudSnow, 73: CloudSnow, 75: CloudSnow, 77: CloudSnow,
+  80: CloudRain, 81: CloudRain, 82: CloudLightning,
+  95: CloudLightning, 96: CloudLightning, 99: CloudLightning,
 };
 
 interface Props {
@@ -32,11 +36,10 @@ export default function DashboardHeader({ greeting, dateStr, windowKey }: Props)
       .catch(() => {});
   }, []);
 
-  const emoji = weather?.wmoCode != null ? (WMO_EMOJI[weather.wmoCode] ?? "🌡") : null;
+  const Icon = weather?.wmoCode != null ? (WMO_ICON[weather.wmoCode] ?? Cloudy) : Thermometer;
 
   return (
     <div className="flex items-start justify-between gap-4">
-      {/* Left: greeting + date + weather */}
       <div>
         <h1 className="font-heading font-semibold" style={{ fontSize: 24, color: "var(--color-text)" }}>
           {greeting}
@@ -46,7 +49,7 @@ export default function DashboardHeader({ greeting, dateStr, windowKey }: Props)
         </p>
         {weather && (
           <p className="mt-0.5 flex flex-wrap items-center gap-x-1.5 gap-y-0" style={{ fontSize: 13, color: "var(--color-text-muted)" }}>
-            {emoji && <span style={{ fontSize: 14, lineHeight: 1 }}>{emoji}</span>}
+            <Icon size={14} style={{ color: "var(--color-text-muted)", flexShrink: 0 }} aria-hidden />
             {weather.temp != null && (
               <span style={{ color: "var(--color-text)" }}>{Math.round(weather.temp)}°</span>
             )}
@@ -60,7 +63,6 @@ export default function DashboardHeader({ greeting, dateStr, windowKey }: Props)
         )}
       </div>
 
-      {/* Right: sync + window */}
       <div className="flex items-center gap-3 flex-shrink-0">
         <SyncButton />
         <WindowSelector current={windowKey} />

--- a/web/src/components/dashboard/health-breakdown.tsx
+++ b/web/src/components/dashboard/health-breakdown.tsx
@@ -12,6 +12,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import type { RecoveryMetrics } from "@/lib/types";
+import { useChartColors, type ChartColors } from "@/lib/chart-colors";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -33,16 +34,21 @@ type SleepTab   = "stages" | "hrv" | "rhr" | "spo2";
 
 // ── Recharts shared config ───────────────────────────────────────────────────
 
-const TOOLTIP_STYLE = {
-  contentStyle: { background: "#181B24", border: "1px solid #2A2F45", borderRadius: 8 },
-  labelStyle:   { color: "#E2E8F0", fontSize: 12 },
-  itemStyle:    { color: "#64748B", fontSize: 11 },
-};
-const GRID  = { strokeDasharray: "3 3", stroke: "#1E2130", vertical: false as const };
-const AXIS  = { stroke: "#334155", tick: { fill: "#64748B", fontSize: 10 }, tickLine: false as const, axisLine: false as const };
 const CHART_H = 180;
-const AVG_LINE = { stroke: "#64748B", strokeWidth: 1.5, strokeDasharray: "4 2", dot: false };
-const LEGEND_STYLE = { fontSize: 10, color: "#64748B", paddingBottom: 4 };
+
+function buildChartConfig(c: ChartColors) {
+  return {
+    TOOLTIP_STYLE: {
+      contentStyle: { background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 8 },
+      labelStyle:   { color: c.text, fontSize: 12 },
+      itemStyle:    { color: c.textMuted, fontSize: 11 },
+    },
+    GRID:  { strokeDasharray: "3 3", stroke: c.grid, vertical: false as const },
+    AXIS:  { stroke: c.axis, tick: { fill: c.textMuted, fontSize: 10 }, tickLine: false as const, axisLine: false as const },
+    AVG_LINE: { stroke: c.textMuted, strokeWidth: 1.5, strokeDasharray: "4 2", dot: false },
+    LEGEND_STYLE: { fontSize: 10, color: c.textMuted, paddingBottom: 4 },
+  };
+}
 
 // ── Score helpers ────────────────────────────────────────────────────────────
 
@@ -186,6 +192,8 @@ function FitnessChartPanel({
   animate: boolean;
 }) {
   const [tab, setTab] = useState<FitnessTab>("weight");
+  const c = useChartColors();
+  const { TOOLTIP_STYLE, GRID, AXIS, AVG_LINE, LEGEND_STYLE } = buildChartConfig(c);
 
   const weightDataRaw = fitnessData.map((d) => ({ date: d.date.slice(5), value: d.weight_lb }));
   const weightAvgs    = trailing7Avg(weightDataRaw);
@@ -229,8 +237,8 @@ function FitnessChartPanel({
             <YAxis {...AXIS} domain={["auto", "auto"]} />
             <Tooltip {...TOOLTIP_STYLE} formatter={(v: number) => `${v} lb`} />
             <Legend verticalAlign="top" height={20} wrapperStyle={LEGEND_STYLE} />
-            <Line type="monotone" dataKey="value" name="Weight" stroke="#6366F1" strokeWidth={2} dot={false}
-              activeDot={{ r: 4, fill: "#6366F1", strokeWidth: 0 }} connectNulls
+            <Line type="monotone" dataKey="value" name="Weight" stroke={c.primary} strokeWidth={2} dot={false}
+              activeDot={{ r: 4, fill: c.primary, strokeWidth: 0 }} connectNulls
               isAnimationActive={animate} animationDuration={300} />
             <Line type="monotone" dataKey="avg" name="7d avg" {...AVG_LINE} connectNulls
               isAnimationActive={false} />
@@ -246,8 +254,8 @@ function FitnessChartPanel({
             <YAxis {...AXIS} domain={["auto", "auto"]} tickFormatter={(v) => `${v}%`} />
             <Tooltip {...TOOLTIP_STYLE} formatter={(v: number) => `${(v as number).toFixed(1)}%`} />
             <Legend verticalAlign="top" height={20} wrapperStyle={LEGEND_STYLE} />
-            <Line type="monotone" dataKey="value" name="Body Fat" stroke="#10B981" strokeWidth={2} dot={false}
-              activeDot={{ r: 4, fill: "#10B981", strokeWidth: 0 }} connectNulls
+            <Line type="monotone" dataKey="value" name="Body Fat" stroke={c.positive} strokeWidth={2} dot={false}
+              activeDot={{ r: 4, fill: c.positive, strokeWidth: 0 }} connectNulls
               isAnimationActive={animate} animationDuration={300} />
             <Line type="monotone" dataKey="avg" name="7d avg" {...AVG_LINE} connectNulls
               isAnimationActive={false} />
@@ -263,7 +271,7 @@ function FitnessChartPanel({
             <YAxis {...AXIS} tickFormatter={(v) => v >= 1000 ? `${(v/1000).toFixed(0)}k` : v} />
             <Tooltip {...TOOLTIP_STYLE} formatter={(v: number) => v.toLocaleString()} />
             <Legend verticalAlign="top" height={20} wrapperStyle={LEGEND_STYLE} />
-            <Bar dataKey="value" name="Steps" fill="#38BDF8" radius={[3, 3, 0, 0]}
+            <Bar dataKey="value" name="Steps" fill={c.info} radius={[3, 3, 0, 0]}
               isAnimationActive={animate} animationDuration={300} />
             <Line type="monotone" dataKey="avg" name="7d avg" {...AVG_LINE} connectNulls
               isAnimationActive={false} />
@@ -276,8 +284,8 @@ function FitnessChartPanel({
           <ComposedChart data={calData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
             <defs>
               <linearGradient id="calGrad" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%"  stopColor="#F59E0B" stopOpacity={0.25} />
-                <stop offset="95%" stopColor="#F59E0B" stopOpacity={0.02} />
+                <stop offset="5%"  stopColor={c.warning} stopOpacity={0.25} />
+                <stop offset="95%" stopColor={c.warning} stopOpacity={0.02} />
               </linearGradient>
             </defs>
             <CartesianGrid {...GRID} />
@@ -285,7 +293,7 @@ function FitnessChartPanel({
             <YAxis {...AXIS} />
             <Tooltip {...TOOLTIP_STYLE} formatter={(v: number) => `${Math.round(v)} kcal`} />
             <Legend verticalAlign="top" height={20} wrapperStyle={LEGEND_STYLE} />
-            <Area type="monotone" dataKey="value" name="Active Cal" stroke="#F59E0B" strokeWidth={2}
+            <Area type="monotone" dataKey="value" name="Active Cal" stroke={c.warning} strokeWidth={2}
               fill="url(#calGrad)" dot={false} connectNulls
               isAnimationActive={animate} animationDuration={300} />
             <Line type="monotone" dataKey="avg" name="7d avg" {...AVG_LINE} connectNulls
@@ -318,6 +326,8 @@ function SleepChartPanel({
   ];
 
   const [tab, setTab] = useState<SleepTab>("stages");
+  const c = useChartColors();
+  const { TOOLTIP_STYLE, GRID, AXIS } = buildChartConfig(c);
 
   const stagesData = trends.map((d) => ({
     date:  d.date.slice(5),
@@ -357,9 +367,9 @@ function SleepChartPanel({
                 return [m > 0 ? `${h}h ${m}m` : `${h}h`, name];
               }}
             />
-            <Bar dataKey="deep"  name="Deep"  fill="#6366F1" stackId="s" radius={[0,0,0,0]} isAnimationActive={animate} animationDuration={300} />
-            <Bar dataKey="rem"   name="REM"   fill="#A78BFA" stackId="s" radius={[0,0,0,0]} isAnimationActive={animate} animationDuration={300} />
-            <Bar dataKey="light" name="Light" fill="#38BDF8" stackId="s" radius={[3,3,0,0]} isAnimationActive={animate} animationDuration={300} />
+            <Bar dataKey="deep"  name="Deep"  fill={c.primary} stackId="s" radius={[0,0,0,0]} isAnimationActive={animate} animationDuration={300} />
+            <Bar dataKey="rem"   name="REM"   fill={c.secondary} stackId="s" radius={[0,0,0,0]} isAnimationActive={animate} animationDuration={300} />
+            <Bar dataKey="light" name="Light" fill={c.info} stackId="s" radius={[3,3,0,0]} isAnimationActive={animate} animationDuration={300} />
           </BarChart>
         </ResponsiveContainer>
       )}
@@ -369,15 +379,15 @@ function SleepChartPanel({
           <AreaChart data={hrvData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
             <defs>
               <linearGradient id="hrvGrad" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%"  stopColor="#10B981" stopOpacity={0.25} />
-                <stop offset="95%" stopColor="#10B981" stopOpacity={0.02} />
+                <stop offset="5%"  stopColor={c.positive} stopOpacity={0.25} />
+                <stop offset="95%" stopColor={c.positive} stopOpacity={0.02} />
               </linearGradient>
             </defs>
             <CartesianGrid {...GRID} />
             <XAxis dataKey="date" {...AXIS} interval="preserveStartEnd" />
             <YAxis {...AXIS} />
             <Tooltip {...TOOLTIP_STYLE} formatter={(v: number) => [`${Math.round(v)} ms`, "HRV"]} />
-            <Area type="monotone" dataKey="value" stroke="#10B981" strokeWidth={2}
+            <Area type="monotone" dataKey="value" stroke={c.positive} strokeWidth={2}
               fill="url(#hrvGrad)" dot={false} connectNulls
               isAnimationActive={animate} animationDuration={300} />
           </AreaChart>
@@ -391,8 +401,8 @@ function SleepChartPanel({
             <XAxis dataKey="date" {...AXIS} interval="preserveStartEnd" />
             <YAxis {...AXIS} domain={["auto", "auto"]} />
             <Tooltip {...TOOLTIP_STYLE} formatter={(v: number) => [`${Math.round(v)} bpm`, "RHR"]} />
-            <Line type="monotone" dataKey="value" stroke="#EF4444" strokeWidth={2} dot={false}
-              activeDot={{ r: 4, fill: "#EF4444", strokeWidth: 0 }} connectNulls
+            <Line type="monotone" dataKey="value" stroke={c.danger} strokeWidth={2} dot={false}
+              activeDot={{ r: 4, fill: c.danger, strokeWidth: 0 }} connectNulls
               isAnimationActive={animate} animationDuration={300} />
           </LineChart>
         </ResponsiveContainer>
@@ -405,8 +415,8 @@ function SleepChartPanel({
             <XAxis dataKey="date" {...AXIS} interval="preserveStartEnd" />
             <YAxis {...AXIS} domain={["auto", "auto"]} tickFormatter={(v) => `${v}%`} />
             <Tooltip {...TOOLTIP_STYLE} formatter={(v: number) => [`${v.toFixed(1)}%`, "SpO₂"]} />
-            <Line type="monotone" dataKey="value" stroke="#38BDF8" strokeWidth={2} dot={false}
-              activeDot={{ r: 4, fill: "#38BDF8", strokeWidth: 0 }} connectNulls
+            <Line type="monotone" dataKey="value" stroke={c.info} strokeWidth={2} dot={false}
+              activeDot={{ r: 4, fill: c.info, strokeWidth: 0 }} connectNulls
               isAnimationActive={animate} animationDuration={300} />
           </LineChart>
         </ResponsiveContainer>
@@ -543,7 +553,7 @@ export default function HealthBreakdown({ recovery, trends, fitnessData, windowL
               </div>
 
               {/* Sleep (border-left only on desktop) */}
-              <div className="min-w-0 lg:pl-6 lg:border-l lg:border-[#1E2130]">
+              <div className="min-w-0 lg:pl-6 lg:border-l" style={{ borderColor: "var(--color-border)" }}>
                 <SleepChartPanel trends={trends} windowLabel={windowLabel} animate={animate} />
               </div>
             </div>

--- a/web/src/components/dashboard/important-emails.tsx
+++ b/web/src/components/dashboard/important-emails.tsx
@@ -20,37 +20,44 @@ export default function ImportantEmails() {
       .finally(() => setLoading(false));
   }, []);
 
+  const muted = { color: "var(--color-text-muted)" };
+  const faint = { color: "var(--color-text-faint)" };
+  const text = { color: "var(--color-text)" };
+
   return (
-    <div className="bg-neutral-900 rounded-xl p-4 border border-neutral-800">
+    <div
+      className="rounded-xl p-4"
+      style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+    >
       <div className="flex items-center gap-2 mb-3">
-        <Mail size={13} className="text-neutral-500 shrink-0" />
-        <p className="text-xs text-neutral-500 uppercase tracking-wide">Important Emails</p>
+        <Mail size={13} style={{ color: "var(--color-text-muted)", flexShrink: 0 }} />
+        <p className="text-xs uppercase tracking-wide" style={muted}>Important Emails</p>
       </div>
 
       {loading ? (
         <div className="space-y-3">
           {[1, 2].map((i) => (
             <div key={i} className="space-y-1.5">
-              <div className="h-3 bg-neutral-800 rounded animate-pulse w-1/3" />
-              <div className="h-3 bg-neutral-800 rounded animate-pulse w-4/5" />
+              <div className="h-3 rounded animate-pulse w-1/3" style={{ background: "var(--color-surface-raised)" }} />
+              <div className="h-3 rounded animate-pulse w-4/5" style={{ background: "var(--color-surface-raised)" }} />
             </div>
           ))}
         </div>
       ) : error ? (
-        <p className="text-sm text-red-400/70">Failed to load — check Google credentials</p>
+        <p className="text-sm" style={{ color: "var(--color-danger)" }}>Failed to load — check Google credentials</p>
       ) : emails.length > 0 ? (
-        <div className="divide-y divide-neutral-800/50">
+        <div className="divide-y" style={{ borderColor: "var(--color-border)" }}>
           {emails.map((email, i) => (
             <div key={i} className="py-2.5 first:pt-0 last:pb-0 min-w-0">
               <div className="flex items-baseline justify-between gap-3 mb-0.5">
-                <p className="text-xs text-neutral-400 truncate">
+                <p className="text-xs truncate" style={muted}>
                   {email.from}
                   {email.account === "professional" && (
-                    <span className="ml-1.5 text-neutral-600 text-[10px]">work</span>
+                    <span className="ml-1.5 text-[10px]" style={faint}>work</span>
                   )}
                 </p>
                 {email.receivedAt && (
-                  <p className="text-[10px] text-neutral-600 shrink-0">
+                  <p className="text-[10px] shrink-0" style={faint}>
                     {(() => {
                       const d = new Date(email.receivedAt);
                       const today = new Date();
@@ -65,11 +72,12 @@ export default function ImportantEmails() {
                   </p>
                 )}
               </div>
-              <p className="text-sm text-neutral-200 truncate">{email.subject}</p>
+              <p className="text-sm truncate" style={text}>{email.subject}</p>
               {email.snippet && (
                 <p
-                  className="mt-1 text-xs text-neutral-500"
+                  className="mt-1 text-xs"
                   style={{
+                    ...muted,
                     display: "-webkit-box",
                     WebkitLineClamp: 2,
                     WebkitBoxOrient: "vertical",
@@ -83,7 +91,7 @@ export default function ImportantEmails() {
           ))}
         </div>
       ) : (
-        <p className="text-sm text-neutral-600">Inbox clear</p>
+        <p className="text-sm" style={faint}>Inbox clear</p>
       )}
     </div>
   );

--- a/web/src/components/dashboard/schedule-today.tsx
+++ b/web/src/components/dashboard/schedule-today.tsx
@@ -5,7 +5,6 @@ import { Calendar, Gift } from "lucide-react";
 import type { CalendarEvent } from "@/app/api/google/calendar/route";
 
 function parseTimeToMinutes(timeStr: string): number | null {
-  // Handles "9:00 AM", "2:30 PM" — returns minutes since midnight
   const match = timeStr.match(/(\d+):(\d+)\s*(AM|PM)/i);
   if (!match) return null;
   let h = parseInt(match[1]);
@@ -36,7 +35,6 @@ export default function ScheduleToday() {
     setNowMinutes(now.getHours() * 60 + now.getMinutes());
   }, []);
 
-  // Split events into past / upcoming based on start time
   type RenderedItem =
     | { type: "event"; event: CalendarEvent; isPast: boolean; index: number }
     | { type: "now" };
@@ -50,7 +48,6 @@ export default function ScheduleToday() {
       const eventMins = parseTimeToMinutes(event.time);
       const isPast = eventMins !== null && eventMins < nowMinutes;
 
-      // Insert "now" divider at the transition from past to upcoming
       if (!nowDividerInserted && eventMins !== null && eventMins >= nowMinutes) {
         const hasPastEvents = renderedItems.some((r) => r.type === "event" && r.isPast);
         if (hasPastEvents) {
@@ -64,25 +61,32 @@ export default function ScheduleToday() {
   }
 
   const useEnhanced = nowMinutes !== null && renderedItems.length > 0;
+  const muted = { color: "var(--color-text-muted)" };
+  const faint = { color: "var(--color-text-faint)" };
+  const text = { color: "var(--color-text)" };
+  const accent = { color: "var(--color-cta)" };
 
   return (
-    <div className="bg-neutral-900 rounded-xl p-4 border border-neutral-800 h-full">
+    <div
+      className="rounded-xl p-4 h-full"
+      style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+    >
       <div className="flex items-center gap-2 mb-3">
-        <Calendar size={13} className="text-neutral-500 shrink-0" />
-        <p className="text-xs text-neutral-500 uppercase tracking-wide">Schedule Today</p>
+        <Calendar size={13} style={{ color: "var(--color-text-muted)", flexShrink: 0 }} />
+        <p className="text-xs uppercase tracking-wide" style={muted}>Schedule Today</p>
       </div>
 
       {loading ? (
         <div className="space-y-2.5">
           {[1, 2, 3].map((i) => (
             <div key={i} className="flex gap-3">
-              <div className="h-3 bg-neutral-800 rounded animate-pulse w-14 shrink-0" />
-              <div className="h-3 bg-neutral-800 rounded animate-pulse flex-1" />
+              <div className="h-3 rounded animate-pulse w-14 shrink-0" style={{ background: "var(--color-surface-raised)" }} />
+              <div className="h-3 rounded animate-pulse flex-1" style={{ background: "var(--color-surface-raised)" }} />
             </div>
           ))}
         </div>
       ) : error ? (
-        <p className="text-sm text-red-400/70">Failed to load — check Google credentials</p>
+        <p className="text-sm" style={{ color: "var(--color-danger)" }}>Failed to load — check Google credentials</p>
       ) : events.length > 0 ? (
         <div className="space-y-2.5">
           {useEnhanced ? (
@@ -90,25 +94,25 @@ export default function ScheduleToday() {
               if (item.type === "now") {
                 return (
                   <div key="now-divider" className="flex items-center gap-2 py-0.5">
-                    <span className="text-[10px] text-blue-400 font-[family-name:var(--font-mono)] shrink-0">now</span>
-                    <div className="flex-1 h-px bg-blue-500/30" />
+                    <span className="text-[10px] font-mono shrink-0" style={{ color: "var(--color-primary)" }}>now</span>
+                    <div className="flex-1 h-px" style={{ background: "var(--color-primary)", opacity: 0.3 }} />
                   </div>
                 );
               }
               const { event, isPast } = item;
               return (
                 <div key={idx} className={`flex gap-3 items-start transition-opacity ${isPast ? "opacity-40" : ""}`}>
-                  <span className="text-xs font-[family-name:var(--font-mono)] text-neutral-500 shrink-0 w-16 pt-px flex items-center">
+                  <span className="text-xs font-mono shrink-0 w-16 pt-px flex items-center" style={muted}>
                     {event.isBirthday
-                      ? <Gift size={12} className="text-rose-400" />
+                      ? <Gift size={12} style={accent} />
                       : event.time}
                   </span>
                   <div className="min-w-0">
-                    <p className={`text-sm leading-snug truncate ${isPast ? "text-neutral-400" : event.isBirthday ? "text-rose-300" : "text-neutral-200"}`}>
+                    <p className="text-sm leading-snug truncate" style={isPast ? muted : event.isBirthday ? accent : text}>
                       {event.title}
                     </p>
                     {(event.location || !event.isPrimary) && (
-                      <p className="text-xs text-neutral-600 truncate mt-0.5">
+                      <p className="text-xs truncate mt-0.5" style={faint}>
                         {event.location}
                         {!event.isPrimary && (
                           <span className={event.location ? " · " : ""}>{event.calendarName}</span>
@@ -122,15 +126,15 @@ export default function ScheduleToday() {
           ) : (
             events.map((event, i) => (
               <div key={i} className="flex gap-3 items-start">
-                <span className="text-xs font-[family-name:var(--font-mono)] text-neutral-500 shrink-0 w-16 pt-px flex items-center">
+                <span className="text-xs font-mono shrink-0 w-16 pt-px flex items-center" style={muted}>
                   {event.isBirthday
-                    ? <Gift size={12} className="text-rose-400" />
+                    ? <Gift size={12} style={accent} />
                     : event.time}
                 </span>
                 <div className="min-w-0">
-                  <p className={`text-sm leading-snug truncate ${event.isBirthday ? "text-rose-300" : "text-neutral-200"}`}>{event.title}</p>
+                  <p className="text-sm leading-snug truncate" style={event.isBirthday ? accent : text}>{event.title}</p>
                   {(event.location || !event.isPrimary) && (
-                    <p className="text-xs text-neutral-600 truncate mt-0.5">
+                    <p className="text-xs truncate mt-0.5" style={faint}>
                       {event.location}
                       {!event.isPrimary && (
                         <span className={event.location ? " · " : ""}>{event.calendarName}</span>
@@ -143,7 +147,7 @@ export default function ScheduleToday() {
           )}
         </div>
       ) : (
-        <p className="text-sm text-neutral-600">No events today</p>
+        <p className="text-sm" style={faint}>No events today</p>
       )}
     </div>
   );

--- a/web/src/components/dashboard/sports-card.tsx
+++ b/web/src/components/dashboard/sports-card.tsx
@@ -12,8 +12,8 @@ interface Props {
   refreshAction: () => Promise<void>;
 }
 
-const WIN_COLOR = "#22c55e";
-const LOSS_COLOR = "#ef4444";
+const WIN_COLOR = "var(--color-positive)";
+const LOSS_COLOR = "var(--color-danger)";
 
 function fmtDay(iso: string): string {
   const d = new Date(iso);

--- a/web/src/components/dashboard/sync-button.tsx
+++ b/web/src/components/dashboard/sync-button.tsx
@@ -90,7 +90,7 @@ export default function SyncButton() {
           <path d="M8 16H3v5" />
         </svg>
         {state === "error" ? (
-          <span className="text-red-500">Sync failed</span>
+          <span style={{ color: "var(--color-danger)" }}>Sync failed</span>
         ) : state === "syncing" ? (
           "Syncing…"
         ) : syncedAt ? (
@@ -101,7 +101,7 @@ export default function SyncButton() {
       </button>
 
       {state === "error" && errorSummary && (
-        <p className="text-xs text-right" style={{ color: "var(--color-negative, #ef4444)", maxWidth: 260 }}>
+        <p className="text-xs text-right" style={{ color: "var(--color-danger)", maxWidth: 260 }}>
           {errorSummary}
         </p>
       )}

--- a/web/src/components/dashboard/trends-card.tsx
+++ b/web/src/components/dashboard/trends-card.tsx
@@ -4,7 +4,6 @@ import { useState, useMemo } from "react";
 import Link from "next/link";
 import {
   ComposedChart,
-  BarChart,
   Bar,
   Line,
   XAxis,
@@ -15,6 +14,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import type { FitnessLog, RecoveryMetrics, WorkoutSession } from "@/lib/types";
+import { useChartColors } from "@/lib/chart-colors";
 
 interface Props {
   fitnessData: FitnessLog[];
@@ -36,8 +36,14 @@ interface TooltipProps {
 function CustomTooltip({ active, payload, label }: TooltipProps) {
   if (!active || !payload?.length) return null;
   return (
-    <div className="bg-neutral-900 border border-neutral-700 rounded-lg px-3 py-2 text-xs">
-      <p className="text-neutral-400 mb-1">{label}</p>
+    <div
+      className="rounded-lg px-3 py-2 text-xs"
+      style={{
+        background: "var(--color-surface-raised)",
+        border: "1px solid var(--color-border)",
+      }}
+    >
+      <p style={{ color: "var(--color-text-muted)", marginBottom: 4 }}>{label}</p>
       {payload.map((p) => (
         <p key={p.name} style={{ color: p.color }}>
           {p.name}: {p.value != null ? p.value : "—"}
@@ -46,18 +52,6 @@ function CustomTooltip({ active, payload, label }: TooltipProps) {
     </div>
   );
 }
-
-const axisProps = {
-  tick: { fill: "#737373", fontSize: 11 },
-  tickLine: false,
-  axisLine: false,
-} as const;
-
-const gridProps = {
-  strokeDasharray: "3 3",
-  stroke: "#262626",
-  vertical: false,
-} as const;
 
 const TAB_LABELS: Record<Tab, string> = {
   bodycomp: "Body Comp",
@@ -68,6 +62,19 @@ const TAB_LABELS: Record<Tab, string> = {
 export default function TrendsCard({ fitnessData, recoveryData, recentWorkout }: Props) {
   const [tab, setTab] = useState<Tab>("bodycomp");
   const [window, setWindow] = useState<Window>("30d");
+  const c = useChartColors();
+
+  const axisProps = {
+    tick: { fill: c.textMuted, fontSize: 11 },
+    tickLine: false,
+    axisLine: false,
+  } as const;
+  const gridProps = {
+    strokeDasharray: "3 3",
+    stroke: c.grid,
+    vertical: false,
+  } as const;
+  const legendWrapperStyle = { fontSize: "11px", color: c.textMuted, paddingTop: "8px" };
 
   const cutoff = useMemo(() => {
     const d = new Date();
@@ -120,8 +127,16 @@ export default function TrendsCard({ fitnessData, recoveryData, recentWorkout }:
       ? recoveryChartData.length === 0
       : activityChartData.length === 0;
 
+  const pillStyle = (active: boolean): React.CSSProperties => ({
+    background: active ? "var(--color-surface-raised)" : "transparent",
+    color: active ? "var(--color-text)" : "var(--color-text-muted)",
+  });
+
   return (
-    <div className="bg-neutral-900 rounded-xl border border-neutral-800 p-4 h-full">
+    <div
+      className="rounded-xl p-4 h-full"
+      style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+    >
       {/* Header row */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-4">
         <div className="flex gap-1">
@@ -129,11 +144,8 @@ export default function TrendsCard({ fitnessData, recoveryData, recentWorkout }:
             <button
               key={t}
               onClick={() => setTab(t)}
-              className={`text-xs px-3 py-1 rounded-full transition-colors ${
-                tab === t
-                  ? "bg-neutral-700 text-neutral-100"
-                  : "text-neutral-500 hover:text-neutral-300"
-              }`}
+              className="text-xs px-3 py-1 rounded-full transition-colors cursor-pointer"
+              style={pillStyle(tab === t)}
             >
               {TAB_LABELS[t]}
             </button>
@@ -144,11 +156,8 @@ export default function TrendsCard({ fitnessData, recoveryData, recentWorkout }:
             <button
               key={w}
               onClick={() => setWindow(w)}
-              className={`text-xs px-2.5 py-1 rounded-full transition-colors font-[family-name:var(--font-mono)] ${
-                window === w
-                  ? "bg-neutral-700 text-neutral-100"
-                  : "text-neutral-500 hover:text-neutral-300"
-              }`}
+              className="text-xs px-2.5 py-1 rounded-full transition-colors cursor-pointer"
+              style={pillStyle(window === w)}
             >
               {w}
             </button>
@@ -158,7 +167,7 @@ export default function TrendsCard({ fitnessData, recoveryData, recentWorkout }:
 
       {/* Chart */}
       {isEmpty ? (
-        <div className="h-48 flex items-center justify-center text-sm text-neutral-600">
+        <div className="h-48 flex items-center justify-center text-sm" style={{ color: "var(--color-text-faint)" }}>
           No data for this period
         </div>
       ) : tab === "bodycomp" ? (
@@ -169,33 +178,13 @@ export default function TrendsCard({ fitnessData, recoveryData, recentWorkout }:
             <YAxis yAxisId="weight" orientation="left" {...axisProps} domain={["auto", "auto"]} />
             <YAxis yAxisId="bf" orientation="right" {...axisProps} domain={["auto", "auto"]} />
             <Tooltip content={<CustomTooltip />} />
-            <Legend
-              iconType="circle"
-              iconSize={6}
-              wrapperStyle={{ fontSize: "11px", color: "#737373", paddingTop: "8px" }}
-            />
-            <Line
-              yAxisId="weight"
-              type="monotone"
-              dataKey="weight"
-              name="Weight (lb)"
-              stroke="#3b82f6"
-              strokeWidth={1.5}
-              dot={false}
-              activeDot={{ r: 3, strokeWidth: 0 }}
-              connectNulls
-            />
-            <Line
-              yAxisId="bf"
-              type="monotone"
-              dataKey="bodyFat"
-              name="Body fat %"
-              stroke="#f97316"
-              strokeWidth={1.5}
-              dot={false}
-              activeDot={{ r: 3, strokeWidth: 0 }}
-              connectNulls
-            />
+            <Legend iconType="circle" iconSize={6} wrapperStyle={legendWrapperStyle} />
+            <Line yAxisId="weight" type="monotone" dataKey="weight" name="Weight (lb)"
+              stroke={c.primary} strokeWidth={1.5} dot={false}
+              activeDot={{ r: 3, strokeWidth: 0 }} connectNulls />
+            <Line yAxisId="bf" type="monotone" dataKey="bodyFat" name="Body fat %"
+              stroke={c.warning} strokeWidth={1.5} dot={false}
+              activeDot={{ r: 3, strokeWidth: 0 }} connectNulls />
           </ComposedChart>
         </ResponsiveContainer>
       ) : tab === "recovery" ? (
@@ -206,110 +195,62 @@ export default function TrendsCard({ fitnessData, recoveryData, recentWorkout }:
             <YAxis yAxisId="hrv" orientation="left" {...axisProps} domain={["auto", "auto"]} />
             <YAxis yAxisId="readiness" orientation="right" {...axisProps} domain={[0, 100]} />
             <Tooltip content={<CustomTooltip />} />
-            <Legend
-              iconType="circle"
-              iconSize={6}
-              wrapperStyle={{ fontSize: "11px", color: "#737373", paddingTop: "8px" }}
-            />
-            <Line
-              yAxisId="hrv"
-              type="monotone"
-              dataKey="hrv"
-              name="HRV (ms)"
-              stroke="#3b82f6"
-              strokeWidth={1.5}
-              dot={false}
-              activeDot={{ r: 3, strokeWidth: 0 }}
-              connectNulls
-              animationDuration={300}
-            />
-            <Line
-              yAxisId="readiness"
-              type="monotone"
-              dataKey="readiness"
-              name="Readiness"
-              stroke="#a3e635"
-              strokeWidth={1.5}
-              dot={false}
-              activeDot={{ r: 3, strokeWidth: 0 }}
-              connectNulls
-              animationDuration={300}
-            />
-            <Line
-              yAxisId="readiness"
-              type="monotone"
-              dataKey="spo2"
-              name="SpO2 %"
-              stroke="#06b6d4"
-              strokeWidth={1}
-              dot={false}
-              activeDot={{ r: 3, strokeWidth: 0 }}
-              connectNulls
-              animationDuration={300}
-              strokeDasharray="4 2"
-            />
+            <Legend iconType="circle" iconSize={6} wrapperStyle={legendWrapperStyle} />
+            <Line yAxisId="hrv" type="monotone" dataKey="hrv" name="HRV (ms)"
+              stroke={c.primary} strokeWidth={1.5} dot={false}
+              activeDot={{ r: 3, strokeWidth: 0 }} connectNulls animationDuration={300} />
+            <Line yAxisId="readiness" type="monotone" dataKey="readiness" name="Readiness"
+              stroke={c.positive} strokeWidth={1.5} dot={false}
+              activeDot={{ r: 3, strokeWidth: 0 }} connectNulls animationDuration={300} />
+            <Line yAxisId="readiness" type="monotone" dataKey="spo2" name="SpO2 %"
+              stroke={c.info} strokeWidth={1} dot={false}
+              activeDot={{ r: 3, strokeWidth: 0 }} connectNulls animationDuration={300}
+              strokeDasharray="4 2" />
           </ComposedChart>
         </ResponsiveContainer>
       ) : (
-        /* Activity tab: steps bars + active cal line */
         <ResponsiveContainer width="100%" height={200}>
           <ComposedChart data={activityChartData} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
             <CartesianGrid {...gridProps} />
             <XAxis dataKey="date" {...axisProps} interval="preserveStartEnd" />
-            <YAxis yAxisId="steps" orientation="left" {...axisProps} domain={[0, "auto"]} tickFormatter={(v) => v >= 1000 ? `${(v/1000).toFixed(0)}k` : v} />
+            <YAxis yAxisId="steps" orientation="left" {...axisProps} domain={[0, "auto"]}
+              tickFormatter={(v) => v >= 1000 ? `${(v/1000).toFixed(0)}k` : v} />
             <YAxis yAxisId="cal" orientation="right" {...axisProps} domain={[0, "auto"]} />
             <Tooltip content={<CustomTooltip />} />
-            <Legend
-              iconType="circle"
-              iconSize={6}
-              wrapperStyle={{ fontSize: "11px", color: "#737373", paddingTop: "8px" }}
-            />
-            <Bar
-              yAxisId="steps"
-              dataKey="steps"
-              name="Steps"
-              fill="#6366f1"
-              opacity={0.7}
-              radius={[2, 2, 0, 0]}
-              isAnimationActive
-              animationDuration={300}
-            />
-            <Line
-              yAxisId="cal"
-              type="monotone"
-              dataKey="activeCal"
-              name="Active Cal"
-              stroke="#f97316"
-              strokeWidth={1.5}
-              dot={false}
-              activeDot={{ r: 3, strokeWidth: 0 }}
-              connectNulls
-              animationDuration={300}
-            />
+            <Legend iconType="circle" iconSize={6} wrapperStyle={legendWrapperStyle} />
+            <Bar yAxisId="steps" dataKey="steps" name="Steps" fill={c.primary} opacity={0.7}
+              radius={[2, 2, 0, 0]} isAnimationActive animationDuration={300} />
+            <Line yAxisId="cal" type="monotone" dataKey="activeCal" name="Active Cal"
+              stroke={c.warning} strokeWidth={1.5} dot={false}
+              activeDot={{ r: 3, strokeWidth: 0 }} connectNulls animationDuration={300} />
           </ComposedChart>
         </ResponsiveContainer>
       )}
 
       {/* Recent workout row */}
       {recentWorkout && (
-        <div className="mt-3 pt-3 border-t border-neutral-800 flex items-center justify-between">
+        <div
+          className="mt-3 pt-3 flex items-center justify-between"
+          style={{ borderTop: "1px solid var(--color-border)" }}
+        >
           <div>
-            <p className="text-xs text-neutral-500 mb-0.5">Last workout</p>
-            <p className="text-sm text-neutral-300 font-medium capitalize">{recentWorkout.activity}</p>
+            <p className="text-xs mb-0.5" style={{ color: "var(--color-text-muted)" }}>Last workout</p>
+            <p className="text-sm font-medium capitalize" style={{ color: "var(--color-text)" }}>{recentWorkout.activity}</p>
           </div>
           <div className="text-right">
-            <p className="text-xs font-[family-name:var(--font-mono)] text-neutral-400">
+            <p className="text-xs tabular-nums" style={{ color: "var(--color-text-muted)" }}>
               {recentWorkout.duration_mins != null && <span>{recentWorkout.duration_mins}m</span>}
               {recentWorkout.calories != null && (
                 <span>{recentWorkout.duration_mins != null ? " · " : ""}{recentWorkout.calories} cal</span>
               )}
               {recentWorkout.avg_hr != null && <span> · {recentWorkout.avg_hr} bpm</span>}
             </p>
-            <p className="text-xs text-neutral-600 mt-0.5">{recentWorkout.date}</p>
+            <p className="text-xs mt-0.5" style={{ color: "var(--color-text-faint)" }}>{recentWorkout.date}</p>
           </div>
           <Link
             href="/fitness"
-            className="ml-4 text-xs text-neutral-500 hover:text-neutral-300 transition-colors"
+            className="ml-4 text-xs transition-colors"
+            style={{ color: "var(--color-text-muted)" }}
             onClick={(e) => e.stopPropagation()}
           >
             View all →

--- a/web/src/components/dashboard/upcoming-birthday.tsx
+++ b/web/src/components/dashboard/upcoming-birthday.tsx
@@ -5,7 +5,6 @@ import { Gift } from "lucide-react";
 import type { UpcomingBirthday } from "@/app/api/google/calendar/upcoming-birthday/route";
 
 function formatDisplayDate(dateStr: string): string {
-  // dateStr is YYYY-MM-DD; append T12:00 to avoid UTC-shift on date-only strings
   const d = new Date(`${dateStr}T12:00:00`);
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
@@ -29,19 +28,27 @@ export default function UpcomingBirthdayWidget() {
     ? "Today!"
     : `in ${birthday.daysUntil} day${birthday.daysUntil === 1 ? "" : "s"} (${formatDisplayDate(birthday.date)})`;
 
+  const containerStyle: React.CSSProperties = isToday
+    ? {
+        background: "color-mix(in srgb, var(--color-cta) 15%, transparent)",
+        border: "1px solid color-mix(in srgb, var(--color-cta) 40%, transparent)",
+        color: "var(--color-cta)",
+      }
+    : {
+        background: "var(--color-surface)",
+        border: "1px solid var(--color-border)",
+        color: "var(--color-text-muted)",
+      };
+
   return (
-    <div className={`flex items-center gap-2 px-3 py-2 rounded-lg border text-sm ${
-      isToday
-        ? "bg-rose-950/40 border-rose-800/50 text-rose-300"
-        : "bg-neutral-900 border-neutral-800 text-neutral-400"
-    }`}>
-      <Gift size={13} className={isToday ? "text-rose-400 shrink-0" : "text-rose-500/70 shrink-0"} />
+    <div className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm" style={containerStyle}>
+      <Gift size={13} style={{ color: "var(--color-cta)", flexShrink: 0 }} />
       <span>
-        <span className={isToday ? "text-rose-300 font-medium" : "text-neutral-200"}>
+        <span style={{ color: isToday ? "var(--color-cta)" : "var(--color-text)", fontWeight: isToday ? 500 : 400 }}>
           {birthday.name}&apos;s birthday
         </span>
         {" — "}
-        <span className={isToday ? "text-rose-400 font-semibold" : "text-neutral-500"}>
+        <span style={{ color: isToday ? "var(--color-cta)" : "var(--color-text-muted)", fontWeight: isToday ? 600 : 400 }}>
           {label}
         </span>
       </span>

--- a/web/src/components/dashboard/watchlist-widget.tsx
+++ b/web/src/components/dashboard/watchlist-widget.tsx
@@ -49,7 +49,7 @@ function formatChange(changeAbs: number | null, changePct: number | null): strin
 
 function TickerRow({ row }: { row: StocksCache }) {
   const isPositive = (row.change_abs ?? 0) >= 0;
-  const changeColor = isPositive ? "#22c55e" : "#ef4444";
+  const changeColor = isPositive ? "var(--color-positive)" : "var(--color-danger)";
 
   const sparkData = (row.sparkline ?? []).map((p) => ({ close: p.close }));
 

--- a/web/src/components/dashboard/weight-trend-chart.tsx
+++ b/web/src/components/dashboard/weight-trend-chart.tsx
@@ -10,6 +10,7 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from "recharts";
+import { useChartColors } from "@/lib/chart-colors";
 
 interface DataPoint {
   date: string;
@@ -36,13 +37,13 @@ function DeltaBadge({ delta, positiveIsDown }: { delta: number; positiveIsDown?:
   );
 }
 
-const TOOLTIP_STYLE = {
-  contentStyle: { background: "#181B24", border: "1px solid #2A2F45", borderRadius: 8 },
-  labelStyle: { color: "#E2E8F0", fontSize: 13 },
-  itemStyle: { color: "#64748B", fontSize: 12 },
-};
-
 export function WeightTrendChart({ data, windowLabel = "30D", weightLb, bfPct, weightDelta, bfDelta }: Props) {
+  const c = useChartColors();
+  const tooltipStyle = {
+    contentStyle: { background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 8 },
+    labelStyle: { color: c.text, fontSize: 13 },
+    itemStyle: { color: c.textMuted, fontSize: 12 },
+  };
   const [animate, setAnimate] = useState(true);
 
   useEffect(() => {
@@ -107,30 +108,30 @@ export function WeightTrendChart({ data, windowLabel = "30D", weightLb, bfPct, w
       </div>
       <ResponsiveContainer width="100%" height={180}>
         <LineChart data={chartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#1E2130" vertical={false} />
+          <CartesianGrid strokeDasharray="3 3" stroke={c.grid} vertical={false} />
           <XAxis
             dataKey="date"
-            stroke="#334155"
-            tick={{ fill: "#64748B", fontSize: 11 }}
+            stroke={c.axis}
+            tick={{ fill: c.textMuted, fontSize: 11 }}
             tickLine={false}
             axisLine={false}
             interval="preserveStartEnd"
           />
           <YAxis
-            stroke="#334155"
-            tick={{ fill: "#64748B", fontSize: 11 }}
+            stroke={c.axis}
+            tick={{ fill: c.textMuted, fontSize: 11 }}
             tickLine={false}
             axisLine={false}
             domain={["auto", "auto"]}
           />
-          <Tooltip {...TOOLTIP_STYLE} formatter={(v: number) => [`${v} lb`, "Weight"]} />
+          <Tooltip {...tooltipStyle} formatter={(v: number) => [`${v} lb`, "Weight"]} />
           <Line
             type="monotone"
             dataKey="weight"
-            stroke="#6366F1"
+            stroke={c.primary}
             strokeWidth={2}
             dot={false}
-            activeDot={{ r: 4, fill: "#6366F1", strokeWidth: 0 }}
+            activeDot={{ r: 4, fill: c.primary, strokeWidth: 0 }}
             connectNulls
             isAnimationActive={animate}
             animationDuration={300}

--- a/web/src/components/fitness/active-cal-chart.tsx
+++ b/web/src/components/fitness/active-cal-chart.tsx
@@ -10,6 +10,7 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from "recharts";
+import { useChartColors } from "@/lib/chart-colors";
 
 interface DataPoint {
   date: string;
@@ -21,14 +22,15 @@ interface Props {
   windowLabel?: string;
 }
 
-const TOOLTIP_STYLE = {
-  contentStyle: { background: "#181B24", border: "1px solid #2A2F45", borderRadius: 8 },
-  labelStyle: { color: "#E2E8F0", fontSize: 13 },
-  itemStyle: { color: "#64748B", fontSize: 12 },
-};
-
 export function ActiveCalChart({ data, windowLabel = "30D" }: Props) {
   const [animate, setAnimate] = useState(true);
+  const c = useChartColors();
+
+  const tooltipStyle = {
+    contentStyle: { background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 8 },
+    labelStyle: { color: c.text, fontSize: 13 },
+    itemStyle: { color: c.textMuted, fontSize: 12 },
+  };
 
   useEffect(() => {
     const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
@@ -59,35 +61,35 @@ export function ActiveCalChart({ data, windowLabel = "30D" }: Props) {
           <AreaChart data={chartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
             <defs>
               <linearGradient id="cal-grad" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stopColor="#F59E0B" stopOpacity={0.3} />
-                <stop offset="100%" stopColor="#F59E0B" stopOpacity={0} />
+                <stop offset="0%" stopColor={c.warning} stopOpacity={0.3} />
+                <stop offset="100%" stopColor={c.warning} stopOpacity={0} />
               </linearGradient>
             </defs>
-            <CartesianGrid strokeDasharray="3 3" stroke="#1E2130" vertical={false} />
+            <CartesianGrid strokeDasharray="3 3" stroke={c.grid} vertical={false} />
             <XAxis
               dataKey="date"
-              stroke="#334155"
-              tick={{ fill: "#64748B", fontSize: 11 }}
+              stroke={c.axis}
+              tick={{ fill: c.textMuted, fontSize: 11 }}
               tickLine={false}
               axisLine={false}
               interval="preserveStartEnd"
             />
             <YAxis
-              stroke="#334155"
-              tick={{ fill: "#64748B", fontSize: 11 }}
+              stroke={c.axis}
+              tick={{ fill: c.textMuted, fontSize: 11 }}
               tickLine={false}
               axisLine={false}
               domain={[0, "auto"]}
             />
-            <Tooltip {...TOOLTIP_STYLE} formatter={(v: number) => [`${v} kcal`, "Active Cal"]} />
+            <Tooltip {...tooltipStyle} formatter={(v: number) => [`${v} kcal`, "Active Cal"]} />
             <Area
               type="monotone"
               dataKey="cal"
-              stroke="#F59E0B"
+              stroke={c.warning}
               strokeWidth={2}
               fill="url(#cal-grad)"
               dot={false}
-              activeDot={{ r: 4, fill: "#F59E0B", strokeWidth: 0 }}
+              activeDot={{ r: 4, fill: c.warning, strokeWidth: 0 }}
               connectNulls
               isAnimationActive={animate}
               animationDuration={300}

--- a/web/src/components/fitness/active-cal-goal-chart.tsx
+++ b/web/src/components/fitness/active-cal-goal-chart.tsx
@@ -9,6 +9,7 @@ import {
 import Link from "next/link";
 import { GranularityToggle } from "@/components/ui/granularity-toggle";
 import { formatDate, computeDailyTicks, computeWeeklyTicks, daysToWindowKey } from "@/lib/chart-utils";
+import { useChartColors } from "@/lib/chart-colors";
 
 interface DataPoint {
   date: string;
@@ -20,12 +21,6 @@ interface Props {
   goal?: number | null;
   days: number;
 }
-
-const TOOLTIP_STYLE = {
-  contentStyle: { background: "#181B24", border: "1px solid #2A2F45", borderRadius: 8 },
-  labelStyle: { color: "#E2E8F0", fontSize: 13 },
-  itemStyle: { color: "#64748B", fontSize: 12 },
-};
 
 function getISOWeekLabel(dateStr: string): string {
   const d = new Date(dateStr + "T00:00:00");
@@ -51,6 +46,12 @@ function dayOfWeek(dateStr: string): number {
 
 export function ActiveCalGoalChart({ data, goal, days }: Props) {
   const [animate, setAnimate] = useState(true);
+  const c = useChartColors();
+  const TOOLTIP_STYLE = {
+    contentStyle: { background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 8 },
+    labelStyle: { color: c.text, fontSize: 13 },
+    itemStyle: { color: c.textMuted, fontSize: 12 },
+  };
   const weekCount = Math.ceil(days / 7);
   const forceWeekly = days > 90;
   const [granularity, setGranularity] = useState<"daily" | "weekly">(
@@ -156,22 +157,22 @@ export function ActiveCalGoalChart({ data, goal, days }: Props) {
         <AreaChart data={chartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
           <defs>
             <linearGradient id="acal-goal-grad" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%"   stopColor="#F59E0B" stopOpacity={0.3} />
-              <stop offset="100%" stopColor="#F59E0B" stopOpacity={0} />
+              <stop offset="0%"   stopColor={c.warning} stopOpacity={0.3} />
+              <stop offset="100%" stopColor={c.warning} stopOpacity={0} />
             </linearGradient>
           </defs>
-          <CartesianGrid strokeDasharray="3 3" stroke="#1E2130" vertical={false} />
+          <CartesianGrid strokeDasharray="3 3" stroke={c.grid} vertical={false} />
           <XAxis
             dataKey="label"
-            stroke="#334155"
-            tick={{ fill: "#64748B", fontSize: 10 }}
+            stroke={c.axis}
+            tick={{ fill: c.textMuted, fontSize: 10 }}
             tickLine={false}
             axisLine={false}
             ticks={ticks}
           />
           <YAxis
-            stroke="#334155"
-            tick={{ fill: "#64748B", fontSize: 11 }}
+            stroke={c.axis}
+            tick={{ fill: c.textMuted, fontSize: 11 }}
             tickLine={false}
             axisLine={false}
             domain={[0, "auto"]}
@@ -187,7 +188,7 @@ export function ActiveCalGoalChart({ data, goal, days }: Props) {
           {hasGoal && granularity === "weekly" && (
             <ReferenceLine
               y={goal}
-              stroke="#64748B"
+              stroke={c.textMuted}
               strokeDasharray="4 3"
               strokeWidth={1.5}
             />
@@ -195,20 +196,20 @@ export function ActiveCalGoalChart({ data, goal, days }: Props) {
           {hasGoal && granularity === "daily" && dailyGoal != null && (
             <ReferenceLine
               y={dailyGoal}
-              stroke="#64748B"
+              stroke={c.textMuted}
               strokeDasharray="4 3"
               strokeWidth={1.5}
-              label={{ value: "Daily target", fill: "#64748B", fontSize: 10, position: "insideTopRight" }}
+              label={{ value: "Daily target", fill: c.textMuted, fontSize: 10, position: "insideTopRight" }}
             />
           )}
           <Area
             type="monotone"
             dataKey="total"
-            stroke="#F59E0B"
+            stroke={c.warning}
             strokeWidth={2}
             fill="url(#acal-goal-grad)"
             dot={false}
-            activeDot={{ r: 4, fill: "#F59E0B", strokeWidth: 0 }}
+            activeDot={{ r: 4, fill: c.warning, strokeWidth: 0 }}
             isAnimationActive={animate}
             animationDuration={300}
             connectNulls={false}

--- a/web/src/components/fitness/body-comp-chart.tsx
+++ b/web/src/components/fitness/body-comp-chart.tsx
@@ -11,6 +11,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import type { FitnessLog } from "@/lib/types";
+import { useChartColors } from "@/lib/chart-colors";
 
 interface Props {
   data: FitnessLog[];
@@ -25,8 +26,14 @@ interface TooltipProps {
 function CustomTooltip({ active, payload, label }: TooltipProps) {
   if (!active || !payload?.length) return null;
   return (
-    <div className="bg-neutral-900 border border-neutral-700 rounded-lg px-3 py-2 text-xs">
-      <p className="text-neutral-400 mb-1">{label}</p>
+    <div
+      className="rounded-lg px-3 py-2 text-xs"
+      style={{
+        background: "var(--color-surface-raised)",
+        border: "1px solid var(--color-border)",
+      }}
+    >
+      <p style={{ color: "var(--color-text-muted)", marginBottom: 4 }}>{label}</p>
       {payload.map((p) => (
         <p key={p.name} style={{ color: p.color }}>
           {p.name}: {p.value}
@@ -37,15 +44,16 @@ function CustomTooltip({ active, payload, label }: TooltipProps) {
 }
 
 export default function BodyCompChart({ data }: Props) {
+  const c = useChartColors();
   const chartData = data.map((d) => ({
-    date: d.date.slice(5), // MM-DD
+    date: d.date.slice(5),
     weight: d.weight_lb,
     bodyFat: d.body_fat_pct,
   }));
 
   if (chartData.length === 0) {
     return (
-      <div className="h-48 flex items-center justify-center text-sm text-neutral-600">
+      <div className="h-48 flex items-center justify-center text-sm" style={{ color: "var(--color-text-faint)" }}>
         No fitness data yet
       </div>
     );
@@ -56,7 +64,7 @@ export default function BodyCompChart({ data }: Props) {
       <ComposedChart data={chartData} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
         <XAxis
           dataKey="date"
-          tick={{ fill: "#737373", fontSize: 11 }}
+          tick={{ fill: c.textMuted, fontSize: 11 }}
           tickLine={false}
           axisLine={false}
           interval="preserveStartEnd"
@@ -64,7 +72,7 @@ export default function BodyCompChart({ data }: Props) {
         <YAxis
           yAxisId="weight"
           orientation="left"
-          tick={{ fill: "#737373", fontSize: 11 }}
+          tick={{ fill: c.textMuted, fontSize: 11 }}
           tickLine={false}
           axisLine={false}
           domain={["auto", "auto"]}
@@ -72,24 +80,24 @@ export default function BodyCompChart({ data }: Props) {
         <YAxis
           yAxisId="bf"
           orientation="right"
-          tick={{ fill: "#737373", fontSize: 11 }}
+          tick={{ fill: c.textMuted, fontSize: 11 }}
           tickLine={false}
           axisLine={false}
           domain={["auto", "auto"]}
         />
-        <CartesianGrid strokeDasharray="3 3" stroke="#262626" vertical={false} />
+        <CartesianGrid strokeDasharray="3 3" stroke={c.grid} vertical={false} />
         <Tooltip content={<CustomTooltip />} />
         <Legend
           iconType="circle"
           iconSize={6}
-          wrapperStyle={{ fontSize: "11px", color: "#737373", paddingTop: "8px" }}
+          wrapperStyle={{ fontSize: "11px", color: c.textMuted, paddingTop: "8px" }}
         />
         <Line
           yAxisId="weight"
           type="monotone"
           dataKey="weight"
           name="Weight (lb)"
-          stroke="#3b82f6"
+          stroke={c.primary}
           strokeWidth={1.5}
           dot={false}
           connectNulls
@@ -99,7 +107,7 @@ export default function BodyCompChart({ data }: Props) {
           type="monotone"
           dataKey="bodyFat"
           name="Body fat %"
-          stroke="#f97316"
+          stroke={c.warning}
           strokeWidth={1.5}
           dot={false}
           connectNulls

--- a/web/src/components/fitness/body-comp-dual-chart.tsx
+++ b/web/src/components/fitness/body-comp-dual-chart.tsx
@@ -14,6 +14,7 @@ import {
 import type { FitnessLog } from "@/lib/types";
 import type { WindowKey } from "@/lib/window";
 import { formatDate, computeDailyTicks } from "@/lib/chart-utils";
+import { useChartColors } from "@/lib/chart-colors";
 
 interface Props {
   data: FitnessLog[];
@@ -21,14 +22,14 @@ interface Props {
   windowKey: WindowKey;
 }
 
-const TOOLTIP_STYLE = {
-  contentStyle: { background: "#181B24", border: "1px solid #2A2F45", borderRadius: 8 },
-  labelStyle: { color: "#E2E8F0", fontSize: 13 },
-  itemStyle: { color: "#64748B", fontSize: 12 },
-};
-
 export function BodyCompDualChart({ data, windowLabel = "90D", windowKey }: Props) {
   const [animate, setAnimate] = useState(true);
+  const c = useChartColors();
+  const TOOLTIP_STYLE = {
+    contentStyle: { background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 8 },
+    labelStyle: { color: c.text, fontSize: 13 },
+    itemStyle: { color: c.textMuted, fontSize: 12 },
+  };
 
   useEffect(() => {
     const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
@@ -68,11 +69,11 @@ export function BodyCompDualChart({ data, windowLabel = "90D", windowKey }: Prop
       </p>
       <ResponsiveContainer width="100%" height={240}>
         <ComposedChart data={chartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#1E2130" vertical={false} />
+          <CartesianGrid strokeDasharray="3 3" stroke={c.grid} vertical={false} />
           <XAxis
             dataKey="date"
-            stroke="#334155"
-            tick={{ fill: "#64748B", fontSize: 11 }}
+            stroke={c.axis}
+            tick={{ fill: c.textMuted, fontSize: 11 }}
             tickLine={false}
             axisLine={false}
             ticks={ticks}
@@ -80,8 +81,8 @@ export function BodyCompDualChart({ data, windowLabel = "90D", windowKey }: Prop
           <YAxis
             yAxisId="weight"
             orientation="left"
-            stroke="#334155"
-            tick={{ fill: "#64748B", fontSize: 11 }}
+            stroke={c.axis}
+            tick={{ fill: c.textMuted, fontSize: 11 }}
             tickLine={false}
             axisLine={false}
             domain={["auto", "auto"]}
@@ -89,8 +90,8 @@ export function BodyCompDualChart({ data, windowLabel = "90D", windowKey }: Prop
           <YAxis
             yAxisId="bf"
             orientation="right"
-            stroke="#334155"
-            tick={{ fill: "#64748B", fontSize: 11 }}
+            stroke={c.axis}
+            tick={{ fill: c.textMuted, fontSize: 11 }}
             tickLine={false}
             axisLine={false}
             domain={["auto", "auto"]}
@@ -105,17 +106,17 @@ export function BodyCompDualChart({ data, windowLabel = "90D", windowKey }: Prop
           <Legend
             iconType="circle"
             iconSize={7}
-            wrapperStyle={{ fontSize: 12, color: "#64748B", paddingTop: 8 }}
+            wrapperStyle={{ fontSize: 12, color: c.textMuted, paddingTop: 8 }}
           />
           <Line
             yAxisId="weight"
             type="monotone"
             dataKey="weight"
             name="Weight (lb)"
-            stroke="#6366F1"
+            stroke={c.primary}
             strokeWidth={2}
             dot={false}
-            activeDot={{ r: 4, fill: "#6366F1", strokeWidth: 0 }}
+            activeDot={{ r: 4, fill: c.primary, strokeWidth: 0 }}
             connectNulls
             isAnimationActive={animate}
             animationDuration={300}
@@ -125,10 +126,10 @@ export function BodyCompDualChart({ data, windowLabel = "90D", windowKey }: Prop
             type="monotone"
             dataKey="bodyFat"
             name="Body Fat %"
-            stroke="#10B981"
+            stroke={c.positive}
             strokeWidth={2}
             dot={false}
-            activeDot={{ r: 4, fill: "#10B981", strokeWidth: 0 }}
+            activeDot={{ r: 4, fill: c.positive, strokeWidth: 0 }}
             connectNulls
             isAnimationActive={animate}
             animationDuration={300}

--- a/web/src/components/fitness/body-fat-goal-chart.tsx
+++ b/web/src/components/fitness/body-fat-goal-chart.tsx
@@ -10,6 +10,7 @@ import type { FitnessLog } from "@/lib/types";
 import type { WindowKey } from "@/lib/window";
 import { formatDate, computeDailyTicks } from "@/lib/chart-utils";
 import Link from "next/link";
+import { useChartColors } from "@/lib/chart-colors";
 
 interface Props {
   data: FitnessLog[];
@@ -18,14 +19,14 @@ interface Props {
   windowKey: WindowKey;
 }
 
-const TOOLTIP_STYLE = {
-  contentStyle: { background: "#181B24", border: "1px solid #2A2F45", borderRadius: 8 },
-  labelStyle: { color: "#E2E8F0", fontSize: 13 },
-  itemStyle: { color: "#64748B", fontSize: 12 },
-};
-
 export function BodyFatGoalChart({ data, goal, windowLabel = "90D", windowKey }: Props) {
   const [animate, setAnimate] = useState(true);
+  const c = useChartColors();
+  const TOOLTIP_STYLE = {
+    contentStyle: { background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 8 },
+    labelStyle: { color: c.text, fontSize: 13 },
+    itemStyle: { color: c.textMuted, fontSize: 12 },
+  };
 
   useEffect(() => {
     const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
@@ -86,18 +87,18 @@ export function BodyFatGoalChart({ data, goal, windowLabel = "90D", windowKey }:
       ) : (
         <ResponsiveContainer width="100%" height={200}>
           <LineChart data={chartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#1E2130" vertical={false} />
+            <CartesianGrid strokeDasharray="3 3" stroke={c.grid} vertical={false} />
             <XAxis
               dataKey="date"
-              stroke="#334155"
-              tick={{ fill: "#64748B", fontSize: 11 }}
+              stroke={c.axis}
+              tick={{ fill: c.textMuted, fontSize: 11 }}
               tickLine={false}
               axisLine={false}
               ticks={ticks}
             />
             <YAxis
-              stroke="#334155"
-              tick={{ fill: "#64748B", fontSize: 11 }}
+              stroke={c.axis}
+              tick={{ fill: c.textMuted, fontSize: 11 }}
               tickLine={false}
               axisLine={false}
               domain={["auto", "auto"]}
@@ -110,19 +111,19 @@ export function BodyFatGoalChart({ data, goal, windowLabel = "90D", windowKey }:
             {hasGoal && (
               <ReferenceLine
                 y={goal}
-                stroke="#64748B"
+                stroke={c.textMuted}
                 strokeDasharray="4 3"
                 strokeWidth={1.5}
-                label={{ value: `Goal ${goal}%`, fill: "#64748B", fontSize: 10, position: "insideTopRight" }}
+                label={{ value: `Goal ${goal}%`, fill: c.textMuted, fontSize: 10, position: "insideTopRight" }}
               />
             )}
             <Line
               type="monotone"
               dataKey="bf"
-              stroke="#10B981"
+              stroke={c.positive}
               strokeWidth={2}
               dot={false}
-              activeDot={{ r: 4, fill: "#10B981", strokeWidth: 0 }}
+              activeDot={{ r: 4, fill: c.positive, strokeWidth: 0 }}
               connectNulls
               isAnimationActive={animate}
               animationDuration={300}

--- a/web/src/components/fitness/weekly-workout-plan.tsx
+++ b/web/src/components/fitness/weekly-workout-plan.tsx
@@ -153,7 +153,7 @@ export function WeeklyWorkoutPlan({ plans, completedDates }: Props) {
                 {day.isToday && (
                   <span
                     className="text-xs uppercase font-semibold tracking-wide px-2 py-0.5 rounded-full"
-                    style={{ fontSize: 10, background: "var(--color-accent, #6366f1)", color: "#fff" }}
+                    style={{ fontSize: 10, background: "var(--color-primary)", color: "#fff" }}
                   >
                     Today
                   </span>
@@ -197,7 +197,7 @@ export function WeeklyWorkoutPlan({ plans, completedDates }: Props) {
                 {day.isToday && (
                   <span
                     className="text-xs uppercase font-semibold tracking-wide px-2 py-0.5 rounded-full"
-                    style={{ fontSize: 10, background: "var(--color-accent, #6366f1)", color: "#fff", flexShrink: 0 }}
+                    style={{ fontSize: 10, background: "var(--color-primary)", color: "#fff", flexShrink: 0 }}
                   >
                     Today
                   </span>
@@ -219,7 +219,7 @@ export function WeeklyWorkoutPlan({ plans, completedDates }: Props) {
                 )}
                 {!day.plan.name && <span style={{ flex: 1 }} />}
                 {day.isCompleted && (
-                  <span style={{ color: "#34d399", fontSize: 14, marginLeft: 4, flexShrink: 0 }}>✓</span>
+                  <span style={{ color: "var(--color-positive)", fontSize: 14, marginLeft: 4, flexShrink: 0 }}>✓</span>
                 )}
                 <span style={{ color: "var(--color-text-faint, var(--color-text-muted))", flexShrink: 0 }}>
                   {isOpen ? <ChevronUp size={14} /> : <ChevronDown size={14} />}

--- a/web/src/components/fitness/weight-goal-chart.tsx
+++ b/web/src/components/fitness/weight-goal-chart.tsx
@@ -10,6 +10,7 @@ import type { FitnessLog } from "@/lib/types";
 import type { WindowKey } from "@/lib/window";
 import { formatDate, computeDailyTicks } from "@/lib/chart-utils";
 import Link from "next/link";
+import { useChartColors } from "@/lib/chart-colors";
 
 interface Props {
   data: FitnessLog[];
@@ -18,14 +19,14 @@ interface Props {
   windowKey: WindowKey;
 }
 
-const TOOLTIP_STYLE = {
-  contentStyle: { background: "#181B24", border: "1px solid #2A2F45", borderRadius: 8 },
-  labelStyle: { color: "#E2E8F0", fontSize: 13 },
-  itemStyle: { color: "#64748B", fontSize: 12 },
-};
-
 export function WeightGoalChart({ data, goal, windowLabel = "90D", windowKey }: Props) {
   const [animate, setAnimate] = useState(true);
+  const c = useChartColors();
+  const TOOLTIP_STYLE = {
+    contentStyle: { background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 8 },
+    labelStyle: { color: c.text, fontSize: 13 },
+    itemStyle: { color: c.textMuted, fontSize: 12 },
+  };
 
   useEffect(() => {
     const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
@@ -86,18 +87,18 @@ export function WeightGoalChart({ data, goal, windowLabel = "90D", windowKey }: 
       ) : (
         <ResponsiveContainer width="100%" height={200}>
           <LineChart data={chartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#1E2130" vertical={false} />
+            <CartesianGrid strokeDasharray="3 3" stroke={c.grid} vertical={false} />
             <XAxis
               dataKey="date"
-              stroke="#334155"
-              tick={{ fill: "#64748B", fontSize: 11 }}
+              stroke={c.axis}
+              tick={{ fill: c.textMuted, fontSize: 11 }}
               tickLine={false}
               axisLine={false}
               ticks={ticks}
             />
             <YAxis
-              stroke="#334155"
-              tick={{ fill: "#64748B", fontSize: 11 }}
+              stroke={c.axis}
+              tick={{ fill: c.textMuted, fontSize: 11 }}
               tickLine={false}
               axisLine={false}
               domain={["auto", "auto"]}
@@ -109,19 +110,19 @@ export function WeightGoalChart({ data, goal, windowLabel = "90D", windowKey }: 
             {hasGoal && (
               <ReferenceLine
                 y={goal}
-                stroke="#64748B"
+                stroke={c.textMuted}
                 strokeDasharray="4 3"
                 strokeWidth={1.5}
-                label={{ value: `Goal ${goal} lb`, fill: "#64748B", fontSize: 10, position: "insideTopRight" }}
+                label={{ value: `Goal ${goal} lb`, fill: c.textMuted, fontSize: 10, position: "insideTopRight" }}
               />
             )}
             <Line
               type="monotone"
               dataKey="weight"
-              stroke="#6366F1"
+              stroke={c.primary}
               strokeWidth={2}
               dot={false}
-              activeDot={{ r: 4, fill: "#6366F1", strokeWidth: 0 }}
+              activeDot={{ r: 4, fill: c.primary, strokeWidth: 0 }}
               connectNulls
               isAnimationActive={animate}
               animationDuration={300}

--- a/web/src/components/fitness/workout-freq-chart.tsx
+++ b/web/src/components/fitness/workout-freq-chart.tsx
@@ -10,18 +10,13 @@ import type { WorkoutSession } from "@/lib/types";
 import Link from "next/link";
 import { GranularityToggle } from "@/components/ui/granularity-toggle";
 import { formatDate, computeDailyTicks, computeWeeklyTicks, daysToWindowKey } from "@/lib/chart-utils";
+import { useChartColors, type ChartColors } from "@/lib/chart-colors";
 
 interface Props {
   sessions: WorkoutSession[];
   days: number;
   goal?: number | null;
 }
-
-const TOOLTIP_STYLE = {
-  contentStyle: { background: "#181B24", border: "1px solid #2A2F45", borderRadius: 8 },
-  labelStyle: { color: "#E2E8F0", fontSize: 13 },
-  itemStyle: { color: "#64748B", fontSize: 12 },
-};
 
 function getISOWeekLabel(dateStr: string): string {
   const d = new Date(dateStr + "T00:00:00");
@@ -41,10 +36,10 @@ function getISOWeekKey(dateStr: string): string {
   return monday.toISOString().slice(0, 10);
 }
 
-function barColor(count: number, goal: number): string {
-  if (count >= goal)      return "#10B981"; // green
-  if (count === goal - 1) return "#F59E0B"; // amber
-  return "#EF4444";                         // red
+function barColor(count: number, goal: number, c: ChartColors): string {
+  if (count >= goal)      return c.positive;
+  if (count === goal - 1) return c.warning;
+  return c.danger;
 }
 
 function dayOfWeek(dateStr: string): number {
@@ -53,6 +48,12 @@ function dayOfWeek(dateStr: string): number {
 
 export function WorkoutFreqChart({ sessions, days, goal }: Props) {
   const [animate, setAnimate] = useState(true);
+  const c = useChartColors();
+  const TOOLTIP_STYLE = {
+    contentStyle: { background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 8 },
+    labelStyle: { color: c.text, fontSize: 13 },
+    itemStyle: { color: c.textMuted, fontSize: 12 },
+  };
   const weekCount = Math.ceil(days / 7);
   const forceWeekly = days > 90;
   const [granularity, setGranularity] = useState<"daily" | "weekly">(
@@ -157,18 +158,18 @@ export function WorkoutFreqChart({ sessions, days, goal }: Props) {
 
       <ResponsiveContainer width="100%" height={200}>
         <BarChart data={chartData} margin={{ top: 4, right: 4, left: -24, bottom: 0 }}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#1E2130" vertical={false} />
+          <CartesianGrid strokeDasharray="3 3" stroke={c.grid} vertical={false} />
           <XAxis
             dataKey="label"
-            stroke="#334155"
-            tick={{ fill: "#64748B", fontSize: 10 }}
+            stroke={c.axis}
+            tick={{ fill: c.textMuted, fontSize: 10 }}
             tickLine={false}
             axisLine={false}
             ticks={ticks}
           />
           <YAxis
-            stroke="#334155"
-            tick={{ fill: "#64748B", fontSize: 11 }}
+            stroke={c.axis}
+            tick={{ fill: c.textMuted, fontSize: 11 }}
             tickLine={false}
             axisLine={false}
             allowDecimals={false}
@@ -180,7 +181,7 @@ export function WorkoutFreqChart({ sessions, days, goal }: Props) {
           {hasGoal && granularity === "weekly" && (
             <ReferenceLine
               y={goal}
-              stroke="#64748B"
+              stroke={c.textMuted}
               strokeDasharray="4 3"
               strokeWidth={1.5}
             />
@@ -197,14 +198,14 @@ export function WorkoutFreqChart({ sessions, days, goal }: Props) {
                 return (
                   <Cell
                     key={entry.key}
-                    fill={entry.count > 0 ? (hasGoal ? "#10B981" : "#6366F1") : "#1E2130"}
+                    fill={entry.count > 0 ? (hasGoal ? c.positive : c.primary) : c.grid}
                   />
                 );
               }
               return (
                 <Cell
                   key={entry.key}
-                  fill={hasGoal ? barColor(entry.count, goal!) : "#6366F1"}
+                  fill={hasGoal ? barColor(entry.count, goal!, c) : c.primary}
                 />
               );
             })}

--- a/web/src/components/fitness/workout-history-table.tsx
+++ b/web/src/components/fitness/workout-history-table.tsx
@@ -48,7 +48,7 @@ function SortIcon({ col, sortKey, dir }: { col: SortKey; sortKey: SortKey; dir: 
 }
 
 const SOURCE_COLORS: Record<string, string> = {
-  fitbit: "var(--color-accent, #6366f1)",
+  fitbit: "var(--color-primary)",
   manual: "var(--color-text-muted)",
 };
 
@@ -143,7 +143,7 @@ export function WorkoutHistoryTable({ workouts }: Props) {
                   fontWeight: activityFilter === type ? 600 : 400,
                   background:
                     activityFilter === type
-                      ? "var(--color-accent, #6366f1)"
+                      ? "var(--color-primary)"
                       : "var(--color-surface-raised, rgba(255,255,255,0.05))",
                   color:
                     activityFilter === type

--- a/web/src/components/fitness/workout-list.tsx
+++ b/web/src/components/fitness/workout-list.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export default function WorkoutList({ workouts }: Props) {
   if (workouts.length === 0) {
-    return <p className="text-sm text-neutral-600">No workouts logged.</p>;
+    return <p className="text-sm" style={{ color: "var(--color-text-faint)" }}>No workouts logged.</p>;
   }
 
   return (
@@ -14,13 +14,14 @@ export default function WorkoutList({ workouts }: Props) {
       {workouts.map((w) => (
         <div
           key={w.id}
-          className="flex items-center gap-3 bg-neutral-900 rounded-xl px-4 py-3 border border-neutral-800"
+          className="flex items-center gap-3 rounded-xl px-4 py-3"
+          style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
         >
           <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium text-neutral-200 capitalize">{w.activity}</p>
-            <p className="text-xs text-neutral-500 mt-0.5">{w.date}</p>
+            <p className="text-sm font-medium capitalize" style={{ color: "var(--color-text)" }}>{w.activity}</p>
+            <p className="text-xs mt-0.5" style={{ color: "var(--color-text-muted)" }}>{w.date}</p>
           </div>
-          <div className="flex gap-3 text-xs text-neutral-500 flex-shrink-0">
+          <div className="flex gap-3 text-xs flex-shrink-0" style={{ color: "var(--color-text-muted)" }}>
             {w.duration_mins != null && <span>{w.duration_mins} min</span>}
             {w.calories != null && <span>{w.calories} cal</span>}
             {w.avg_hr != null && <span>{w.avg_hr} bpm</span>}

--- a/web/src/components/habits/habit-history.tsx
+++ b/web/src/components/habits/habit-history.tsx
@@ -6,7 +6,7 @@ import type { HabitRegistry, HabitLog } from "@/lib/types";
 interface Props {
   habits: HabitRegistry[];
   logs: HabitLog[];
-  dates: string[]; // ascending YYYY-MM-DD strings
+  dates: string[];
   range: 7 | 30 | 90;
   toggleAction: (habitId: string, date: string, completed: boolean) => Promise<void>;
 }
@@ -27,14 +27,14 @@ function groupByWeek(dates: string[]): { label: string; dates: string[] }[] {
   return weeks;
 }
 
-function countToOpacity(count: number, total: number): string {
-  if (total === 0) return "opacity-20";
+function countToOpacity(count: number, total: number): number {
+  if (total === 0) return 0.2;
   const ratio = count / total;
-  if (ratio === 0) return "opacity-20";
-  if (ratio <= 0.3) return "opacity-40";
-  if (ratio <= 0.57) return "opacity-60";
-  if (ratio <= 0.86) return "opacity-80";
-  return "opacity-100";
+  if (ratio === 0) return 0.2;
+  if (ratio <= 0.3) return 0.4;
+  if (ratio <= 0.57) return 0.6;
+  if (ratio <= 0.86) return 0.8;
+  return 1;
 }
 
 export default function HabitHistory({ habits, logs, dates, range, toggleAction }: Props) {
@@ -56,7 +56,6 @@ export default function HabitHistory({ habits, logs, dates, range, toggleAction 
       try {
         await toggleAction(habitId, date, next);
       } catch {
-        // revert on error
         setOverrides((prev) => {
           const updated = { ...prev };
           if (current === undefined) {
@@ -70,6 +69,9 @@ export default function HabitHistory({ habits, logs, dates, range, toggleAction 
     });
   }
 
+  const thStyle = { color: "var(--color-text-muted)" };
+  const tdHabitStyle = { color: "var(--color-text)" };
+
   if (range === 90) {
     const weeks = groupByWeek(dates);
     return (
@@ -77,9 +79,9 @@ export default function HabitHistory({ habits, logs, dates, range, toggleAction 
         <table className="w-full text-xs">
           <thead>
             <tr>
-              <th className="text-left text-neutral-500 font-normal pb-2 pr-4 w-32">Habit</th>
+              <th className="text-left font-normal pb-2 pr-4 w-32" style={thStyle}>Habit</th>
               {weeks.map((w) => (
-                <th key={w.label} className="text-neutral-500 font-normal pb-2 px-1 text-center whitespace-nowrap">
+                <th key={w.label} className="font-normal pb-2 px-1 text-center whitespace-nowrap" style={thStyle}>
                   {w.label}
                 </th>
               ))}
@@ -88,16 +90,22 @@ export default function HabitHistory({ habits, logs, dates, range, toggleAction 
           <tbody>
             {habits.map((h) => (
               <tr key={h.id}>
-                <td className="text-neutral-400 py-1.5 pr-4 truncate max-w-[8rem]">
+                <td className="py-1.5 pr-4 truncate max-w-[8rem]" style={tdHabitStyle}>
                   {h.emoji} {h.name}
                 </td>
                 {weeks.map((w) => {
                   const count = w.dates.filter((d) => getCompleted(h.id, d) === true).length;
                   const total = w.dates.length;
+                  const op = countToOpacity(count, total);
                   return (
                     <td key={w.label} className="py-1.5 px-1 text-center">
                       <span
-                        className={`inline-flex items-center justify-center w-6 h-5 rounded text-neutral-100 bg-neutral-100 text-[10px] font-medium ${countToOpacity(count, total)}`}
+                        className="inline-flex items-center justify-center w-6 h-5 rounded text-[10px] font-medium"
+                        style={{
+                          background: "var(--color-primary)",
+                          color: "#fff",
+                          opacity: op,
+                        }}
                         title={`${count}/${total} days`}
                       >
                         {count > 0 ? count : ""}
@@ -118,9 +126,9 @@ export default function HabitHistory({ habits, logs, dates, range, toggleAction 
       <table className="w-full text-xs">
         <thead>
           <tr>
-            <th className="text-left text-neutral-500 font-normal pb-2 pr-4 w-32">Habit</th>
+            <th className="text-left font-normal pb-2 pr-4 w-32" style={thStyle}>Habit</th>
             {dates.map((d) => (
-              <th key={d} className="text-neutral-500 font-normal pb-2 px-1 text-center whitespace-nowrap">
+              <th key={d} className="font-normal pb-2 px-1 text-center whitespace-nowrap" style={thStyle}>
                 {formatHeader(d)}
               </th>
             ))}
@@ -129,7 +137,7 @@ export default function HabitHistory({ habits, logs, dates, range, toggleAction 
         <tbody>
           {habits.map((h) => (
             <tr key={h.id}>
-              <td className="text-neutral-400 py-1.5 pr-4 truncate max-w-[8rem]">
+              <td className="py-1.5 pr-4 truncate max-w-[8rem]" style={tdHabitStyle}>
                 {h.emoji} {h.name}
               </td>
               {dates.map((d) => {
@@ -138,11 +146,12 @@ export default function HabitHistory({ habits, logs, dates, range, toggleAction 
                   <td key={d} className="py-1.5 px-1 text-center">
                     <button
                       onClick={() => handleCellClick(h.id, d)}
-                      className={`inline-block w-4 h-4 rounded-full transition-all hover:ring-1 hover:ring-neutral-500 ${
+                      className="inline-block w-4 h-4 rounded-full transition-all cursor-pointer"
+                      style={
                         done === true
-                          ? "bg-neutral-100"
-                          : "bg-neutral-800 border border-neutral-700 opacity-50"
-                      }`}
+                          ? { background: "var(--color-primary)", border: "none" }
+                          : { background: "transparent", border: "1px solid var(--color-border)", opacity: 0.6 }
+                      }
                       title={`${h.name} — ${formatHeader(d)}`}
                     />
                   </td>

--- a/web/src/components/habits/habit-range-toggle.tsx
+++ b/web/src/components/habits/habit-range-toggle.tsx
@@ -24,11 +24,12 @@ export default function HabitRangeToggle({ current }: Props) {
         <button
           key={r}
           onClick={() => setRange(r)}
-          className={`text-xs px-2 py-0.5 rounded transition-colors ${
-            current === r
-              ? "bg-neutral-700 text-neutral-100"
-              : "text-neutral-500 hover:text-neutral-300"
-          }`}
+          className="text-xs px-2 py-0.5 rounded transition-colors cursor-pointer"
+          style={{
+            background: current === r ? "var(--color-surface-raised)" : "transparent",
+            color: current === r ? "var(--color-text)" : "var(--color-text-muted)",
+            border: "none",
+          }}
         >
           {r}d
         </button>

--- a/web/src/components/habits/habit-today-section.tsx
+++ b/web/src/components/habits/habit-today-section.tsx
@@ -70,18 +70,19 @@ export default function HabitTodaySection({
   return (
     <section>
       <div className="flex items-center justify-between mb-3">
-        <h2 className="text-xs text-neutral-500 uppercase tracking-wide">Today</h2>
+        <h2 className="text-xs uppercase tracking-wide" style={{ color: "var(--color-text-muted)" }}>Today</h2>
         <div className="flex items-center gap-2">
           <button
             onClick={() => {
               setManageMode((m) => !m);
               setShowAdd(false);
             }}
-            className={`text-xs px-2 py-0.5 rounded transition-colors ${
-              manageMode
-                ? "bg-neutral-700 text-neutral-200"
-                : "text-neutral-500 hover:text-neutral-300"
-            }`}
+            className="text-xs px-2 py-0.5 rounded transition-colors cursor-pointer"
+            style={{
+              background: manageMode ? "var(--color-surface-raised)" : "transparent",
+              color: manageMode ? "var(--color-text)" : "var(--color-text-muted)",
+              border: "none",
+            }}
           >
             Manage
           </button>
@@ -90,18 +91,19 @@ export default function HabitTodaySection({
               setShowAdd((s) => !s);
               setManageMode(false);
             }}
-            className={`text-xs px-2 py-0.5 rounded transition-colors ${
-              showAdd
-                ? "bg-neutral-700 text-neutral-200"
-                : "text-neutral-500 hover:text-neutral-300"
-            }`}
+            className="text-xs px-2 py-0.5 rounded transition-colors cursor-pointer"
+            style={{
+              background: showAdd ? "var(--color-surface-raised)" : "transparent",
+              color: showAdd ? "var(--color-text)" : "var(--color-text-muted)",
+              border: "none",
+            }}
           >
             + Add
           </button>
         </div>
       </div>
 
-      <div className="divide-y divide-neutral-800/50">
+      <div className="divide-y" style={{ borderColor: "var(--color-border)" }}>
         {habits.map((habit) => (
           <HabitToggle
             key={habit.id}
@@ -115,17 +117,18 @@ export default function HabitTodaySection({
           />
         ))}
         {habits.length === 0 && !showAdd && (
-          <p className="text-sm text-neutral-600 py-4">No habits configured.</p>
+          <p className="text-sm py-4" style={{ color: "var(--color-text-faint)" }}>No habits configured.</p>
         )}
       </div>
 
       {showAdd && (
-        <div className="mt-3 flex flex-wrap items-center gap-2 py-3 border-t border-neutral-800/50">
+        <div className="mt-3 flex flex-wrap items-center gap-2 py-3" style={{ borderTop: "1px solid var(--color-border)" }}>
           <div className="relative" ref={pickerRef}>
             <button
               type="button"
               onClick={() => setShowEmojiPicker((v) => !v)}
-              className="w-10 h-8 bg-neutral-800 text-neutral-100 text-lg rounded flex items-center justify-center focus:outline-none focus:ring-1 focus:ring-neutral-600"
+              className="w-10 h-8 text-lg rounded flex items-center justify-center cursor-pointer"
+              style={{ background: "var(--color-surface-raised)", color: "var(--color-text)", border: "1px solid var(--color-border)" }}
               title="Pick emoji"
             >
               {emoji || "😀"}
@@ -151,25 +154,29 @@ export default function HabitTodaySection({
             placeholder="Habit name"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            className="flex-1 min-w-[120px] bg-neutral-800 text-neutral-100 text-sm rounded px-2 py-1.5 placeholder-neutral-600 focus:outline-none focus:ring-1 focus:ring-neutral-600"
+            className="flex-1 min-w-[120px] text-sm rounded px-2 py-1.5"
+            style={{ background: "var(--color-surface-raised)", color: "var(--color-text)", border: "1px solid var(--color-border)" }}
           />
           <input
             type="text"
             placeholder="Category"
             value={category}
             onChange={(e) => setCategory(e.target.value)}
-            className="w-28 bg-neutral-800 text-neutral-100 text-sm rounded px-2 py-1.5 placeholder-neutral-600 focus:outline-none focus:ring-1 focus:ring-neutral-600"
+            className="w-28 text-sm rounded px-2 py-1.5"
+            style={{ background: "var(--color-surface-raised)", color: "var(--color-text)", border: "1px solid var(--color-border)" }}
           />
           <button
             onClick={handleAdd}
             disabled={!name.trim() || isPending}
-            className="text-xs px-3 py-1.5 bg-neutral-700 text-neutral-100 rounded hover:bg-neutral-600 disabled:opacity-40 transition-colors"
+            className="text-xs px-3 py-1.5 rounded disabled:opacity-40 transition-colors cursor-pointer"
+            style={{ background: "var(--color-primary)", color: "#fff", border: "none" }}
           >
             Save
           </button>
           <button
             onClick={handleCancel}
-            className="text-xs px-2 py-1.5 text-neutral-500 hover:text-neutral-300 transition-colors"
+            className="text-xs px-2 py-1.5 transition-colors cursor-pointer"
+            style={{ color: "var(--color-text-muted)", background: "transparent", border: "none" }}
           >
             Cancel
           </button>

--- a/web/src/components/habits/habit-toggle.tsx
+++ b/web/src/components/habits/habit-toggle.tsx
@@ -77,7 +77,8 @@ export default function HabitToggle({
             <button
               type="button"
               onClick={() => setShowEmojiPicker((v) => !v)}
-              className="w-10 h-8 bg-neutral-800 text-neutral-100 text-lg rounded flex items-center justify-center focus:outline-none focus:ring-1 focus:ring-neutral-600"
+              className="w-10 h-8 text-lg rounded flex items-center justify-center cursor-pointer"
+              style={{ background: "var(--color-surface-raised)", color: "var(--color-text)", border: "1px solid var(--color-border)" }}
               title="Pick emoji"
             >
               {editEmoji || "😀"}
@@ -101,14 +102,16 @@ export default function HabitToggle({
             type="text"
             value={editName}
             onChange={(e) => setEditName(e.target.value)}
-            className="flex-1 min-w-[100px] bg-neutral-800 text-neutral-100 text-sm rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-neutral-600"
+            className="flex-1 min-w-[100px] text-sm rounded px-2 py-1"
+            style={{ background: "var(--color-surface-raised)", color: "var(--color-text)", border: "1px solid var(--color-border)" }}
             placeholder="Habit name"
           />
           <input
             type="text"
             value={editCategory}
             onChange={(e) => setEditCategory(e.target.value)}
-            className="w-24 bg-neutral-800 text-neutral-100 text-sm rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-neutral-600"
+            className="w-24 text-sm rounded px-2 py-1"
+            style={{ background: "var(--color-surface-raised)", color: "var(--color-text)", border: "1px solid var(--color-border)" }}
             placeholder="Category"
           />
           <button
@@ -119,7 +122,8 @@ export default function HabitToggle({
                 setEditing(false);
               });
             }}
-            className="text-xs px-2 py-1 bg-neutral-700 text-neutral-100 rounded hover:bg-neutral-600 disabled:opacity-40"
+            className="text-xs px-2 py-1 rounded disabled:opacity-40 cursor-pointer"
+            style={{ background: "var(--color-primary)", color: "#fff" }}
           >
             Save
           </button>
@@ -130,7 +134,8 @@ export default function HabitToggle({
               setEditCategory(habit.category ?? "");
               setEditing(false);
             }}
-            className="text-xs px-2 py-1 text-neutral-500 hover:text-neutral-300"
+            className="text-xs px-2 py-1 cursor-pointer"
+            style={{ color: "var(--color-text-muted)", background: "transparent", border: "none" }}
           >
             Cancel
           </button>
@@ -140,15 +145,17 @@ export default function HabitToggle({
           <button
             onClick={handleToggle}
             disabled={isPending || archivePending}
-            className="flex-1 flex items-center gap-3 py-3 px-1 text-left hover:bg-neutral-800/50 rounded-lg transition-colors"
+            className="flex-1 flex items-center gap-3 py-3 px-1 text-left rounded-lg transition-colors cursor-pointer"
           >
             <span
-              className={`w-5 h-5 rounded-md border flex items-center justify-center flex-shrink-0 transition-colors ${
-                completed ? "bg-blue-500 border-blue-500" : "border-neutral-600"
-              }`}
+              className="w-5 h-5 rounded-md border flex items-center justify-center flex-shrink-0 transition-colors"
+              style={{
+                background: completed ? "var(--color-primary)" : "transparent",
+                borderColor: completed ? "var(--color-primary)" : "var(--color-border)",
+              }}
             >
               {completed && (
-                <svg className="w-3 h-3 text-white" viewBox="0 0 12 12" fill="none">
+                <svg className="w-3 h-3" viewBox="0 0 12 12" fill="none" style={{ color: "#fff" }}>
                   <path
                     d="M2 6l3 3 5-5"
                     stroke="currentColor"
@@ -161,12 +168,16 @@ export default function HabitToggle({
             </span>
             <span className="text-lg leading-none">{habit.emoji}</span>
             <span
-              className={`text-sm ${completed ? "text-neutral-500 line-through" : "text-neutral-200"}`}
+              className="text-sm"
+              style={{
+                color: completed ? "var(--color-text-muted)" : "var(--color-text)",
+                textDecoration: completed ? "line-through" : "none",
+              }}
             >
               {habit.name}
             </span>
             {!manageMode && habit.category && (
-              <span className="ml-auto text-xs text-neutral-600">{habit.category}</span>
+              <span className="ml-auto text-xs" style={{ color: "var(--color-text-faint)" }}>{habit.category}</span>
             )}
           </button>
           {manageMode ? (
@@ -175,7 +186,8 @@ export default function HabitToggle({
                 <button
                   onClick={() => setEditing(true)}
                   disabled={archivePending}
-                  className="ml-1 text-xs text-neutral-600 hover:text-neutral-300 px-1 py-3 transition-colors disabled:opacity-40"
+                  className="ml-1 text-xs px-1 py-3 transition-colors disabled:opacity-40 cursor-pointer"
+                  style={{ color: "var(--color-text-muted)", background: "transparent", border: "none" }}
                   title="Edit habit"
                 >
                   Edit
@@ -185,7 +197,8 @@ export default function HabitToggle({
                 <button
                   onClick={handleArchive}
                   disabled={archivePending}
-                  className="ml-1 text-xs text-neutral-600 hover:text-red-400 px-1 py-3 transition-colors disabled:opacity-40"
+                  className="ml-1 text-xs px-1 py-3 transition-colors disabled:opacity-40 cursor-pointer"
+                  style={{ color: "var(--color-danger)", background: "transparent", border: "none" }}
                   title="Archive habit"
                 >
                   ✕

--- a/web/src/components/habits/radial-completion.tsx
+++ b/web/src/components/habits/radial-completion.tsx
@@ -9,27 +9,27 @@ import {
   Legend,
 } from "recharts";
 import type { HabitRegistry, HabitLog } from "@/lib/types";
+import { useChartColors, type ChartColors } from "@/lib/chart-colors";
 
 interface Props {
   habits: HabitRegistry[];
-  /** All logs from the last 7 days */
   weekLogs: HabitLog[];
 }
 
-const TOOLTIP_STYLE = {
-  contentStyle: { background: "#181B24", border: "1px solid #2A2F45", borderRadius: 8 },
-  labelStyle: { color: "#E2E8F0", fontSize: 13 },
-  itemStyle: { color: "#64748B", fontSize: 12 },
-};
-
-function rateColor(rate: number): string {
-  if (rate >= 0.8) return "#10B981";
-  if (rate >= 0.5) return "#F59E0B";
-  return "#EF4444";
+function rateColor(rate: number, c: ChartColors): string {
+  if (rate >= 0.8) return c.positive;
+  if (rate >= 0.5) return c.warning;
+  return c.danger;
 }
 
 export function RadialCompletion({ habits, weekLogs }: Props) {
   const [animate, setAnimate] = useState(true);
+  const c = useChartColors();
+  const TOOLTIP_STYLE = {
+    contentStyle: { background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 8 },
+    labelStyle: { color: c.text, fontSize: 13 },
+    itemStyle: { color: c.textMuted, fontSize: 12 },
+  };
 
   useEffect(() => {
     const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
@@ -49,7 +49,7 @@ export function RadialCompletion({ habits, weekLogs }: Props) {
     return {
       name: h.name,
       value: Math.round(rate * 100),
-      fill: rateColor(rate),
+      fill: rateColor(rate, c),
     };
   });
 
@@ -102,7 +102,7 @@ export function RadialCompletion({ habits, weekLogs }: Props) {
           <Legend
             iconType="circle"
             iconSize={7}
-            wrapperStyle={{ fontSize: 11, color: "#64748B" }}
+            wrapperStyle={{ fontSize: 11, color: c.textMuted }}
             formatter={(value) => {
               const entry = data.find((d) => d.name === value);
               return `${value} ${entry ? `(${entry.value}%)` : ""}`;

--- a/web/src/components/habits/streak-chart.tsx
+++ b/web/src/components/habits/streak-chart.tsx
@@ -13,20 +13,21 @@ import {
 } from "recharts";
 import type { HabitRegistry } from "@/lib/types";
 import type { HabitStreaks } from "@/lib/streaks";
+import { useChartColors } from "@/lib/chart-colors";
 
 interface Props {
   habits: HabitRegistry[];
   streaks: HabitStreaks;
 }
 
-const TOOLTIP_STYLE = {
-  contentStyle: { background: "#181B24", border: "1px solid #2A2F45", borderRadius: 8 },
-  labelStyle: { color: "#E2E8F0", fontSize: 13 },
-  itemStyle: { color: "#64748B", fontSize: 12 },
-};
-
 export function StreakChart({ habits, streaks }: Props) {
   const [animate, setAnimate] = useState(true);
+  const c = useChartColors();
+  const TOOLTIP_STYLE = {
+    contentStyle: { background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 8 },
+    labelStyle: { color: c.text, fontSize: 13 },
+    itemStyle: { color: c.textMuted, fontSize: 12 },
+  };
 
   useEffect(() => {
     const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
@@ -71,11 +72,11 @@ export function StreakChart({ habits, streaks }: Props) {
           layout="vertical"
           margin={{ top: 0, right: 16, left: 0, bottom: 0 }}
         >
-          <CartesianGrid strokeDasharray="3 3" stroke="#1E2130" horizontal={false} />
+          <CartesianGrid strokeDasharray="3 3" stroke={c.grid} horizontal={false} />
           <XAxis
             type="number"
-            stroke="#334155"
-            tick={{ fill: "#64748B", fontSize: 11 }}
+            stroke={c.axis}
+            tick={{ fill: c.textMuted, fontSize: 11 }}
             tickLine={false}
             axisLine={false}
             allowDecimals={false}
@@ -84,8 +85,8 @@ export function StreakChart({ habits, streaks }: Props) {
             type="category"
             dataKey="name"
             width={110}
-            stroke="#334155"
-            tick={{ fill: "#64748B", fontSize: 12 }}
+            stroke={c.axis}
+            tick={{ fill: c.textMuted, fontSize: 12 }}
             tickLine={false}
             axisLine={false}
           />
@@ -106,7 +107,7 @@ export function StreakChart({ habits, streaks }: Props) {
             {data.map((entry, i) => (
               <Cell
                 key={i}
-                fill={entry.current > 0 ? "#6366F1" : "#1E2130"}
+                fill={entry.current > 0 ? c.primary : c.grid}
               />
             ))}
           </Bar>

--- a/web/src/components/journal/journal-editor.tsx
+++ b/web/src/components/journal/journal-editor.tsx
@@ -239,7 +239,7 @@ export default function JournalEditor({
               className="w-full py-3 rounded-xl text-sm font-medium transition-opacity"
               style={{
                 background: "var(--color-primary)",
-                color:      "var(--color-primary-foreground)",
+                color:      "#fff",
                 opacity:    saveStatus === "saving" || isEmpty ? 0.5 : 1,
                 cursor:     saveStatus === "saving" || isEmpty ? "not-allowed" : "pointer",
               }}

--- a/web/src/components/journal/journal-tabs.tsx
+++ b/web/src/components/journal/journal-tabs.tsx
@@ -58,7 +58,7 @@ export default function JournalTabs({
             className="px-4 py-1.5 rounded-lg text-sm font-medium transition-colors"
             style={{
               background: tab === t ? "var(--color-primary)"     : "transparent",
-              color:      tab === t ? "var(--color-primary-foreground)" : "var(--color-text-muted)",
+              color:      tab === t ? "#fff" : "var(--color-text-muted)",
             }}
           >
             {label}

--- a/web/src/components/meals/MealsClient.tsx
+++ b/web/src/components/meals/MealsClient.tsx
@@ -353,7 +353,7 @@ function TodayTab({
                         <button
                           onClick={() => saveEdit(m.id)}
                           disabled={editSaving}
-                          style={{ fontSize: 13, padding: "4px 12px", background: "var(--color-primary)", color: "var(--color-primary-foreground)", border: "none", borderRadius: 6, cursor: "pointer", opacity: editSaving ? 0.5 : 1 }}
+                          style={{ fontSize: 13, padding: "4px 12px", background: "var(--color-primary)", color: "#fff", border: "none", borderRadius: 6, cursor: "pointer", opacity: editSaving ? 0.5 : 1 }}
                         >
                           {editSaving ? "Saving…" : "Save"}
                         </button>
@@ -1201,7 +1201,7 @@ function PastMeals({ pastMeals }: { pastMeals: MealRow[] }) {
                           <button
                             onClick={() => saveEdit(m.id)}
                             disabled={editSaving}
-                            style={{ fontSize: 13, padding: "4px 12px", background: "var(--color-primary)", color: "var(--color-primary-foreground)", border: "none", borderRadius: 6, cursor: "pointer", opacity: editSaving ? 0.5 : 1 }}
+                            style={{ fontSize: 13, padding: "4px 12px", background: "var(--color-primary)", color: "#fff", border: "none", borderRadius: 6, cursor: "pointer", opacity: editSaving ? 0.5 : 1 }}
                           >
                             {editSaving ? "Saving…" : "Save"}
                           </button>

--- a/web/src/components/nav.tsx
+++ b/web/src/components/nav.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import Logo from "@/components/ui/logo";
 import SignOutButton from "@/components/ui/sign-out-button";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { createClient } from "@/lib/supabase/client";
 
 const NAV_ITEMS = [
@@ -80,15 +81,16 @@ export default function Nav() {
           borderRight: "1px solid var(--color-border)",
         }}
       >
-        {/* Logo */}
+        {/* Logo + theme toggle */}
         <div className="flex items-center gap-2.5 px-5 pt-6 pb-6">
           <Logo size={26} />
           <span
-            className="font-heading text-sm font-semibold tracking-tight"
+            className="font-heading text-sm font-semibold tracking-tight flex-1"
             style={{ color: "var(--color-text)" }}
           >
             Mr. Bridge
           </span>
+          <ThemeToggle />
         </div>
 
         {/* Nav links */}
@@ -116,7 +118,7 @@ export default function Nav() {
                     <span
                       className="absolute -top-1 -right-1 flex items-center justify-center rounded-full text-white"
                       style={{
-                        background: "#EF4444",
+                        background: "var(--color-danger)",
                         minWidth: 14,
                         height: 14,
                         fontSize: 9,
@@ -228,12 +230,15 @@ export default function Nav() {
               <span className="text-sm font-semibold" style={{ color: "var(--color-text)" }}>
                 More
               </span>
-              <button
-                onClick={() => setShowMore(false)}
-                style={{ color: "var(--color-text-muted)", background: "transparent", border: "none", cursor: "pointer" }}
-              >
-                <X size={18} />
-              </button>
+              <div className="flex items-center gap-2">
+                <ThemeToggle />
+                <button
+                  onClick={() => setShowMore(false)}
+                  style={{ color: "var(--color-text-muted)", background: "transparent", border: "none", cursor: "pointer" }}
+                >
+                  <X size={18} />
+                </button>
+              </div>
             </div>
 
             <div className="px-3 pb-4 grid grid-cols-2 gap-1">
@@ -261,7 +266,7 @@ export default function Nav() {
                         <span
                           className="absolute -top-1 -right-1 flex items-center justify-center rounded-full text-white"
                           style={{
-                            background: "#EF4444",
+                            background: "var(--color-danger)",
                             minWidth: 14,
                             height: 14,
                             fontSize: 9,

--- a/web/src/components/notifications/notification-list.tsx
+++ b/web/src/components/notifications/notification-list.tsx
@@ -17,9 +17,9 @@ type FilterKey = (typeof TYPE_FILTERS)[number]["key"];
 function typeIcon(type: string) {
   switch (type) {
     case "hrv_alert": return <Activity size={16} style={{ color: "var(--color-primary)", flexShrink: 0 }} />;
-    case "weather":   return <CloudRain size={16} style={{ color: "#38BDF8", flexShrink: 0 }} />;
-    case "task_due":  return <CheckSquare size={16} style={{ color: "#10B981", flexShrink: 0 }} />;
-    case "birthday":  return <Cake size={16} style={{ color: "#F59E0B", flexShrink: 0 }} />;
+    case "weather":   return <CloudRain size={16} style={{ color: "var(--color-info)", flexShrink: 0 }} />;
+    case "task_due":  return <CheckSquare size={16} style={{ color: "var(--color-positive)", flexShrink: 0 }} />;
+    case "birthday":  return <Cake size={16} style={{ color: "var(--color-warning)", flexShrink: 0 }} />;
     default:          return <Bell size={16} style={{ color: "var(--color-text-muted)", flexShrink: 0 }} />;
   }
 }

--- a/web/src/components/settings/appearance-settings.tsx
+++ b/web/src/components/settings/appearance-settings.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { useTheme } from "next-themes";
+import { setThemePreference } from "@/lib/theme-actions";
+import type { ThemePreference } from "@/lib/theme";
+
+const OPTIONS: { value: ThemePreference; label: string; desc: string }[] = [
+  { value: "system", label: "System", desc: "Match your device setting" },
+  { value: "light",  label: "Light",  desc: "Light mode always" },
+  { value: "dark",   label: "Dark",   desc: "Dark mode always" },
+];
+
+export function AppearanceSettings() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  const [, startTransition] = useTransition();
+
+  useEffect(() => setMounted(true), []);
+
+  const current = (theme as ThemePreference | undefined) ?? "system";
+
+  function handleChange(value: ThemePreference) {
+    setTheme(value);
+    startTransition(() => {
+      setThemePreference(value);
+    });
+  }
+
+  return (
+    <div
+      className="rounded-xl p-5"
+      style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+    >
+      <p
+        className="text-xs uppercase tracking-widest mb-4"
+        style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}
+      >
+        Appearance
+      </p>
+      <fieldset className="space-y-2" aria-label="Theme preference">
+        {OPTIONS.map((opt) => {
+          const selected = mounted && current === opt.value;
+          return (
+            <label
+              key={opt.value}
+              className="flex items-start gap-3 px-3 py-2.5 rounded-lg cursor-pointer transition-colors"
+              style={{
+                background: selected ? "var(--color-primary-dim)" : "transparent",
+                border: `1px solid ${selected ? "var(--color-primary)" : "var(--color-border)"}`,
+              }}
+            >
+              <input
+                type="radio"
+                name="theme_preference"
+                value={opt.value}
+                checked={selected}
+                onChange={() => handleChange(opt.value)}
+                style={{ marginTop: 3, accentColor: "var(--color-primary)" }}
+              />
+              <span className="flex-1">
+                <span className="block text-sm font-medium" style={{ color: "var(--color-text)" }}>
+                  {opt.label}
+                </span>
+                <span className="block text-xs mt-0.5" style={{ color: "var(--color-text-muted)" }}>
+                  {opt.desc}
+                </span>
+              </span>
+            </label>
+          );
+        })}
+      </fieldset>
+    </div>
+  );
+}

--- a/web/src/components/tasks/task-item.tsx
+++ b/web/src/components/tasks/task-item.tsx
@@ -260,7 +260,7 @@ export default function TaskItem({
           {totalCount > 0 && (
             <span
               className="text-xs tabular-nums flex-shrink-0 font-medium"
-              style={{ color: allDone ? "#10B981" : "var(--color-text-muted)" }}
+              style={{ color: allDone ? "var(--color-positive)" : "var(--color-text-muted)" }}
             >
               {completedCount}/{totalCount}
             </span>

--- a/web/src/components/theme-provider.tsx
+++ b/web/src/components/theme-provider.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ThemePreference } from "@/lib/theme";
+
+export function ThemeProvider({
+  children,
+  defaultTheme,
+}: {
+  children: React.ReactNode;
+  defaultTheme: ThemePreference;
+}) {
+  return (
+    <NextThemesProvider
+      attribute="data-theme"
+      defaultTheme={defaultTheme}
+      enableSystem
+      disableTransitionOnChange
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/web/src/components/theme-toggle.tsx
+++ b/web/src/components/theme-toggle.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { useTheme } from "next-themes";
+import { Sun, Moon, Monitor } from "lucide-react";
+import { setThemePreference } from "@/lib/theme-actions";
+import type { ThemePreference } from "@/lib/theme";
+
+const CYCLE: ThemePreference[] = ["system", "light", "dark"];
+
+const LABEL: Record<ThemePreference, string> = {
+  system: "System",
+  light: "Light",
+  dark: "Dark",
+};
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  const [, startTransition] = useTransition();
+
+  useEffect(() => setMounted(true), []);
+
+  const current: ThemePreference = (theme as ThemePreference | undefined) ?? "system";
+  const Icon = current === "light" ? Sun : current === "dark" ? Moon : Monitor;
+
+  function handleClick() {
+    const idx = CYCLE.indexOf(current);
+    const next = CYCLE[(idx + 1) % CYCLE.length];
+    setTheme(next);
+    startTransition(() => {
+      setThemePreference(next);
+    });
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label={mounted ? `Theme: ${LABEL[current]}. Click to change.` : "Theme toggle"}
+      title={mounted ? `Theme: ${LABEL[current]}` : undefined}
+      className="flex items-center justify-center rounded-md transition-colors cursor-pointer"
+      style={{
+        width: 32,
+        height: 32,
+        background: "transparent",
+        color: "var(--color-text-muted)",
+        border: "1px solid var(--color-border)",
+      }}
+      onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = "var(--color-text)"; }}
+      onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = "var(--color-text-muted)"; }}
+    >
+      <Icon size={15} />
+    </button>
+  );
+}

--- a/web/src/components/ui/logo.tsx
+++ b/web/src/components/ui/logo.tsx
@@ -13,35 +13,33 @@ export default function Logo({ size = 32, className = "" }: LogoProps) {
       xmlns="http://www.w3.org/2000/svg"
       className={className}
       aria-label="Mr. Bridge"
+      style={{ color: "var(--color-primary)" }}
     >
-      {/* Geometric background square */}
-      <rect width="32" height="32" rx="7" fill="#1d4ed8" fillOpacity="0.15" />
-      {/* M stroke */}
+      <rect width="32" height="32" rx="7" fill="currentColor" fillOpacity="0.15" />
       <path
         d="M6 22V10l5 6 5-6v12"
-        stroke="#3b82f6"
+        stroke="currentColor"
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
-      {/* B strokes */}
       <path
         d="M18 10h5a2.5 2.5 0 0 1 0 5h-5V10z"
-        stroke="#3b82f6"
+        stroke="currentColor"
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
       <path
         d="M18 15h5.5a2.5 2.5 0 0 1 0 5H18V15z"
-        stroke="#3b82f6"
+        stroke="currentColor"
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
       <path
         d="M18 10v12"
-        stroke="#3b82f6"
+        stroke="currentColor"
         strokeWidth="2"
         strokeLinecap="round"
       />

--- a/web/src/components/ui/metric-card.tsx
+++ b/web/src/components/ui/metric-card.tsx
@@ -41,7 +41,7 @@ export function MetricCard({
         border: "1px solid var(--color-border)",
       }}
       onMouseEnter={(e) => {
-        (e.currentTarget as HTMLElement).style.borderColor = "#2A2F45";
+        (e.currentTarget as HTMLElement).style.borderColor = "var(--color-text-faint)";
       }}
       onMouseLeave={(e) => {
         (e.currentTarget as HTMLElement).style.borderColor = "var(--color-border)";

--- a/web/src/lib/chart-colors.ts
+++ b/web/src/lib/chart-colors.ts
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+
+export type ChartColors = {
+  primary: string;
+  secondary: string;
+  positive: string;
+  warning: string;
+  danger: string;
+  info: string;
+  cta: string;
+  text: string;
+  textMuted: string;
+  textFaint: string;
+  border: string;
+  surface: string;
+  surfaceRaised: string;
+  grid: string;
+  axis: string;
+  tooltipBg: string;
+  tooltipBorder: string;
+};
+
+const KEYS: Record<keyof ChartColors, string> = {
+  primary:       "--color-primary",
+  secondary:     "--color-secondary",
+  positive:      "--color-positive",
+  warning:       "--color-warning",
+  danger:        "--color-danger",
+  info:          "--color-info",
+  cta:           "--color-cta",
+  text:          "--color-text",
+  textMuted:     "--color-text-muted",
+  textFaint:     "--color-text-faint",
+  border:        "--color-border",
+  surface:       "--color-surface",
+  surfaceRaised: "--color-surface-raised",
+  grid:          "--color-border",
+  axis:          "--color-text-faint",
+  tooltipBg:     "--color-surface-raised",
+  tooltipBorder: "--color-border",
+};
+
+const FALLBACK_DARK: ChartColors = {
+  primary: "#3B82F6",
+  secondary: "#60A5FA",
+  positive: "#10B981",
+  warning: "#F59E0B",
+  danger: "#EF4444",
+  info: "#38BDF8",
+  cta: "#F59E0B",
+  text: "#F8FAFC",
+  textMuted: "#94A3B8",
+  textFaint: "#64748B",
+  border: "#1F2937",
+  surface: "#111827",
+  surfaceRaised: "#181B24",
+  grid: "#1F2937",
+  axis: "#64748B",
+  tooltipBg: "#181B24",
+  tooltipBorder: "#1F2937",
+};
+
+function readColors(): ChartColors {
+  if (typeof window === "undefined") return FALLBACK_DARK;
+  const styles = getComputedStyle(document.documentElement);
+  const out = {} as ChartColors;
+  (Object.keys(KEYS) as (keyof ChartColors)[]).forEach((k) => {
+    const v = styles.getPropertyValue(KEYS[k]).trim();
+    out[k] = v || FALLBACK_DARK[k];
+  });
+  return out;
+}
+
+export function useChartColors(): ChartColors {
+  const { resolvedTheme } = useTheme();
+  const [colors, setColors] = useState<ChartColors>(FALLBACK_DARK);
+
+  useEffect(() => {
+    setColors(readColors());
+  }, [resolvedTheme]);
+
+  return colors;
+}

--- a/web/src/lib/theme-actions.ts
+++ b/web/src/lib/theme-actions.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { revalidatePath } from "next/cache";
+import type { ThemePreference } from "@/lib/theme";
+
+export async function setThemePreference(pref: ThemePreference) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return;
+
+  if (pref === "system") {
+    await supabase
+      .from("profile")
+      .delete()
+      .eq("user_id", user.id)
+      .eq("key", "theme_preference");
+  } else {
+    await supabase
+      .from("profile")
+      .upsert(
+        { user_id: user.id, key: "theme_preference", value: pref },
+        { onConflict: "user_id,key" },
+      );
+  }
+  revalidatePath("/", "layout");
+}

--- a/web/src/lib/theme.ts
+++ b/web/src/lib/theme.ts
@@ -1,0 +1,22 @@
+import { createClient } from "@/lib/supabase/server";
+
+export type ThemePreference = "system" | "light" | "dark";
+
+export async function getServerThemePreference(): Promise<ThemePreference> {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return "system";
+    const { data } = await supabase
+      .from("profile")
+      .select("value")
+      .eq("user_id", user.id)
+      .eq("key", "theme_preference")
+      .maybeSingle();
+    const v = data?.value;
+    if (v === "light" || v === "dark" || v === "system") return v;
+    return "system";
+  } catch {
+    return "system";
+  }
+}


### PR DESCRIPTION
Closes #214 on merge.

## Summary
- **Phase 1 audit** delivered as a standalone artifact at `.claude/plans/snappy-twirling-cookie.md` (executive summary, C/H/M/L findings with file:line refs, ~230 hardcoded-color census, impact-vs-effort recommendations, scope split).
- **Phase 2 (this PR):** System/Light/Dark theme toggle with SSR persistence via Supabase `profile.theme_preference`, plus the color-token migration that makes light mode viable.

## What's in this PR
- `next-themes` + `ThemeProvider` wired into the root layout; server reads `profile.theme_preference` and emits `data-theme` on `<html>` so SSR paints the right theme (no FOUC).
- Header icon button (desktop sidebar + mobile More sheet) cycles System → Light → Dark.
- Settings "Appearance" radio group synced bidirectionally via `useTheme()`.
- `web/src/lib/chart-colors.ts` — `useChartColors()` reads CSS vars at runtime via `getComputedStyle()` so Recharts responds to theme switches.
- `globals.css` — `:root[data-theme="dark"]` and `:root[data-theme="light"]` token blocks from MASTER.md; aligned dark `--color-primary` to `#3B82F6` (was `#6366F1`); global `:focus-visible` outline; `color-scheme: dark light`.
- Color migration: ~200 hardcoded hex values and ~30 Tailwind `neutral-*` / `rose-*` / `blue-*` utilities swapped to CSS vars across dashboard + fitness + habits + journal + chat + nav + settings + login.
- Weather emoji map replaced with Lucide icons (`Sun`, `CloudRain`, etc.).
- `design-system/mr-bridge/MASTER.md` §Typography updated to DM Sans + Inter (intentional deviation from the original Fira spec, confirmed with user).

## Not in this PR (spun off)
- #215 — focus traps + `aria-modal` on More sheet and chat session sheet.
- #216 — dashboard section reorder (MASTER.md briefing order) + empty/error state polish.
- #217 — per-page metadata, error.tsx boundaries, skip link, login polish, chat timestamps, archive confirmation.

## Test plan
- [ ] `cd web && npm run build` passes (verified locally).
- [ ] Toggle cycles System → Light → Dark in both desktop sidebar and mobile More sheet; Settings radio stays in sync.
- [ ] Hard refresh preserves preference (Supabase write confirmed via server action).
- [ ] Light mode at 375 / 768 / 1024 / 1440 — dashboard, chat, fitness, habits, journal, settings, meals, login.
- [ ] Dark mode at 375 / 768 / 1024 / 1440 — same routes.
- [ ] Disable JS, load `/dashboard` — SSR emits correct `data-theme` (no FOUC).
- [ ] Body text contrast ≥ 4.5:1 in light mode (spot-check with WebAIM).
- [ ] Tab through `/dashboard`, `/chat`, `/settings` — focus ring visible everywhere.
- [ ] "System" preference follows OS dark/light switch without reload.