### PR TITLE
ux: metadata, error boundaries, skip link, chat polish (#217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (UX polish bundle — issue #217)
+- **`web/src/app/error.tsx`** — top-level error boundary with friendly copy, Retry button calling Next.js `reset()`.
+- **`web/src/app/(protected)/error.tsx`** — protected route error boundary with Retry + "Dashboard" fallback link.
+- **`web/src/app/login/layout.tsx`** — server-component wrapper so the (client) login page can still export `metadata`.
+- **Per-page metadata** — `export const metadata` added to dashboard, chat, settings, fitness, habits, journal, meals, notifications, tasks, weekly, and login. Root `layout.tsx` now defines a `title.template` of `"%s · Mr. Bridge"`, so each tab shows a unique browser title.
+- **Skip link** in `web/src/app/(protected)/layout.tsx` — visible on focus, jumps past the sidebar/nav to `#main-content`.
+
+### Changed (issue #217)
+- **`web/src/app/login/page.tsx`** — password visibility toggle (`Eye`/`EyeOff` with `aria-pressed`, `aria-label`); `aria-describedby` on email + password inputs linked to the error `<p>`; submit button now carries `aria-disabled` and a contextual `title` ("Enter a valid email" / "Enter your password") when disabled.
+- **`web/src/components/chat/message-bubble.tsx`** — timestamp tooltip (`title=`) now includes the full date, not just the time, so long-scroll context is visible on hover.
+- **`web/src/components/chat/chat-page-client.tsx`** — session-switch now shows a 3-row shimmer skeleton (respecting `role="status"`) instead of a static "Loading…" line; archive undo window extended from 5s → 10s.
+- **`web/src/components/chat/chat-interface.tsx`** — typing dots gated behind `motion-safe:animate-bounce` with a `motion-reduce:opacity-60` fallback; the container is now `role="status" aria-label="Assistant is typing"`.
+- **`web/src/components/chat/session-sheet.tsx`** — archive now opens a confirmation dialog (Radix Dialog) instead of firing immediately; preview of the chat is shown in the confirmation body; Cancel / Archive actions.
+
 ### Added (dashboard reorder + empty/error states — issue #216)
 - **`web/src/components/dashboard/empty-state.tsx`** — shared `<EmptyState icon children actionHref? actionLabel? variant?>` component. Empty variant uses `--color-text-faint`; error variant swaps icon for `AlertTriangle` and uses `--color-danger` with `role="status"`.
 

--- a/README.md
+++ b/README.md
@@ -342,7 +342,11 @@ mr-bridge-assistant/
 │   │   │   │   └── google/
 │   │   │   │       ├── calendar/route.ts  # Today's Google Calendar events
 │   │   │   │       └── gmail/route.ts     # Important unread emails
-│   │   │   └── login/page.tsx
+│   │   │   ├── error.tsx                   # Top-level error boundary (friendly + retry)
+│   │   │   ├── (protected)/error.tsx       # Protected-route error boundary (retry + dashboard fallback)
+│   │   │   └── login/
+│   │   │       ├── layout.tsx              # Server shell so client login page can export metadata
+│   │   │       └── page.tsx
 │   │   ├── components/
 │   │   │   ├── nav.tsx                    # Left sidebar (desktop); bottom tab bar + More sheet (mobile)
 │   │   │   ├── ui/

--- a/web/src/app/(protected)/chat/page.tsx
+++ b/web/src/app/(protected)/chat/page.tsx
@@ -1,10 +1,16 @@
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
 
+import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import ChatPageClient from "@/components/chat/chat-page-client";
 import type { ChatMessage, ChatSession } from "@/lib/types";
 import type { Message } from "ai";
+
+export const metadata: Metadata = {
+  title: "Chat",
+  description: "Conversational interface with Mr. Bridge.",
+};
 
 export default async function ChatPage() {
   const supabase = await createClient();

--- a/web/src/app/(protected)/dashboard/page.tsx
+++ b/web/src/app/(protected)/dashboard/page.tsx
@@ -1,6 +1,12 @@
 export const dynamic = "force-dynamic";
 
+import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
+
+export const metadata: Metadata = {
+  title: "Dashboard",
+  description: "Daily briefing — weather, schedule, health, tasks, habits, markets, and email.",
+};
 import { revalidatePath } from "next/cache";
 import { todayString, daysAgoString, USER_TZ } from "@/lib/timezone";
 import { computeStreaks } from "@/lib/streaks";

--- a/web/src/app/(protected)/error.tsx
+++ b/web/src/app/(protected)/error.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+import { AlertTriangle, RotateCcw, LayoutDashboard } from "lucide-react";
+
+export default function ProtectedError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Protected route error:", error);
+  }, [error]);
+
+  return (
+    <div className="max-w-sm mx-auto text-center" style={{ paddingTop: 48 }}>
+      <AlertTriangle
+        size={32}
+        style={{ color: "var(--color-danger)", margin: "0 auto 12px" }}
+        aria-hidden
+      />
+      <h1 className="font-heading font-semibold" style={{ fontSize: 18, marginBottom: 8 }}>
+        This page hit a snag
+      </h1>
+      <p style={{ fontSize: 14, color: "var(--color-text-muted)", marginBottom: 20 }}>
+        Try again, or head back to the dashboard.
+      </p>
+      <div className="flex items-center justify-center gap-2">
+        <button
+          onClick={reset}
+          className="inline-flex items-center gap-2 rounded-lg"
+          style={{
+            background: "var(--color-primary)",
+            color: "white",
+            border: "none",
+            padding: "10px 16px",
+            fontSize: 14,
+            fontWeight: 500,
+            cursor: "pointer",
+          }}
+        >
+          <RotateCcw size={14} />
+          Try again
+        </button>
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center gap-2 rounded-lg"
+          style={{
+            background: "var(--color-surface-raised)",
+            color: "var(--color-text)",
+            padding: "10px 16px",
+            fontSize: 14,
+            fontWeight: 500,
+          }}
+        >
+          <LayoutDashboard size={14} />
+          Dashboard
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(protected)/fitness/page.tsx
+++ b/web/src/app/(protected)/fitness/page.tsx
@@ -1,8 +1,14 @@
 export const dynamic = "force-dynamic";
 
+import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { daysAgoString } from "@/lib/timezone";
 import { getWindow } from "@/lib/window";
+
+export const metadata: Metadata = {
+  title: "Fitness",
+  description: "Body composition, workout frequency, active calories, and goal trends.",
+};
 import { WindowSelector } from "@/components/ui/window-selector";
 import { BodyCompDualChart } from "@/components/fitness/body-comp-dual-chart";
 import { WorkoutFreqChart } from "@/components/fitness/workout-freq-chart";

--- a/web/src/app/(protected)/habits/page.tsx
+++ b/web/src/app/(protected)/habits/page.tsx
@@ -1,8 +1,14 @@
 export const dynamic = "force-dynamic";
 
+import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 import { HabitHeatmap } from "@/components/habits/heatmap";
+
+export const metadata: Metadata = {
+  title: "Habits",
+  description: "Daily habit check-ins, streaks, and heatmap.",
+};
 import { StreakChart } from "@/components/habits/streak-chart";
 import { RadialCompletion } from "@/components/habits/radial-completion";
 import HabitHistory from "@/components/habits/habit-history";

--- a/web/src/app/(protected)/journal/page.tsx
+++ b/web/src/app/(protected)/journal/page.tsx
@@ -1,8 +1,14 @@
 export const dynamic = "force-dynamic";
 
+import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 import JournalTabs from "@/components/journal/journal-tabs";
+
+export const metadata: Metadata = {
+  title: "Journal",
+  description: "Guided journal entries and history.",
+};
 import type { JournalEntry, JournalResponses } from "@/lib/types";
 import { todayString } from "@/lib/timezone";
 

--- a/web/src/app/(protected)/layout.tsx
+++ b/web/src/app/(protected)/layout.tsx
@@ -21,11 +21,27 @@ export default async function ProtectedLayout({
       className="flex min-h-screen"
       style={{ background: "var(--color-bg)", color: "var(--color-text)" }}
     >
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-3 focus:left-3 focus:z-[100] focus:rounded-lg"
+        style={{
+          background: "var(--color-primary)",
+          color: "white",
+          padding: "10px 14px",
+          fontSize: 14,
+          fontWeight: 500,
+        }}
+      >
+        Skip to main content
+      </a>
       <Nav />
       {/* ml-0 on mobile (nav is bottom bar), ml-60 on desktop (240px sidebar) */}
       {/* pb-16 on mobile to clear the 56px bottom tab bar */}
       {/* pb accounts for 56px tab bar + safe-area-inset-bottom on iOS */}
-      <main className="flex-1 ml-0 lg:ml-60 px-5 lg:px-8 pt-8 pb-[calc(56px+env(safe-area-inset-bottom)+16px)] lg:pb-8 min-w-0">
+      <main
+        id="main-content"
+        className="flex-1 ml-0 lg:ml-60 px-5 lg:px-8 pt-8 pb-[calc(56px+env(safe-area-inset-bottom)+16px)] lg:pb-8 min-w-0"
+      >
         <div className="max-w-6xl mx-auto">{children}</div>
       </main>
     </div>

--- a/web/src/app/(protected)/meals/page.tsx
+++ b/web/src/app/(protected)/meals/page.tsx
@@ -1,8 +1,14 @@
 export const dynamic = "force-dynamic";
 
+import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { daysAgoString, todayString } from "@/lib/timezone";
 import MealsClient, { type MealRow, type RecipeRow, type MacroGoals, type MacroTotals } from "@/components/meals/MealsClient";
+
+export const metadata: Metadata = {
+  title: "Meals",
+  description: "Meal log, macro totals, and recipes.",
+};
 
 export default async function MealsPage() {
   const supabase = await createClient();

--- a/web/src/app/(protected)/notifications/page.tsx
+++ b/web/src/app/(protected)/notifications/page.tsx
@@ -1,7 +1,13 @@
 export const dynamic = "force-dynamic";
 
+import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import NotificationList from "@/components/notifications/notification-list";
+
+export const metadata: Metadata = {
+  title: "Notifications",
+  description: "Recent alerts and activity.",
+};
 
 export interface Notification {
   id: string;

--- a/web/src/app/(protected)/settings/page.tsx
+++ b/web/src/app/(protected)/settings/page.tsx
@@ -1,8 +1,14 @@
 export const dynamic = "force-dynamic";
 
+import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 import { ProfileForm } from "@/components/settings/profile-form";
+
+export const metadata: Metadata = {
+  title: "Settings",
+  description: "Appearance, profile, location, watchlist, and sports favorites.",
+};
 import { WatchlistSettings } from "@/components/settings/watchlist-settings";
 import { SportsSettings } from "@/components/settings/sports-settings";
 import { AppearanceSettings } from "@/components/settings/appearance-settings";

--- a/web/src/app/(protected)/tasks/page.tsx
+++ b/web/src/app/(protected)/tasks/page.tsx
@@ -1,8 +1,14 @@
 export const dynamic = "force-dynamic";
 
+import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 import TaskItem from "@/components/tasks/task-item";
+
+export const metadata: Metadata = {
+  title: "Tasks",
+  description: "Active tasks with priorities and due dates.",
+};
 import AddTaskForm from "@/components/tasks/add-task-form";
 import CompletedTasks from "@/components/tasks/completed-tasks";
 import type { Task } from "@/lib/types";

--- a/web/src/app/(protected)/weekly/page.tsx
+++ b/web/src/app/(protected)/weekly/page.tsx
@@ -1,8 +1,14 @@
 export const dynamic = "force-dynamic";
 
+import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { todayString, daysAgoString, getLast7Days } from "@/lib/timezone";
 import { computeStreaks } from "@/lib/streaks";
+
+export const metadata: Metadata = {
+  title: "Weekly",
+  description: "Weekly review — habits, workouts, and recovery trends.",
+};
 import type { HabitRegistry, Task, WorkoutSession, RecoveryMetrics, FitnessLog } from "@/lib/types";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RotateCcw } from "lucide-react";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Unhandled error:", error);
+  }, [error]);
+
+  return (
+    <div
+      className="min-h-screen flex items-center justify-center px-6"
+      style={{ background: "var(--color-bg)", color: "var(--color-text)" }}
+    >
+      <div className="max-w-sm text-center">
+        <AlertTriangle
+          size={36}
+          style={{ color: "var(--color-danger)", margin: "0 auto 16px" }}
+          aria-hidden
+        />
+        <h1 className="font-heading font-semibold" style={{ fontSize: 20, marginBottom: 8 }}>
+          Something went wrong
+        </h1>
+        <p style={{ fontSize: 14, color: "var(--color-text-muted)", marginBottom: 20 }}>
+          An unexpected error interrupted this page. You can try again — if it keeps
+          happening, reload or sign out and back in.
+        </p>
+        <button
+          onClick={reset}
+          className="inline-flex items-center gap-2 rounded-lg"
+          style={{
+            background: "var(--color-primary)",
+            color: "white",
+            border: "none",
+            padding: "10px 16px",
+            fontSize: 14,
+            fontWeight: 500,
+            cursor: "pointer",
+          }}
+        >
+          <RotateCcw size={14} />
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -4,7 +4,10 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { getServerThemePreference } from "@/lib/theme";
 
 export const metadata: Metadata = {
-  title: "Mr. Bridge",
+  title: {
+    default: "Mr. Bridge",
+    template: "%s · Mr. Bridge",
+  },
   description: "Personal assistant dashboard",
   manifest: "/manifest.json",
 };

--- a/web/src/app/login/layout.tsx
+++ b/web/src/app/login/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign in",
+  description: "Sign in to Mr. Bridge.",
+};
+
+export default function LoginLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { createClient } from "@/lib/supabase/client";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
 import Logo from "@/components/ui/logo";
 
 const DEMO_EMAIL = process.env.NEXT_PUBLIC_DEMO_EMAIL ?? "";
@@ -13,6 +14,7 @@ type State = "idle" | "loading" | "error";
 function LoginForm() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [state, setState] = useState<State>("idle");
   const [errorMsg, setErrorMsg] = useState("");
   const searchParams = useSearchParams();
@@ -91,6 +93,7 @@ function LoginForm() {
               required
               placeholder="you@example.com"
               aria-invalid={state === "error"}
+              aria-describedby={state === "error" ? "login-error" : undefined}
               className="w-full rounded-lg px-4 py-2.5 text-sm"
               style={inputStyle}
             />
@@ -100,26 +103,60 @@ function LoginForm() {
             <label htmlFor="password" className="block text-sm mb-1.5" style={{ color: "var(--color-text-muted)" }}>
               Password
             </label>
-            <input
-              id="password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              placeholder="••••••••"
-              aria-invalid={state === "error"}
-              className="w-full rounded-lg px-4 py-2.5 text-sm"
-              style={inputStyle}
-            />
+            <div className="relative">
+              <input
+                id="password"
+                type={showPassword ? "text" : "password"}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                placeholder="••••••••"
+                aria-invalid={state === "error"}
+                aria-describedby={state === "error" ? "login-error" : undefined}
+                className="w-full rounded-lg px-4 py-2.5 text-sm"
+                style={{ ...inputStyle, paddingRight: 40 }}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((v) => !v)}
+                aria-label={showPassword ? "Hide password" : "Show password"}
+                aria-pressed={showPassword}
+                className="absolute top-1/2 -translate-y-1/2 right-2 flex items-center justify-center"
+                style={{
+                  background: "transparent",
+                  border: "none",
+                  color: "var(--color-text-muted)",
+                  cursor: "pointer",
+                  padding: 6,
+                  borderRadius: 4,
+                }}
+              >
+                {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            </div>
           </div>
 
           {state === "error" && (
-            <p className="text-sm" style={{ color: "var(--color-danger)" }}>{errorMsg || "Invalid email or password."}</p>
+            <p id="login-error" role="alert" className="text-sm" style={{ color: "var(--color-danger)" }}>
+              {errorMsg || "Invalid email or password."}
+            </p>
           )}
 
+          {(() => {
+            const emailInvalid = !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+            const pwInvalid = !password.trim();
+            const isDisabled = state === "loading" || emailInvalid || pwInvalid;
+            const disabledHint = emailInvalid
+              ? "Enter a valid email"
+              : pwInvalid
+                ? "Enter your password"
+                : undefined;
+            return (
           <button
             type="submit"
-            disabled={state === "loading" || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) || !password.trim()}
+            disabled={isDisabled}
+            aria-disabled={isDisabled}
+            title={isDisabled ? disabledHint : undefined}
             className="w-full rounded-lg px-4 py-2.5 text-sm font-medium transition-opacity cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
             style={{ background: "var(--color-primary)", color: "#fff" }}
             onMouseEnter={(e) => { if (!(e.currentTarget as HTMLButtonElement).disabled) (e.currentTarget as HTMLElement).style.opacity = "0.9"; }}
@@ -127,6 +164,8 @@ function LoginForm() {
           >
             {state === "loading" ? "Signing in..." : "Sign in"}
           </button>
+            );
+          })()}
         </form>
 
         {DEMO_EMAIL && DEMO_PASSWORD && (

--- a/web/src/components/chat/chat-interface.tsx
+++ b/web/src/components/chat/chat-interface.tsx
@@ -224,9 +224,13 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
                 border: "1px solid var(--color-border)",
               }}
             >
-              <span className="flex gap-1">
+              <span
+                className="flex gap-1 motion-reduce:opacity-60"
+                role="status"
+                aria-label="Assistant is typing"
+              >
                 <span
-                  className="rounded-full animate-bounce"
+                  className="rounded-full motion-safe:animate-bounce"
                   style={{
                     width: 6,
                     height: 6,
@@ -235,7 +239,7 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
                   }}
                 />
                 <span
-                  className="rounded-full animate-bounce"
+                  className="rounded-full motion-safe:animate-bounce"
                   style={{
                     width: 6,
                     height: 6,
@@ -244,7 +248,7 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
                   }}
                 />
                 <span
-                  className="rounded-full animate-bounce"
+                  className="rounded-full motion-safe:animate-bounce"
                   style={{
                     width: 6,
                     height: 6,

--- a/web/src/components/chat/chat-page-client.tsx
+++ b/web/src/components/chat/chat-page-client.tsx
@@ -287,12 +287,16 @@ function ChatPageClientInner({
         // non-fatal — row remains active on server if request fails
       }
 
-      toast.show("Chat archived", () => {
-        setAllSessions((prev) =>
-          prev.map((s) => (s.id === sessionId ? { ...s, deleted_at: null } : s))
-        );
-        fetch(`/api/chat/sessions/${sessionId}/restore`, { method: "POST" }).catch(() => {});
-      });
+      toast.show(
+        "Chat archived",
+        () => {
+          setAllSessions((prev) =>
+            prev.map((s) => (s.id === sessionId ? { ...s, deleted_at: null } : s))
+          );
+          fetch(`/api/chat/sessions/${sessionId}/restore`, { method: "POST" }).catch(() => {});
+        },
+        10000
+      );
     },
     [allSessions, activeSessionId, loadSession, handleNewChat, toast, fetchSessions]
   );
@@ -406,10 +410,30 @@ function ChatPageClientInner({
         <div className="flex flex-col flex-1 min-w-0 min-h-0">
           {loadingSession ? (
             <div
-              className="flex flex-1 items-center justify-center"
-              style={{ color: "var(--color-text-muted)", fontSize: 14 }}
+              className="flex flex-1 flex-col gap-4 px-4 py-6"
+              role="status"
+              aria-label="Loading conversation"
             >
-              Loading conversation&hellip;
+              {[80, 55, 70].map((w, i) => (
+                <div key={i} className="flex flex-col gap-2" style={{ alignItems: i % 2 ? "flex-end" : "flex-start" }}>
+                  <div
+                    className="rounded-2xl animate-pulse"
+                    style={{
+                      width: `${w}%`,
+                      height: 14,
+                      background: "var(--color-surface-raised)",
+                    }}
+                  />
+                  <div
+                    className="rounded-2xl animate-pulse"
+                    style={{
+                      width: `${w - 20}%`,
+                      height: 14,
+                      background: "var(--color-surface-raised)",
+                    }}
+                  />
+                </div>
+              ))}
             </div>
           ) : (
             <ChatInterface

--- a/web/src/components/chat/message-bubble.tsx
+++ b/web/src/components/chat/message-bubble.tsx
@@ -12,6 +12,16 @@ function formatExactTime(d: Date): string {
   });
 }
 
+function formatExactDateTime(d: Date): string {
+  return d.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
 interface Props {
   message: Message;
 }
@@ -176,13 +186,14 @@ const MessageBubble = memo(function MessageBubble({ message }: Props) {
       {message.createdAt && (
         <span
           aria-hidden={!showTime}
+          title={formatExactDateTime(message.createdAt)}
           style={{
             fontSize: 10,
             color: "var(--color-text-muted)",
             padding: "2px 6px 0",
             opacity: showTime ? 1 : 0,
             transition: "opacity 120ms",
-            pointerEvents: "none",
+            pointerEvents: showTime ? "auto" : "none",
           }}
         >
           {formatExactTime(message.createdAt)}

--- a/web/src/components/chat/session-sheet.tsx
+++ b/web/src/components/chat/session-sheet.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as Dialog from "@radix-ui/react-dialog";
 import { Plus, X, Trash2, RotateCcw } from "lucide-react";
 import { useState } from "react";
 import type { SessionPreview } from "@/app/api/chat/sessions/route";
@@ -32,6 +33,10 @@ export default function SessionSheet({
   timeTick,
 }: Props) {
   const [archivedExpanded, setArchivedExpanded] = useState(false);
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const confirmingSession = confirmingId
+    ? sessions.find((s) => s.id === confirmingId)
+    : null;
 
   return (
     <Sheet
@@ -157,9 +162,9 @@ export default function SessionSheet({
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
-                      onArchive(s.id);
+                      setConfirmingId(s.id);
                     }}
-                    aria-label="Delete chat"
+                    aria-label="Archive chat"
                     style={{
                       position: "absolute",
                       right: 8,
@@ -265,6 +270,77 @@ export default function SessionSheet({
             )}
           </div>
         </div>
+
+        <Dialog.Root
+          open={confirmingId !== null}
+          onOpenChange={(o) => { if (!o) setConfirmingId(null); }}
+        >
+          <Dialog.Portal>
+            <Dialog.Overlay
+              className="fixed inset-0 z-[80]"
+              style={{ background: "rgba(0,0,0,0.6)" }}
+            />
+            <Dialog.Content
+              className="fixed left-1/2 top-1/2 z-[90] w-[calc(100vw-32px)] max-w-sm rounded-2xl"
+              style={{
+                transform: "translate(-50%, -50%)",
+                background: "var(--color-surface)",
+                border: "1px solid var(--color-border)",
+                padding: 20,
+              }}
+            >
+              <Dialog.Title
+                className="font-heading font-semibold"
+                style={{ fontSize: 16, color: "var(--color-text)" }}
+              >
+                Archive this chat?
+              </Dialog.Title>
+              <Dialog.Description
+                className="mt-2"
+                style={{ fontSize: 13, color: "var(--color-text-muted)" }}
+              >
+                {confirmingSession?.preview
+                  ? `"${confirmingSession.preview.slice(0, 80)}${confirmingSession.preview.length > 80 ? "…" : ""}" — you'll have 10 seconds to undo.`
+                  : "You'll have 10 seconds to undo."}
+              </Dialog.Description>
+              <div className="flex items-center justify-end gap-2" style={{ marginTop: 20 }}>
+                <button
+                  onClick={() => setConfirmingId(null)}
+                  style={{
+                    background: "transparent",
+                    border: "1px solid var(--color-border)",
+                    color: "var(--color-text)",
+                    padding: "8px 14px",
+                    borderRadius: 8,
+                    fontSize: 13,
+                    fontWeight: 500,
+                    cursor: "pointer",
+                  }}
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={() => {
+                    if (confirmingId) onArchive(confirmingId);
+                    setConfirmingId(null);
+                  }}
+                  style={{
+                    background: "var(--color-danger)",
+                    border: "none",
+                    color: "white",
+                    padding: "8px 14px",
+                    borderRadius: 8,
+                    fontSize: 13,
+                    fontWeight: 500,
+                    cursor: "pointer",
+                  }}
+                >
+                  Archive
+                </button>
+              </div>
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog.Root>
     </Sheet>
   );
 }


### PR DESCRIPTION
Closes #217.

## Summary
Eight polish items bundled:

- **Per-page metadata** on every protected page (+ login via a server-shell `layout.tsx`). Root layout now defines a `"%s · Mr. Bridge"` title template.
- **Error boundaries** at [`app/error.tsx`](web/src/app/error.tsx) and [`app/(protected)/error.tsx`](web/src/app/(protected)/error.tsx) — friendly copy, Retry, Dashboard fallback.
- **Skip link** at the top of [`(protected)/layout.tsx`](web/src/app/(protected)/layout.tsx) — visible on focus, jumps to `#main-content`.
- **Login polish**: password visibility toggle (`Eye`/`EyeOff`, `aria-pressed`), `aria-describedby` on inputs linked to the error `<p>`, `aria-disabled` + contextual `title` on submit.
- **Chat timestamp**: hover tooltip (`title=`) now includes full date.
- **Session-switch skeleton**: 3-row shimmer (with `role="status"`) replaces the static "Loading…" line.
- **Reduced-motion typing dots**: `motion-safe:animate-bounce` + `motion-reduce:opacity-60` fallback; container is `role="status" aria-label="Assistant is typing"`.
- **Archive confirmation + 10s undo**: Radix Dialog confirmation (Cancel / Archive) before firing; undo window bumped 5s → 10s.

## Test plan
- [ ] Each tab (dashboard, chat, settings, fitness, habits, journal, meals, notifications, tasks, weekly, login) shows a unique browser title.
- [ ] Throw inside any protected page → protected `error.tsx` renders; Retry recovers; Dashboard link works.
- [ ] First Tab press on a protected page focuses the skip link; Enter jumps past the sidebar.
- [ ] Login: click eye → password visible; disable form → hover submit shows the hint `title`; trigger error → screen reader reads error via `aria-describedby`.
- [ ] Long-press / hover a chat message's timestamp → full date visible.
- [ ] Switch chat sessions → skeleton while loading, not static text.
- [ ] macOS System → Accessibility → Reduce Motion ON → typing dots stop bouncing but remain visible.
- [ ] Archive a chat → confirmation dialog appears; Archive → toast with Undo; Undo works within 10s (not 5s).
- [ ] Light + dark at 375 / 768 / 1024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)