### PR TITLE
fix: mobile chat keyboard / composer / FAB overlap (#226)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (mobile chat keyboard / composer / FAB overlap — issue #226)
+- **`web/src/lib/use-keyboard-open.ts`** (new) — `useKeyboardOpen()` hook subscribes to `window.visualViewport` and returns `{ isKeyboardOpen, viewportHeight }`. Heuristic: keyboard open when `vv.height < window.innerHeight - 100`. SSR-safe.
+- **`web/src/components/chat/chat-page-client.tsx`** — mobile new-chat FAB hides while the keyboard is open so it no longer floats above the iOS keyboard.
+- **`web/src/components/chat/chat-interface.tsx`** — composer `maxHeight` (textarea auto-resize cap and inline style) clamps to `min(200, viewportHeight * 0.3)` while the keyboard is open, preserving room for message-history scroll. Load-older-messages button shows `Loader2 + "Loading…"` instead of icon-only.
+- **`web/src/components/nav.tsx`** — demo banner is hidden on `/chat` routes (was overlapping chat messages on short threads).
+- **`web/src/app/globals.css`** — added `.scroll-fade-mask` utility (bottom 16px linear-gradient mask) for truncated scroll regions.
+- **`web/src/components/dashboard/tasks-summary.tsx`, `web/src/components/dashboard/habits-checkin.tsx`** — apply `scroll-fade-mask` so users see overflow indication on capped lists.
+
 ### Added (habit `icon_key` column + picker — issue #225)
 - **`supabase/migrations/20260415000003_habit_registry_icon_key.sql`** — adds nullable `icon_key TEXT` to `habit_registry` and backfills existing rows by mirroring the `getHabitIcon` derivation in SQL (category match → name keyword → `target`). **Apply manually in Supabase SQL editor before deploying.**
 - **`web/src/components/habits/habit-icon-picker.tsx`** (new) — radiogroup of 14 Lucide icons (Target, Dumbbell, HeartPulse, Moon, Droplet, Footprints, BookOpen, Code2, GraduationCap, Brain, NotebookPen, Sparkles, Smile, Ban). Inline in the add form ([habit-today-section.tsx](web/src/components/habits/habit-today-section.tsx)) and the edit form ([habit-toggle.tsx](web/src/components/habits/habit-toggle.tsx)).

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -126,6 +126,12 @@ body {
   background: var(--color-text-faint);
 }
 
+/* ─── Scroll fade mask (bottom fade for truncated lists) ─────────────── */
+.scroll-fade-mask {
+  -webkit-mask-image: linear-gradient(to bottom, black calc(100% - 16px), transparent);
+          mask-image: linear-gradient(to bottom, black calc(100% - 16px), transparent);
+}
+
 /* ─── Skeleton shimmer ────────────────────────────────────────────────── */
 @keyframes shimmer {
   0%   { background-position: -200% center; }

--- a/web/src/components/chat/chat-interface.tsx
+++ b/web/src/components/chat/chat-interface.tsx
@@ -8,6 +8,7 @@ import MessageBubble from "./message-bubble";
 import ToolStatusBar from "./tool-status-bar";
 import SlashCommandMenu, { SLASH_COMMANDS, type SlashCommand } from "./slash-command-menu";
 import { formatDaySeparator, isSameDay } from "@/lib/relative-time";
+import { useKeyboardOpen } from "@/lib/use-keyboard-open";
 import type { Message } from "ai";
 
 interface Props {
@@ -40,6 +41,11 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
   useEffect(() => {
     setIsTouchDevice(window.matchMedia("(pointer: coarse)").matches);
   }, []);
+
+  const { isKeyboardOpen, viewportHeight } = useKeyboardOpen();
+  const composerMaxHeight = isKeyboardOpen
+    ? Math.max(80, Math.min(200, viewportHeight * 0.3))
+    : 200;
 
   type ModelOverride = "auto" | "haiku" | "sonnet";
   const [modelOverride, setModelOverride] = useState<ModelOverride>("auto");
@@ -162,8 +168,8 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
     const el = inputRef.current;
     if (!el) return;
     el.style.height = "auto";
-    el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
-  }, [input]);
+    el.style.height = `${Math.min(el.scrollHeight, composerMaxHeight)}px`;
+  }, [input, composerMaxHeight]);
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -188,10 +194,14 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
                 color: "var(--color-text-muted)",
               }}
             >
-              {loadingMore
-                ? <Loader2 size={12} className="animate-spin" />
-                : "Load older messages"
-              }
+              {loadingMore ? (
+                <>
+                  <Loader2 size={12} className="animate-spin" />
+                  Loading…
+                </>
+              ) : (
+                "Load older messages"
+              )}
             </button>
           </div>
         )}
