### PR TITLE
chore: sweep inline-style hover handlers to CSS/Tailwind (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed (hover-handler sweep → CSS / Tailwind — issue #227)
+- **`web/src/app/globals.css`** — added hover utility classes (`.hover-text-brighten`, `.hover-text-danger`, `.hover-text-muted`, `.hover-bg-subtle`, `.hover-bg-border`, `.hover-bg-raised`, `.hover-border-strong`) that override inline-style base colors via `!important` on `:hover`. Paired with `transition-colors` / `transition-opacity` they deliver the 150ms MASTER.md spec.
+- **Mechanical sweep across 10 components** — removed `onMouseEnter`/`onMouseLeave` inline-style writes in [login/page.tsx](web/src/app/login/page.tsx), [chat/chat-interface.tsx](web/src/components/chat/chat-interface.tsx), [chat/chat-page-client.tsx](web/src/components/chat/chat-page-client.tsx), [chat/session-sidebar.tsx](web/src/components/chat/session-sidebar.tsx), [ui/sign-out-button.tsx](web/src/components/ui/sign-out-button.tsx), [theme-toggle.tsx](web/src/components/theme-toggle.tsx), [dashboard/habits-checkin.tsx](web/src/components/dashboard/habits-checkin.tsx), [ui/metric-card.tsx](web/src/components/ui/metric-card.tsx), [dashboard/sync-button.tsx](web/src/components/dashboard/sync-button.tsx), [dashboard/recent-workouts-table.tsx](web/src/components/dashboard/recent-workouts-table.tsx). Buttons with opacity hovers use native Tailwind `hover:opacity-85` / `hover:opacity-90`. Remaining `onMouseEnter`/`onMouseLeave` callsites (message-bubble reveal, slash-command-menu active index, heatmap tooltip) are state-driven and kept.
+- **`web/src/components/chat/session-sidebar.tsx`** — `SessionRow` dropped `hoveredId` state in favor of `group/row` + `group-hover/row:` utilities; delete button now always rendered but `opacity-0 group-hover/row:opacity-100` (keyboard-focus-visible also reveals it).
+- **`web/src/components/theme-toggle.tsx`** (M2) — removed the `mounted` gate on `aria-label` / `title`. SSR label is now `Theme: System. Click to change.` (the correct default before `next-themes` resolves), not the generic "Theme toggle".
+
 ### Fixed (mobile chat keyboard / composer / FAB overlap — issue #226)
 - **`web/src/lib/use-keyboard-open.ts`** (new) — `useKeyboardOpen()` hook subscribes to `window.visualViewport` and returns `{ isKeyboardOpen, viewportHeight }`. Heuristic: keyboard open when `vv.height < window.innerHeight - 100`. SSR-safe.
 - **`web/src/components/chat/chat-page-client.tsx`** — mobile new-chat FAB hides while the keyboard is open so it no longer floats above the iOS keyboard.

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -150,6 +150,18 @@ body {
   border-radius: 6px;
 }
 
+/* ─── Hover utilities ─────────────────────────────────────────────────── */
+/* Used where base color/background is set via inline style; !important is
+   required to win against the inline declaration. Pair with a
+   `transition-colors` / `transition-opacity` class for smooth 150ms changes. */
+.hover-text-brighten:hover { color: var(--color-text) !important; }
+.hover-text-danger:hover   { color: var(--color-danger) !important; }
+.hover-bg-subtle:hover     { background: var(--hover-subtle) !important; }
+.hover-bg-border:hover     { background: var(--color-border) !important; }
+.hover-bg-raised:hover     { background: var(--color-surface-raised) !important; }
+.hover-text-muted:hover    { color: var(--color-text-muted) !important; }
+.hover-border-strong:hover { border-color: var(--color-text-faint) !important; }
+
 /* ─── Reduced motion ──────────────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -157,10 +157,8 @@ function LoginForm() {
             disabled={isDisabled}
             aria-disabled={isDisabled}
             title={isDisabled ? disabledHint : undefined}
-            className="w-full rounded-lg px-4 py-2.5 text-sm font-medium transition-opacity cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+            className="w-full rounded-lg px-4 py-2.5 text-sm font-medium transition-opacity duration-150 cursor-pointer hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:opacity-40"
             style={{ background: "var(--color-primary)", color: "var(--color-text-on-cta)" }}
-            onMouseEnter={(e) => { if (!(e.currentTarget as HTMLButtonElement).disabled) (e.currentTarget as HTMLElement).style.opacity = "0.9"; }}
-            onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.opacity = "1"; }}
           >
             {state === "loading" ? "Signing in..." : "Sign in"}
           </button>

--- a/web/src/components/chat/chat-interface.tsx
+++ b/web/src/components/chat/chat-interface.tsx
@@ -286,10 +286,8 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
               </span>
               <button
                 onClick={() => reload()}
-                className="cursor-pointer transition-colors duration-150"
+                className="cursor-pointer transition-colors duration-150 hover-text-brighten"
                 style={{ fontSize: 12, color: "var(--color-text-muted)", textDecoration: "underline", textUnderlineOffset: 2 }}
-                onMouseEnter={(e) => ((e.target as HTMLElement).style.color = "var(--color-text)")}
-                onMouseLeave={(e) => ((e.target as HTMLElement).style.color = "var(--color-text-muted)")}
               >
                 Retry
               </button>
@@ -379,13 +377,11 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
                   key={opt}
                   type="button"
                   onClick={() => { setModelOverride(opt); setModelMenuOpen(false); }}
-                  className="w-full text-left px-3 py-2 text-xs cursor-pointer transition-colors duration-100"
+                  className="w-full text-left px-3 py-2 text-xs cursor-pointer transition-colors duration-100 hover-bg-border"
                   style={{
                     color: modelOverride === opt ? "var(--color-primary)" : "var(--color-text)",
                     background: "transparent",
                   }}
-                  onMouseEnter={(e) => ((e.currentTarget as HTMLElement).style.background = "var(--color-border)")}
-                  onMouseLeave={(e) => ((e.currentTarget as HTMLElement).style.background = "transparent")}
                 >
                   {opt === "auto" ? "Auto" : opt === "haiku" ? "Haiku (fast)" : "Sonnet (smart)"}
                 </button>
@@ -397,15 +393,8 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
         <button
           type="submit"
           disabled={isLoading || !input.trim()}
-          className="rounded-xl px-3.5 py-2.5 cursor-pointer transition-colors duration-150 disabled:opacity-30 disabled:cursor-default"
+          className="rounded-xl px-3.5 py-2.5 cursor-pointer transition-opacity duration-150 hover:opacity-85 disabled:opacity-30 disabled:cursor-default disabled:hover:opacity-30"
           style={{ background: "var(--color-primary)", color: "white" }}
-          onMouseEnter={(e) => {
-            if (!(e.currentTarget as HTMLButtonElement).disabled)
-              (e.currentTarget as HTMLElement).style.opacity = "0.85";
-          }}
-          onMouseLeave={(e) => {
-            (e.currentTarget as HTMLElement).style.opacity = "1";
-          }}
         >
           <Send size={16} />
         </button>

--- a/web/src/components/chat/chat-page-client.tsx
+++ b/web/src/components/chat/chat-page-client.tsx
@@ -339,7 +339,7 @@ function ChatPageClientInner({
 
           <button
             onClick={toggleDesktopHistory}
-            className="hidden lg:flex items-center justify-center rounded-lg transition-colors duration-150"
+            className={`hidden lg:flex items-center justify-center rounded-lg transition-colors duration-150 ${historyOpen ? "" : "hover-bg-subtle"}`}
             aria-label={historyOpen ? "Close history" : "Open history"}
             style={{
               background: historyOpen ? "var(--color-primary-dim)" : "transparent",
@@ -348,14 +348,6 @@ function ChatPageClientInner({
               cursor: "pointer",
               width: 36,
               height: 36,
-            }}
-            onMouseEnter={(e) => {
-              if (!historyOpen)
-                (e.currentTarget as HTMLElement).style.background = "var(--hover-subtle)";
-            }}
-            onMouseLeave={(e) => {
-              if (!historyOpen)
-                (e.currentTarget as HTMLElement).style.background = "transparent";
             }}
           >
             <History size={18} />
@@ -371,7 +363,7 @@ function ChatPageClientInner({
 
         <button
           onClick={handleNewChat}
-          className="transition-colors duration-150"
+          className="transition-colors duration-150 hover-text-brighten"
           style={{
             background: "transparent",
             border: "none",
@@ -380,12 +372,6 @@ function ChatPageClientInner({
             color: "var(--color-text-muted)",
             padding: "8px 4px",
             minHeight: 48,
-          }}
-          onMouseEnter={(e) => {
-            (e.currentTarget as HTMLElement).style.color = "var(--color-text)";
-          }}
-          onMouseLeave={(e) => {
-            (e.currentTarget as HTMLElement).style.color = "var(--color-text-muted)";
           }}
         >
           New chat

--- a/web/src/components/chat/session-sidebar.tsx
+++ b/web/src/components/chat/session-sidebar.tsx
@@ -30,7 +30,6 @@ export default function SessionSidebar({
 }: Props) {
   const [olderExpanded, setOlderExpanded] = useState(false);
   const [archivedExpanded, setArchivedExpanded] = useState(false);
-  const [hoveredId, setHoveredId] = useState<string | null>(null);
 
   const now = new Date();
   const recent = sessions.filter((s) => {
@@ -60,7 +59,7 @@ export default function SessionSidebar({
       <div style={{ padding: "12px 12px 8px" }}>
         <button
           onClick={onNewChat}
-          className="flex items-center gap-2 w-full cursor-pointer transition-colors duration-150"
+          className="flex items-center gap-2 w-full cursor-pointer transition-opacity duration-150 hover:opacity-85"
           style={{
             background: "var(--color-primary)",
             color: "white",
@@ -70,12 +69,6 @@ export default function SessionSidebar({
             fontSize: 13,
             fontWeight: 500,
             minHeight: 48,
-          }}
-          onMouseEnter={(e) => {
-            (e.currentTarget as HTMLElement).style.opacity = "0.85";
-          }}
-          onMouseLeave={(e) => {
-            (e.currentTarget as HTMLElement).style.opacity = "1";
           }}
         >
           <Plus size={15} />
@@ -89,8 +82,6 @@ export default function SessionSidebar({
             key={`${s.id}-${timeTick}`}
             session={s}
             active={s.id === activeSessionId}
-            hovered={hoveredId === s.id}
-            onHover={setHoveredId}
             onSelect={onSessionSelect}
             onArchive={onArchive}
           />
@@ -125,8 +116,6 @@ export default function SessionSidebar({
                   key={`${s.id}-${timeTick}`}
                   session={s}
                   active={s.id === activeSessionId}
-                  hovered={hoveredId === s.id}
-                  onHover={setHoveredId}
                   onSelect={onSessionSelect}
                   onArchive={onArchive}
                 />
@@ -173,25 +162,19 @@ export default function SessionSidebar({
 function SessionRow({
   session,
   active,
-  hovered,
-  onHover,
   onSelect,
   onArchive,
 }: {
   session: SessionPreview;
   active: boolean;
-  hovered: boolean;
-  onHover: (id: string | null) => void;
   onSelect: (id: string) => void;
   onArchive: (id: string) => void;
 }) {
   return (
     <div
-      onMouseEnter={() => onHover(session.id)}
-      onMouseLeave={() => onHover(null)}
+      className={`group/row relative transition-colors duration-150 ${active ? "" : "hover-bg-subtle"}`}
       style={{
-        position: "relative",
-        background: active ? "var(--color-primary-dim)" : hovered ? "var(--hover-subtle)" : "transparent",
+        background: active ? "var(--color-primary-dim)" : "transparent",
         borderLeft: active ? "2px solid var(--color-primary)" : "2px solid transparent",
         borderRadius: 6,
       }}
@@ -230,37 +213,30 @@ function SessionRow({
           {session.preview ?? "Empty session"}
         </span>
       </button>
-      {hovered && (
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onArchive(session.id);
-          }}
-          aria-label="Delete chat"
-          style={{
-            position: "absolute",
-            right: 8,
-            top: "50%",
-            transform: "translateY(-50%)",
-            background: "transparent",
-            border: "none",
-            color: "var(--color-text-muted)",
-            cursor: "pointer",
-            padding: 4,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-          onMouseEnter={(e) => {
-            (e.currentTarget as HTMLElement).style.color = "var(--color-danger)";
-          }}
-          onMouseLeave={(e) => {
-            (e.currentTarget as HTMLElement).style.color = "var(--color-text-muted)";
-          }}
-        >
-          <Trash2 size={14} />
-        </button>
-      )}
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onArchive(session.id);
+        }}
+        aria-label="Delete chat"
+        className="opacity-0 pointer-events-none group-hover/row:opacity-100 group-hover/row:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto transition-colors duration-150 hover-text-danger"
+        style={{
+          position: "absolute",
+          right: 8,
+          top: "50%",
+          transform: "translateY(-50%)",
+          background: "transparent",
+          border: "none",
+          color: "var(--color-text-muted)",
+          cursor: "pointer",
+          padding: 4,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Trash2 size={14} />
+      </button>
     </div>
   );
 }

--- a/web/src/components/dashboard/habits-checkin.tsx
+++ b/web/src/components/dashboard/habits-checkin.tsx
@@ -95,15 +95,9 @@ export default function HabitsCheckin({ registry, todayLogs, streaks, toggleActi
               key={habit.id}
               onClick={() => handleToggle(habit.id)}
               disabled={isPending}
-              className="w-full flex items-center gap-2 py-1.5 px-1.5 rounded-lg text-left transition-colors"
+              className="w-full flex items-center gap-2 py-1.5 px-1.5 rounded-lg text-left transition-colors duration-150 hover-bg-raised"
               style={{
                 opacity: isPending ? 0.5 : 1,
-              }}
-              onMouseEnter={(e) => {
-                (e.currentTarget as HTMLButtonElement).style.background = "var(--color-surface-raised)";
-              }}
-              onMouseLeave={(e) => {
-                (e.currentTarget as HTMLButtonElement).style.background = "transparent";
               }}
             >
               {/* Checkbox */}

--- a/web/src/components/dashboard/recent-workouts-table.tsx
+++ b/web/src/components/dashboard/recent-workouts-table.tsx
@@ -33,10 +33,8 @@ export function RecentWorkoutsTable({ workouts }: Props) {
         </p>
         <Link
           href="/fitness"
-          className="text-xs transition-colors duration-150 cursor-pointer"
+          className="text-xs transition-colors duration-150 cursor-pointer hover-text-brighten"
           style={{ color: "var(--color-text-muted)" }}
-          onMouseEnter={(e) => ((e.target as HTMLElement).style.color = "var(--color-text)")}
-          onMouseLeave={(e) => ((e.target as HTMLElement).style.color = "var(--color-text-muted)")}
         >
           View all →
         </Link>

--- a/web/src/components/dashboard/sync-button.tsx
+++ b/web/src/components/dashboard/sync-button.tsx
@@ -67,10 +67,8 @@ export default function SyncButton() {
         onClick={handleSync}
         disabled={state === "syncing"}
         title={syncedAt ? `Last synced ${syncedAt}` : "Sync all data sources"}
-        className="flex items-center gap-1.5 text-xs disabled:opacity-40 transition-colors"
+        className="flex items-center gap-1.5 text-xs disabled:opacity-40 transition-colors duration-150 hover-text-muted"
         style={{ color: "var(--color-text-faint)" }}
-        onMouseEnter={(e) => (e.currentTarget.style.color = "var(--color-text-muted)")}
-        onMouseLeave={(e) => (e.currentTarget.style.color = "var(--color-text-faint)")}
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/web/src/components/theme-toggle.tsx
+++ b/web/src/components/theme-toggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useTransition } from "react";
 import { useTheme } from "next-themes";
 import { Sun, Moon, Monitor } from "lucide-react";
 import { setThemePreference } from "@/lib/theme-actions";
@@ -16,10 +16,7 @@ const LABEL: Record<ThemePreference, string> = {
 
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
   const [, startTransition] = useTransition();
-
-  useEffect(() => setMounted(true), []);
 
   const current: ThemePreference = (theme as ThemePreference | undefined) ?? "system";
   const Icon = current === "light" ? Sun : current === "dark" ? Moon : Monitor;
@@ -37,9 +34,9 @@ export function ThemeToggle() {
     <button
       type="button"
       onClick={handleClick}
-      aria-label={mounted ? `Theme: ${LABEL[current]}. Click to change.` : "Theme toggle"}
-      title={mounted ? `Theme: ${LABEL[current]}` : undefined}
-      className="flex items-center justify-center rounded-md transition-colors cursor-pointer"
+      aria-label={`Theme: ${LABEL[current]}. Click to change.`}
+      title={`Theme: ${LABEL[current]}`}
+      className="flex items-center justify-center rounded-md transition-colors duration-150 cursor-pointer hover-text-brighten"
       style={{
         width: 32,
         height: 32,
@@ -47,8 +44,6 @@ export function ThemeToggle() {
         color: "var(--color-text-muted)",
         border: "1px solid var(--color-border)",
       }}
-      onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = "var(--color-text)"; }}
-      onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = "var(--color-text-muted)"; }}
     >
       <Icon size={15} />
     </button>

--- a/web/src/components/ui/metric-card.tsx
+++ b/web/src/components/ui/metric-card.tsx
@@ -35,16 +35,10 @@ export function MetricCard({
 
   return (
     <div
-      className="rounded-xl p-5 transition-colors duration-200"
+      className="rounded-xl p-5 transition-colors duration-200 hover-border-strong"
       style={{
         background: "var(--color-surface)",
         border: "1px solid var(--color-border)",
-      }}
-      onMouseEnter={(e) => {
-        (e.currentTarget as HTMLElement).style.borderColor = "var(--color-text-faint)";
-      }}
-      onMouseLeave={(e) => {
-        (e.currentTarget as HTMLElement).style.borderColor = "var(--color-border)";
       }}
     >
       <p

--- a/web/src/components/ui/sign-out-button.tsx
+++ b/web/src/components/ui/sign-out-button.tsx
@@ -14,10 +14,8 @@ export default function SignOutButton() {
   return (
     <button
       onClick={handleSignOut}
-      className="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium w-full transition-colors duration-150"
+      className="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium w-full transition-colors duration-150 hover-text-brighten"
       style={{ color: "var(--color-text-muted)", background: "transparent", border: "none", cursor: "pointer" }}
-      onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = "var(--color-text)"; }}
-      onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = "var(--color-text-muted)"; }}
     >
       <LogOut size={18} strokeWidth={1.5} style={{ flexShrink: 0 }} />
       Sign out


### PR DESCRIPTION
## Summary
- Replaces `onMouseEnter`/`onMouseLeave` inline-style writes with Tailwind `hover:` variants and new `.hover-*` utility classes (globals.css). Inline writes bypassed `transition-*` classes, making state changes feel instant instead of the 150ms MASTER.md spec.
- Sweeps 10 components; remaining `onMouseEnter`/`onMouseLeave` are state-driven (reveal toggle, menu active index, tooltip) and intentionally kept.
- Bundles M2: `ThemeToggle` drops the `mounted` gate on `aria-label`/`title` so SSR ships a real label rather than the generic "Theme toggle".
- `SessionRow` in the sidebar drops its `hoveredId` state and uses `group/row` + `group-hover/row:` for both row background and trash-button visibility (plus `focus-visible:` for keyboard users).

Closes #227.

## Test plan
- [ ] `rg 'onMouseEnter|onMouseLeave' web/src/` returns only justified (state-driven) cases
- [ ] Hover transitions smooth at 150ms in both light and dark themes
- [ ] Login submit button, chat send/new-chat, sidebar rows, sign-out, theme toggle, habits-checkin rows, metric cards, sync button all hover correctly
- [ ] Session sidebar trash button appears on row hover and on keyboard focus; active row keeps its primary-dim background
- [ ] Theme toggle `aria-label` reads "Theme: System. Click to change." on initial SSR (no hydration mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)