### PR TITLE
dashboard: reorder + standardize empty/error states (#216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (dashboard reorder + empty/error states — issue #216)
+- **`web/src/components/dashboard/empty-state.tsx`** — shared `<EmptyState icon children actionHref? actionLabel? variant?>` component. Empty variant uses `--color-text-faint`; error variant swaps icon for `AlertTriangle` and uses `--color-danger` with `role="status"`.
+
+### Changed (issue #216)
+- **`web/src/app/(protected)/dashboard/page.tsx`** — Tasks now render before Habits in the 2-column grid, matching the actionable-today cluster for glance-first triage.
+- **`web/src/components/dashboard/dashboard-header.tsx`** — weather failure now surfaces an `AlertTriangle` + "Weather unavailable" line instead of silently hiding the block.
+- **`web/src/components/nav.tsx`** — unread-count fetch errors now surface a small muted dot on the Notifications icon (with `title`/`aria-label`) instead of being silently swallowed.
+- **`web/src/components/dashboard/tasks-summary.tsx`, `habits-checkin.tsx`, `schedule-today.tsx`, `watchlist-widget.tsx`, `sports-card.tsx`** — empty states standardized on the `<EmptyState>` icon + text pattern; watchlist/sports/habits include a settings action link; schedule-today's error branch is now the error variant.
+
 ### Added (a11y: sheet focus traps — issue #215)
 - **`web/src/components/ui/sheet.tsx`** — thin `<Sheet>` wrapper over `@radix-ui/react-dialog` preserving the existing bottom-sheet visuals (rounded top, safe-area inset, backdrop tint). Provides focus trap, Escape dismiss, focus restore, `role="dialog"`, and `aria-modal`. Accessible title rendered via `Dialog.Title` (sr-only; each sheet keeps its own visible header).
 - **`web/package.json`** — adds `@radix-ui/react-dialog` dependency.

--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ mr-bridge-assistant/
 │   │   │   ├── settings/
 │   │   │   │   └── watchlist-settings.tsx # Stock watchlist editor (add/remove tickers, server-proxy validation)
 │   │   │   └── dashboard/
+│   │   │       ├── empty-state.tsx        # Shared icon+text empty/error state for dashboard widgets
 │   │   │       ├── schedule-today.tsx     # Google Calendar card
 │   │   │       ├── important-emails.tsx   # Gmail card
 │   │   │       ├── sync-button.tsx        # Calls all 3 sync routes; spinner + router.refresh()

--- a/web/src/app/(protected)/dashboard/page.tsx
+++ b/web/src/app/(protected)/dashboard/page.tsx
@@ -232,8 +232,9 @@ export default async function DashboardPage() {
       {/* ── Schedule today (full width) ──────────────────────────────── */}
       <ScheduleToday />
 
-      {/* ── Habits + Tasks: fixed height, scrollable ─────────────────── */}
+      {/* ── Tasks + Habits: fixed height, scrollable ─────────────────── */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <TasksSummary tasks={tasks} />
         <HabitsCheckin
           registry={habitRegistry}
           todayLogs={todayLogs}
@@ -241,7 +242,6 @@ export default async function DashboardPage() {
           toggleAction={toggleHabit}
           date={today}
         />
-        <TasksSummary tasks={tasks} />
       </div>
 
       {/* ── Watchlist + Sports: market + favorite teams ──────────────── */}

--- a/web/src/components/dashboard/dashboard-header.tsx
+++ b/web/src/components/dashboard/dashboard-header.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import {
-  Sun, CloudSun, Cloud, Cloudy, CloudFog, CloudRain, CloudSnow, CloudLightning, Thermometer,
+  Sun, CloudSun, Cloud, Cloudy, CloudFog, CloudRain, CloudSnow, CloudLightning, Thermometer, AlertTriangle,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import SyncButton from "./sync-button";
@@ -28,12 +28,16 @@ interface Props {
 
 export default function DashboardHeader({ greeting, dateStr, windowKey }: Props) {
   const [weather, setWeather] = useState<WeatherData | null>(null);
+  const [weatherError, setWeatherError] = useState(false);
 
   useEffect(() => {
     fetch("/api/weather")
-      .then((r) => r.json())
-      .then((d) => { if (!d.error) setWeather(d); })
-      .catch(() => {});
+      .then((r) => r.ok ? r.json() : Promise.reject(new Error("weather fetch failed")))
+      .then((d) => {
+        if (d.error) setWeatherError(true);
+        else setWeather(d);
+      })
+      .catch(() => setWeatherError(true));
   }, []);
 
   const Icon = weather?.wmoCode != null ? (WMO_ICON[weather.wmoCode] ?? Cloudy) : Thermometer;
@@ -47,6 +51,16 @@ export default function DashboardHeader({ greeting, dateStr, windowKey }: Props)
         <p className="mt-0.5" style={{ fontSize: 13, color: "var(--color-text-muted)" }}>
           {dateStr}
         </p>
+        {!weather && weatherError && (
+          <p
+            className="mt-0.5 flex items-center gap-1.5"
+            style={{ fontSize: 13, color: "var(--color-danger)" }}
+            role="status"
+          >
+            <AlertTriangle size={14} aria-hidden />
+            <span>Weather unavailable</span>
+          </p>
+        )}
         {weather && (
           <p className="mt-0.5 flex flex-wrap items-center gap-x-1.5 gap-y-0" style={{ fontSize: 13, color: "var(--color-text-muted)" }}>
             <Icon size={14} style={{ color: "var(--color-text-muted)", flexShrink: 0 }} aria-hidden />

--- a/web/src/components/dashboard/empty-state.tsx
+++ b/web/src/components/dashboard/empty-state.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+import { AlertTriangle } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface EmptyStateProps {
+  icon: LucideIcon;
+  children: ReactNode;
+  actionHref?: string;
+  actionLabel?: string;
+  variant?: "empty" | "error";
+  paddingY?: number;
+}
+
+export default function EmptyState({
+  icon: Icon,
+  children,
+  actionHref,
+  actionLabel,
+  variant = "empty",
+  paddingY = 24,
+}: EmptyStateProps) {
+  const color = variant === "error" ? "var(--color-danger)" : "var(--color-text-faint)";
+  const DisplayIcon = variant === "error" ? AlertTriangle : Icon;
+  return (
+    <div
+      className="flex items-center gap-2"
+      style={{ color, fontSize: 14, padding: `${paddingY}px 0` }}
+      role={variant === "error" ? "status" : undefined}
+    >
+      <DisplayIcon size={16} aria-hidden />
+      <span>{children}</span>
+      {actionHref && actionLabel && (
+        <Link
+          href={actionHref}
+          style={{ marginLeft: 8, color: "var(--color-primary)", fontWeight: 500 }}
+        >
+          {actionLabel}
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/dashboard/habits-checkin.tsx
+++ b/web/src/components/dashboard/habits-checkin.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import { CheckSquare } from "lucide-react";
+import EmptyState from "./empty-state";
 import type { HabitLog, HabitRegistry } from "@/lib/types";
 import type { HabitStreaks } from "@/lib/streaks";
 
@@ -162,9 +164,14 @@ export default function HabitsCheckin({ registry, todayLogs, streaks, toggleActi
         })}
 
         {registry.length === 0 && (
-          <p className="text-sm py-2" style={{ color: "var(--color-text-faint)" }}>
-            No habits configured.
-          </p>
+          <EmptyState
+            icon={CheckSquare}
+            paddingY={8}
+            actionHref="/habits"
+            actionLabel="Configure"
+          >
+            No habits configured
+          </EmptyState>
         )}
       </div>
 

--- a/web/src/components/dashboard/schedule-today.tsx
+++ b/web/src/components/dashboard/schedule-today.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Calendar, Gift } from "lucide-react";
+import EmptyState from "./empty-state";
 import type { CalendarEvent } from "@/app/api/google/calendar/route";
 
 function parseTimeToMinutes(timeStr: string): number | null {
@@ -86,7 +87,9 @@ export default function ScheduleToday() {
           ))}
         </div>
       ) : error ? (
-        <p className="text-sm" style={{ color: "var(--color-danger)" }}>Failed to load — check Google credentials</p>
+        <EmptyState icon={Calendar} variant="error" paddingY={8}>
+          Calendar unavailable — check Google credentials
+        </EmptyState>
       ) : events.length > 0 ? (
         <div className="space-y-2.5">
           {useEnhanced ? (
@@ -147,7 +150,7 @@ export default function ScheduleToday() {
           )}
         </div>
       ) : (
-        <p className="text-sm" style={faint}>No events today</p>
+        <EmptyState icon={Calendar} paddingY={8}>No events today</EmptyState>
       )}
     </div>
   );

--- a/web/src/components/dashboard/sports-card.tsx
+++ b/web/src/components/dashboard/sports-card.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { useEffect, useRef, useState, useTransition } from "react";
-import { RefreshCw, Loader2, ChevronDown, ChevronRight } from "lucide-react";
+import { RefreshCw, Loader2, ChevronDown, ChevronRight, Trophy } from "lucide-react";
+import EmptyState from "./empty-state";
 import type { SportsCache } from "@/lib/types";
 import type { Game, Standing } from "@/lib/sync/sports/provider";
 
@@ -253,11 +253,14 @@ export function SportsCard({ rows, favorites, refreshAction }: Props) {
         </div>
 
         {favorites.length === 0 ? (
-          <div className="px-5 py-6 text-center" style={{ fontSize: 13, color: "var(--color-text-faint)" }}>
-            No teams —{" "}
-            <Link href="/settings#sports" style={{ color: "var(--color-primary)", textDecoration: "underline" }}>
-              add favorites in Settings
-            </Link>
+          <div className="px-5">
+            <EmptyState
+              icon={Trophy}
+              actionHref="/settings#sports"
+              actionLabel="Add"
+            >
+              No teams on watchlist
+            </EmptyState>
           </div>
         ) : (
           <div style={{ opacity: isPending ? 0.5 : 1, transition: "opacity 0.15s" }}>

--- a/web/src/components/dashboard/tasks-summary.tsx
+++ b/web/src/components/dashboard/tasks-summary.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import { ListTodo } from "lucide-react";
+import EmptyState from "./empty-state";
 import type { Task } from "@/lib/types";
 
 interface Props {
@@ -77,9 +79,9 @@ export default function TasksSummary({ tasks }: Props) {
       )}
 
       {tasks.length === 0 && (
-        <p className="mt-2 text-sm" style={{ color: "var(--color-text-faint)" }}>
-          No active tasks
-        </p>
+        <div className="mt-2">
+          <EmptyState icon={ListTodo} paddingY={8}>No active tasks</EmptyState>
+        </div>
       )}
     </Link>
   );

--- a/web/src/components/dashboard/watchlist-widget.tsx
+++ b/web/src/components/dashboard/watchlist-widget.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useRef, useState, useTransition } from "react";
 import { LineChart, Line, ResponsiveContainer } from "recharts";
-import { RefreshCw, Loader2, AlertTriangle } from "lucide-react";
+import { RefreshCw, Loader2, AlertTriangle, LineChart as LineChartIcon } from "lucide-react";
+import EmptyState from "./empty-state";
 import type { StocksCache } from "@/lib/types";
 
 interface Props {
@@ -220,11 +221,14 @@ export function WatchlistWidget({ rows, hasApiKey, refreshAction }: Props) {
 
         {/* Empty watchlist */}
         {hasApiKey && rows.length === 0 && (
-          <div
-            className="px-5 py-6 text-center"
-            style={{ fontSize: 13, color: "var(--color-text-faint)" }}
-          >
-            No stocks — add tickers in Settings
+          <div className="px-5">
+            <EmptyState
+              icon={LineChartIcon}
+              actionHref="/settings#watchlist"
+              actionLabel="Add"
+            >
+              No stocks on watchlist
+            </EmptyState>
           </div>
         )}
 

--- a/web/src/components/nav.tsx
+++ b/web/src/components/nav.tsx
@@ -52,6 +52,7 @@ export default function Nav() {
   const [showMore, setShowMore] = useState(false);
   const [isDemo, setIsDemo] = useState(false);
   const [unreadCount, setUnreadCount] = useState(0);
+  const [unreadError, setUnreadError] = useState(false);
 
   useEffect(() => {
     const demoEmail = process.env.NEXT_PUBLIC_DEMO_EMAIL;
@@ -64,9 +65,15 @@ export default function Nav() {
 
   useEffect(() => {
     fetch("/api/notifications/unread-count")
-      .then((r) => r.ok ? r.json() : { count: 0 })
-      .then((d) => setUnreadCount(d.count ?? 0))
-      .catch(() => {});
+      .then((r) => {
+        if (!r.ok) throw new Error("unread-count fetch failed");
+        return r.json();
+      })
+      .then((d) => {
+        setUnreadCount(d.count ?? 0);
+        setUnreadError(false);
+      })
+      .catch(() => setUnreadError(true));
   }, [pathname]);
 
   // Is the current page one of the "More" pages? If so, highlight the More button.
@@ -99,6 +106,7 @@ export default function Nav() {
           {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
             const active = isActive(pathname, href);
             const showBadge = href === "/notifications" && unreadCount > 0;
+            const showErrorDot = href === "/notifications" && unreadError && unreadCount === 0;
             return (
               <Link
                 key={href}
@@ -130,6 +138,18 @@ export default function Nav() {
                     >
                       {unreadCount > 9 ? "9+" : unreadCount}
                     </span>
+                  )}
+                  {showErrorDot && (
+                    <span
+                      title="Unread count unavailable"
+                      aria-label="Unread count unavailable"
+                      className="absolute -top-1 -right-1 rounded-full"
+                      style={{
+                        background: "var(--color-text-faint)",
+                        width: 6,
+                        height: 6,
+                      }}
+                    />
                   )}
                 </span>
                 {label}
@@ -230,6 +250,7 @@ export default function Nav() {
               {MOBILE_MORE.map(({ href, label, icon: Icon }) => {
                 const active = isActive(pathname, href);
                 const showBadge = href === "/notifications" && unreadCount > 0;
+            const showErrorDot = href === "/notifications" && unreadError && unreadCount === 0;
                 return (
                   <Link
                     key={href}


### PR DESCRIPTION
Closes #216.

## Summary
- **Order**: Tasks now render before Habits in the 2-col grid — surfaces actionable-today items first. Everything else already matched the approved glance-first order (Weather → Birthday → Scores → Health → Schedule → Tasks+Habits → Markets → Emails).
- **Empty states**: new shared [`<EmptyState>`](web/src/components/dashboard/empty-state.tsx) icon+text component applied to tasks-summary, habits-checkin, schedule-today, watchlist-widget, sports-card. Habits/watchlist/sports empties link to Settings.
- **Error indicators**: DashboardHeader shows an `AlertTriangle` + "Weather unavailable" line on fetch failure instead of silently hiding weather. Nav shows a small muted dot on the Notifications icon when unread-count fetch fails.
- **Scope note**: health-breakdown, upcoming-birthday, weight-trend, today-scores-strip intentionally keep their conditional-render behavior (they're hidden when no data) — the plan flagged these but null-render is the right call for these cards.

## Test plan
- [ ] Visual: dashboard order matches the approved glance-first sequence.
- [ ] Disable network → Weather pill shows warning; Notifications icon shows muted dot; Schedule card shows error line.
- [ ] Empty accounts: Tasks, Habits, Watchlist, Sports, Schedule all render icon + text (not plain strings).
- [ ] Action links on Habits/Watchlist/Sports empties go to the right Settings anchor.
- [ ] Light + dark themes at 375 / 768 / 1024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)