### PR TITLE
feat(meals): re-log past meals + ingredient-based macro re-estimate (#220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (re-log past meals — issue #220)
+- **`web/src/components/meals/MealsClient.tsx`** — "Log again" `RefreshCw` icon button on each Today-tab meal row; tap pre-fills the quick-log form (dish name + macros + meal type), scrolls the form into view, and focuses the Log button. Save path unchanged — creates a new `meal_log` row with today's date; the original row is never mutated.
+- **Recent meals section** on the Today tab — renders up to 10 unique dishes from the past 7 days (pulled from existing SSR `pastMeals` prop), deduped by a normalized dish name (lowercase, punctuation stripped). Section is hidden entirely when there's no history (brand-new account).
+- **Estimate macros button + Ingredients textarea** in the quick-log form — collapsible ephemeral textarea (not persisted) for the user to type a full ingredient list OR just a modification (e.g. "added 4oz chicken"). Hits `/api/meals/estimate-macros`, which was extended to accept `dish_name` + `current_macros` as context; when both are present it treats the textarea as additions/modifications to the base dish rather than a full replacement. Macro fields + meal type are overwritten with the AI estimate.
+
 ### Added (UX polish bundle — issue #217)
 - **`web/src/app/error.tsx`** — top-level error boundary with friendly copy, Retry button calling Next.js `reset()`.
 - **`web/src/app/(protected)/error.tsx`** — protected route error boundary with Retry + "Dashboard" fallback link.

--- a/web/src/app/api/meals/estimate-macros/route.ts
+++ b/web/src/app/api/meals/estimate-macros/route.ts
@@ -29,27 +29,46 @@ export async function POST(req: Request) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  let body: { ingredients: string };
+  let body: {
+    ingredients: string;
+    dish_name?: string;
+    current_macros?: { calories?: number; protein_g?: number; carbs_g?: number; fat_g?: number };
+  };
   try {
     body = await req.json();
   } catch {
     return Response.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  if (!body.ingredients?.trim()) {
-    return Response.json({ error: "ingredients is required" }, { status: 400 });
+  const ingredients = body.ingredients?.trim() ?? "";
+  const dishName = body.dish_name?.trim() ?? "";
+  if (!ingredients && !dishName) {
+    return Response.json({ error: "ingredients or dish_name is required" }, { status: 400 });
   }
 
-  try {
-    const { object } = await generateObject({
-      model: anthropic("claude-haiku-4-5-20251001"),
-      schema: MacroEstimateSchema,
-      messages: [
-        {
-          role: "user",
-          content: `Estimate the nutritional content of a meal with these ingredients:
+  const cm = body.current_macros;
+  const hasCurrent = cm && (cm.calories != null || cm.protein_g != null || cm.carbs_g != null || cm.fat_g != null);
 
-"${body.ingredients.trim()}"
+  const prompt = hasCurrent && dishName
+    ? `A user already logged a meal and now wants to adjust its macros.
+
+Base dish: "${dishName}"
+Current macros: ${cm!.calories ?? "?"} cal, P ${cm!.protein_g ?? "?"}g, C ${cm!.carbs_g ?? "?"}g, F ${cm!.fat_g ?? "?"}g
+
+User's modification / additional ingredients:
+"${ingredients || "(none — just re-estimate the base dish)"}"
+
+Instructions:
+- Treat the user's modification as ADDITIONS or CHANGES to the base dish, not a full replacement
+- Start from the current macros and adjust up or down based on what the user added/removed/changed
+- If the modification text is vague (e.g. "added some chicken"), assume a reasonable single-serving quantity (e.g. ~3-4oz for chicken)
+- Use conservative estimates — do not inflate
+- Return the NEW TOTAL macros for the adjusted meal, not just the delta
+- Set confidence to "medium" for vague modifications, "high" for specific quantities
+- Include what you assumed for the modification in notes`
+    : `Estimate the nutritional content of a meal with these ingredients:
+
+"${ingredients || dishName}"
 
 Instructions:
 - Use the listed ingredients and quantities to estimate macros
@@ -57,9 +76,13 @@ Instructions:
 - Use conservative estimates — do not inflate
 - Set confidence to "high" if ingredients and quantities are clearly specified
 - Set confidence to "low" if ingredients are vague or quantities are absent
-- Include any key assumptions in notes`,
-        },
-      ],
+- Include any key assumptions in notes`;
+
+  try {
+    const { object } = await generateObject({
+      model: anthropic("claude-haiku-4-5-20251001"),
+      schema: MacroEstimateSchema,
+      messages: [{ role: "user", content: prompt }],
     });
 
     return Response.json(object);

--- a/web/src/components/meals/MealsClient.tsx
+++ b/web/src/components/meals/MealsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { MessageSquare, ChevronDown, ChevronUp, RefreshCw, Loader2 } from "lucide-react";
 import Link from "next/link";
@@ -79,6 +79,12 @@ const MEAL_ORDER: Record<string, number> = {
 const MEAL_TYPES = ["breakfast", "lunch", "dinner", "snack"] as const;
 type MealType = typeof MEAL_TYPES[number];
 
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function normalizeName(s: string | null | undefined): string {
+  return (s ?? "").toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+}
+
 // ─── Shared styles ────────────────────────────────────────────────────────────
 
 const inputStyle = {
@@ -152,10 +158,12 @@ function MacroBar({ label, unit, consumed, goal }: MacroBarProps) {
 
 function TodayTab({
   todayMeals,
+  pastMeals,
   macroGoals,
   macroTotals,
 }: {
   todayMeals: MealRow[];
+  pastMeals: MealRow[];
   macroGoals: MacroGoals;
   macroTotals: MacroTotals;
 }) {
@@ -168,6 +176,72 @@ function TodayTab({
   const [logCarbs, setLogCarbs] = useState("");
   const [logFat, setLogFat] = useState("");
   const [logging, setLogging] = useState(false);
+  const [reanalyzing, setReanalyzing] = useState(false);
+  const [ingredientsOpen, setIngredientsOpen] = useState(false);
+  const [logIngredients, setLogIngredients] = useState("");
+  const logSaveRef = useRef<HTMLButtonElement>(null);
+  const quickLogRef = useRef<HTMLDivElement>(null);
+
+  function prefillLog(m: MealRow) {
+    const name = m.recipes?.name ?? m.notes ?? "";
+    setLogDesc(name);
+    setLogMealType((MEAL_TYPES as readonly string[]).includes(m.meal_type) ? (m.meal_type as MealType) : "breakfast");
+    setLogCal(m.calories != null ? String(m.calories) : "");
+    setLogProtein(m.protein_g != null ? String(m.protein_g) : "");
+    setLogCarbs(m.carbs_g != null ? String(m.carbs_g) : "");
+    setLogFat(m.fat_g != null ? String(m.fat_g) : "");
+    if (m.calories != null || m.protein_g != null || m.carbs_g != null || m.fat_g != null) {
+      setMacrosOpen(true);
+    }
+    quickLogRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+    setTimeout(() => logSaveRef.current?.focus(), 250);
+  }
+
+  async function handleReanalyze() {
+    if (!logIngredients.trim() && !logDesc.trim()) return;
+    setReanalyzing(true);
+    try {
+      const current_macros = {
+        calories: logCal ? Number(logCal) : undefined,
+        protein_g: logProtein ? Number(logProtein) : undefined,
+        carbs_g: logCarbs ? Number(logCarbs) : undefined,
+        fat_g: logFat ? Number(logFat) : undefined,
+      };
+      const res = await fetch("/api/meals/estimate-macros", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ingredients: logIngredients.trim(),
+          dish_name: logDesc.trim(),
+          current_macros,
+        }),
+      });
+      if (!res.ok) return;
+      const est = await res.json();
+      if (est.calories != null) setLogCal(String(est.calories));
+      if (est.protein_g != null) setLogProtein(String(est.protein_g));
+      if (est.carbs_g != null) setLogCarbs(String(est.carbs_g));
+      if (est.fat_g != null) setLogFat(String(est.fat_g));
+      if (est.meal_type_guess && (MEAL_TYPES as readonly string[]).includes(est.meal_type_guess)) {
+        setLogMealType(est.meal_type_guess as MealType);
+      }
+      setMacrosOpen(true);
+    } finally {
+      setReanalyzing(false);
+    }
+  }
+
+  const recentMeals = useMemo(() => {
+    const byKey = new Map<string, MealRow>();
+    const sorted = [...pastMeals].sort((a, b) => (a.date < b.date ? 1 : -1));
+    for (const m of sorted) {
+      const key = normalizeName(m.recipes?.name ?? m.notes);
+      if (!key) continue;
+      if (!byKey.has(key)) byKey.set(key, m);
+    }
+    return Array.from(byKey.values()).slice(0, 10);
+  }, [pastMeals]);
+
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editFields, setEditFields] = useState<{
     notes: string; meal_type: string; calories: string; protein_g: string; carbs_g: string; fat_g: string;
@@ -241,6 +315,8 @@ function TodayTab({
       setLogProtein("");
       setLogCarbs("");
       setLogFat("");
+      setLogIngredients("");
+      setIngredientsOpen(false);
       setMacrosOpen(false);
       router.refresh();
     } finally {
@@ -382,7 +458,7 @@ function TodayTab({
                       >
                         {m.meal_type}
                       </span>
-                      <div>
+                      <div style={{ flex: 1, minWidth: 0 }}>
                         <span style={{ fontSize: 14, color: "var(--color-text)" }}>
                           {m.recipes?.name ?? m.notes ?? "—"}
                         </span>
@@ -392,6 +468,24 @@ function TodayTab({
                           </span>
                         )}
                       </div>
+                      <button
+                        type="button"
+                        onClick={(e) => { e.stopPropagation(); prefillLog(m); }}
+                        aria-label="Log again"
+                        title="Log again"
+                        style={{
+                          padding: 4,
+                          color: "var(--color-text-muted)",
+                          background: "transparent",
+                          border: "none",
+                          cursor: "pointer",
+                          display: "flex",
+                          alignItems: "center",
+                          flexShrink: 0,
+                        }}
+                      >
+                        <RefreshCw size={14} />
+                      </button>
                     </div>
                   )}
                 </div>
@@ -404,6 +498,7 @@ function TodayTab({
         <div style={{ borderTop: "1px solid var(--color-border)", marginBottom: 14 }} />
 
         {/* Quick-log form */}
+        <div ref={quickLogRef}>
         <p
           className="text-xs uppercase tracking-widest mb-3"
           style={{ color: "var(--color-text-faint)", letterSpacing: "0.07em" }}
@@ -431,6 +526,7 @@ function TodayTab({
             style={{ ...inputStyle, flex: 1 }}
           />
           <button
+            ref={logSaveRef}
             onClick={handleLog}
             disabled={logging || !logDesc.trim()}
             className="flex items-center justify-center rounded-xl font-medium transition-opacity active:opacity-70 disabled:opacity-40"
@@ -447,14 +543,50 @@ function TodayTab({
           </button>
         </div>
 
-        <button
-          onClick={() => setMacrosOpen((v) => !v)}
-          className="flex items-center gap-1 transition-opacity active:opacity-70"
-          style={{ fontSize: 12, color: "var(--color-primary)", background: "none", border: "none", cursor: "pointer", padding: "2px 0" }}
-        >
-          {macrosOpen ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
-          Add macros
-        </button>
+        <div className="flex items-center gap-4 flex-wrap">
+          <button
+            onClick={() => setMacrosOpen((v) => !v)}
+            className="flex items-center gap-1 transition-opacity active:opacity-70"
+            style={{ fontSize: 12, color: "var(--color-primary)", background: "none", border: "none", cursor: "pointer", padding: "2px 0" }}
+          >
+            {macrosOpen ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+            Add macros
+          </button>
+          <button
+            onClick={() => setIngredientsOpen((v) => !v)}
+            className="flex items-center gap-1 transition-opacity active:opacity-70"
+            style={{ fontSize: 12, color: "var(--color-primary)", background: "none", border: "none", cursor: "pointer", padding: "2px 0" }}
+          >
+            {ingredientsOpen ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+            Ingredients
+          </button>
+          <button
+            type="button"
+            onClick={handleReanalyze}
+            disabled={(!logIngredients.trim() && !logDesc.trim()) || reanalyzing}
+            className="flex items-center gap-1 transition-opacity active:opacity-70 disabled:opacity-40"
+            title={logIngredients.trim() ? "Estimate macros from ingredients" : "Estimate macros from dish name"}
+            style={{ fontSize: 12, color: "var(--color-primary)", background: "none", border: "none", cursor: "pointer", padding: "2px 0" }}
+          >
+            {reanalyzing ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
+            Estimate macros
+          </button>
+        </div>
+
+        {ingredientsOpen && (
+          <div className="mt-3 pt-3" style={{ borderTop: "1px solid var(--color-border)" }}>
+            <label style={{ display: "block", fontSize: 11, color: "var(--color-text-muted)", marginBottom: 4 }}>
+              Ingredients or modifications (optional)
+            </label>
+            <textarea
+              value={logIngredients}
+              onChange={(e) => setLogIngredients(e.target.value)}
+              placeholder="e.g. &quot;added 4oz chicken&quot; or full list: &quot;6oz salmon, 1 cup rice, 1 tbsp oil&quot;"
+              rows={3}
+              style={{ ...inputStyle, fontSize: 13, resize: "vertical", fontFamily: "inherit" }}
+            />
+          </div>
+        )}
 
         {macrosOpen && (
           <div
@@ -483,7 +615,86 @@ function TodayTab({
             ))}
           </div>
         )}
+        </div>
       </div>
+
+      {/* Recent meals (deduped past 7 days) */}
+      {recentMeals.length > 0 && (
+        <div
+          className="rounded-xl p-5"
+          style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+        >
+          <p
+            className="text-xs uppercase tracking-widest mb-4"
+            style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}
+          >
+            Recent meals
+          </p>
+          <div className="space-y-2">
+            {recentMeals.map((m) => {
+              const hasMacros = m.calories != null || m.protein_g != null;
+              const macroStr = hasMacros
+                ? [
+                    m.calories != null && `${m.calories} cal`,
+                    m.protein_g != null && `P ${m.protein_g}g`,
+                    m.carbs_g != null && `C ${m.carbs_g}g`,
+                    m.fat_g != null && `F ${m.fat_g}g`,
+                  ]
+                    .filter(Boolean)
+                    .join(" · ")
+                : null;
+              return (
+                <div
+                  key={m.id}
+                  className="flex items-baseline gap-3"
+                  onClick={() => prefillLog(m)}
+                  style={{ cursor: "pointer" }}
+                >
+                  <span
+                    style={{
+                      fontSize: 11,
+                      fontWeight: 500,
+                      color: "var(--color-text-muted)",
+                      textTransform: "capitalize",
+                      minWidth: 64,
+                    }}
+                  >
+                    {m.meal_type}
+                  </span>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <span style={{ fontSize: 14, color: "var(--color-text)" }}>
+                      {m.recipes?.name ?? m.notes ?? "—"}
+                    </span>
+                    {macroStr && (
+                      <span style={{ fontSize: 11, color: "var(--color-text-faint)", marginLeft: 8 }}>
+                        {macroStr}
+                      </span>
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={(e) => { e.stopPropagation(); prefillLog(m); }}
+                    aria-label="Log again"
+                    title="Log again"
+                    style={{
+                      padding: 4,
+                      color: "var(--color-text-muted)",
+                      background: "transparent",
+                      border: "none",
+                      cursor: "pointer",
+                      display: "flex",
+                      alignItems: "center",
+                      flexShrink: 0,
+                    }}
+                  >
+                    <RefreshCw size={14} />
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       {/* Log via chat nudge */}
       <div
@@ -1051,6 +1262,7 @@ export default function MealsClient({
       {tab === "today" && (
         <TodayTab
           todayMeals={todayMeals}
+          pastMeals={pastMeals}
           macroGoals={macroGoals}
           macroTotals={macroTotals}
         />


### PR DESCRIPTION
## Summary
- **"Log again" button** on each Today-tab meal row — prefills the quick-log form (dish + macros + meal type), scrolls the form into view, focuses the Log button. Save creates a new `meal_log` row; original is never mutated.
- **"Recent meals" section** on the Today tab — up to 10 unique dishes from the past 7 days (existing SSR `pastMeals` prop), deduped by a normalized dish name (lowercase, punctuation stripped). Hidden entirely when there's no history.
- **Ingredients textarea + Estimate macros button** in the quick-log form. `/api/meals/estimate-macros` now accepts optional `dish_name` + `current_macros`; when both are present, it treats the textarea as *modifications* to the base dish ("added 4oz chicken") rather than a full replacement, so macros adjust up/down instead of being recomputed from the delta alone.

No schema changes. No new API routes.

Closes #220.

## Test plan
- [ ] Log a meal → `RefreshCw` icon appears on the row; tap it → quick-log prefills, scrolls into view, Log button focuses → Save → new row with today's date; original untouched.
- [ ] "Recent meals" section shows past-week dishes; "Chicken Rice" + "chicken  rice!" collapse to one entry.
- [ ] Brand-new / empty account → no "Recent meals" section renders.
- [ ] Prefill a meal, expand **Ingredients**, type "added some chicken", tap **Estimate macros** → macros go *up* from the base, not down.
- [ ] Prefill a meal, expand **Ingredients**, type a full ingredient list, tap **Estimate macros** → macros replace with fresh estimate.
- [ ] Existing edit/delete flows on today's rows still work (clicking the row, not the button, enters edit mode).
- [ ] Both light and dark themes render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)