@@ -321,7 +331,7 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
             style={{
               resize: "none",
               overflow: "hidden",
-              maxHeight: 200,
+              maxHeight: composerMaxHeight,
               overflowY: "auto",
               background: "var(--color-surface)",
               border: "1px solid var(--color-border)",

--- a/web/src/components/chat/chat-page-client.tsx
+++ b/web/src/components/chat/chat-page-client.tsx
@@ -7,6 +7,7 @@ import ChatInterface from "./chat-interface";
 import SessionSidebar from "./session-sidebar";
 import SessionSheet from "./session-sheet";
 import { UndoToastProvider, useUndoToast } from "@/components/ui/undo-toast";
+import { useKeyboardOpen } from "@/lib/use-keyboard-open";
 import type { SessionPreview } from "@/app/api/chat/sessions/route";
 
 interface Props {
@@ -46,6 +47,7 @@ function ChatPageClientInner({
 
   const [historyOpen, setHistoryOpen] = useState(false);
   const [showSheet, setShowSheet] = useState(false);
+  const { isKeyboardOpen } = useKeyboardOpen();
 
   const [allSessions, setAllSessions] = useState<SessionPreview[]>([]);
   const [loadingSession, setLoadingSession] = useState(false);
@@ -465,7 +467,7 @@ function ChatPageClientInner({
       />
 
       {/* Mobile new-chat FAB */}
-      {!showSheet && (
+      {!showSheet && !isKeyboardOpen && (
         <button
           onClick={handleNewChat}
           aria-label="New chat"

--- a/web/src/components/dashboard/habits-checkin.tsx
+++ b/web/src/components/dashboard/habits-checkin.tsx
@@ -82,7 +82,7 @@ export default function HabitsCheckin({ registry, todayLogs, streaks, toggleActi
       </div>
 
       {/* Habit rows */}
-      <div className="space-y-0.5 overflow-y-auto" style={{ maxHeight: 200 }}>
+      <div className="space-y-0.5 overflow-y-auto scroll-fade-mask" style={{ maxHeight: 200 }}>
         {registry.map((habit) => {
           const done = completedMap.get(habit.id) ?? false;
           const isPending = pendingSet.has(habit.id);

--- a/web/src/components/dashboard/tasks-summary.tsx
+++ b/web/src/components/dashboard/tasks-summary.tsx
@@ -55,7 +55,7 @@ export default function TasksSummary({ tasks }: Props) {
 
       {/* All tasks with inner scroll */}
       {topTasks.length > 0 && (
-        <div className="mt-3 space-y-1.5 overflow-y-auto" style={{ maxHeight: 160 }}>
+        <div className="mt-3 space-y-1.5 overflow-y-auto scroll-fade-mask" style={{ maxHeight: 160 }}>
           {topTasks.map((t) => {
             const dot = PRIORITY_COLOR[t.priority ?? "low"] ?? PRIORITY_COLOR.low;
             return (

--- a/web/src/components/nav.tsx
+++ b/web/src/components/nav.tsx
@@ -174,8 +174,8 @@ export default function Nav() {
         </div>
       </nav>
 
-      {/* Demo banner — mobile (above tab bar) */}
-      {isDemo && (
+      {/* Demo banner — mobile (above tab bar). Hidden on /chat to avoid overlapping the composer. */}
+      {isDemo && !pathname?.startsWith("/chat") && (
         <div
           className="lg:hidden fixed left-0 right-0 z-40 px-4 py-1.5 text-center text-xs"
           style={{ bottom: 56, background: "var(--color-primary-dim)", color: "var(--color-primary)" }}

--- a/web/src/lib/use-keyboard-open.ts
+++ b/web/src/lib/use-keyboard-open.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface KeyboardState {
+  isKeyboardOpen: boolean;
+  viewportHeight: number;
+}
+
+export function useKeyboardOpen(): KeyboardState {
+  const [state, setState] = useState<KeyboardState>({
+    isKeyboardOpen: false,
+    viewportHeight: 0,
+  });
+
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+
+    const update = () => {
+      setState({
+        isKeyboardOpen: vv.height < window.innerHeight - 100,
+        viewportHeight: vv.height,
+      });
+    };
+
+    update();
+    vv.addEventListener("resize", update);
+    vv.addEventListener("scroll", update);
+    return () => {
+      vv.removeEventListener("resize", update);
+      vv.removeEventListener("scroll", update);
+    };
+  }, []);
+
+  return state;
+}


### PR DESCRIPTION
Closes #226.

## Summary
- New `useKeyboardOpen()` hook (`web/src/lib/use-keyboard-open.ts`) reads `window.visualViewport` to detect iOS keyboard open (`vv.height < innerHeight - 100`).
- Mobile new-chat FAB hides while keyboard is open (no longer floats above the keyboard).
- Composer textarea cap clamps to `min(200, viewportHeight * 0.3)` while keyboard is open, so message history stays scrollable mid-compose.
- Demo banner hidden on `/chat` (was overlapping messages on short threads).
- `.scroll-fade-mask` utility + applied to dashboard tasks/habits widgets for overflow affordance.
- Load-older-messages button shows `Loader2 + "Loading…"` while in flight.

## Files
- `web/src/lib/use-keyboard-open.ts` (new)
- `web/src/components/chat/chat-page-client.tsx`
- `web/src/components/chat/chat-interface.tsx`
- `web/src/components/nav.tsx`
- `web/src/app/globals.css`
- `web/src/components/dashboard/tasks-summary.tsx`
- `web/src/components/dashboard/habits-checkin.tsx`
- `CHANGELOG.md`

## Test plan
- [ ] **Real iOS Safari** at 375px: focus composer → FAB disappears, textarea grows but stops at ~30% viewport, can scroll older messages while keyboard open. *(Not yet verified — author has no iOS device available in dev environment; needs hands-on QA before merge.)*
- [ ] iOS PWA (Add to Home Screen) — same flow.
- [ ] Android Chrome — same flow.
- [ ] Dashboard at 375px: tasks + habits widgets show bottom fade when content overflows.
- [ ] `?demo=1` (or `NEXT_PUBLIC_DEMO_EMAIL` user): banner hidden on /chat, visible on /dashboard.
- [ ] Trigger "Load older messages" → spinner + "Loading…" appears.
- [x] `tsc --noEmit` passes.

## Notes
- TS typecheck passes locally. No iOS device available to verify the keyboard heuristic; the 100px threshold is a common value but may need tuning. Visible-viewport API is supported in iOS Safari 13+.
- Heuristic is `vv.height < window.innerHeight - 100`. If false-positive on devices with software-bottom-bar (e.g., some Androids), bump the threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)