### PR TITLE
feat: card hover lift + tab focus ring (#229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed (card hover lift + tab focus ring — issue #229)
+- **`web/src/app/globals.css`** — added `.card-lift` utility (`hover: translateY(-2px) + box-shadow: var(--shadow-lg)`), pairs with `transition-all duration-200` per MASTER.md card spec. Uses `transform` so no layout shift.
+- **`web/src/components/ui/metric-card.tsx`** (H6) — swapped `transition-colors` → `transition-all`, added `.card-lift` so metric cards lift on hover alongside the existing border-color change.
+- **`web/src/components/dashboard/health-breakdown.tsx`** (M13) — `TabPills` now render an explicit 2px primary-colored `focus-visible` outline with 2px offset; global `:focus-visible` was too subtle on the dense pill row.
+
 ### Changed (hover-handler sweep → CSS / Tailwind — issue #227)
 - **`web/src/app/globals.css`** — added hover utility classes (`.hover-text-brighten`, `.hover-text-danger`, `.hover-text-muted`, `.hover-bg-subtle`, `.hover-bg-border`, `.hover-bg-raised`, `.hover-border-strong`) that override inline-style base colors via `!important` on `:hover`. Paired with `transition-colors` / `transition-opacity` they deliver the 150ms MASTER.md spec.
 - **Mechanical sweep across 10 components** — removed `onMouseEnter`/`onMouseLeave` inline-style writes in [login/page.tsx](web/src/app/login/page.tsx), [chat/chat-interface.tsx](web/src/components/chat/chat-interface.tsx), [chat/chat-page-client.tsx](web/src/components/chat/chat-page-client.tsx), [chat/session-sidebar.tsx](web/src/components/chat/session-sidebar.tsx), [ui/sign-out-button.tsx](web/src/components/ui/sign-out-button.tsx), [theme-toggle.tsx](web/src/components/theme-toggle.tsx), [dashboard/habits-checkin.tsx](web/src/components/dashboard/habits-checkin.tsx), [ui/metric-card.tsx](web/src/components/ui/metric-card.tsx), [dashboard/sync-button.tsx](web/src/components/dashboard/sync-button.tsx), [dashboard/recent-workouts-table.tsx](web/src/components/dashboard/recent-workouts-table.tsx). Buttons with opacity hovers use native Tailwind `hover:opacity-85` / `hover:opacity-90`. Remaining `onMouseEnter`/`onMouseLeave` callsites (message-bubble reveal, slash-command-menu active index, heatmap tooltip) are state-driven and kept.

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -162,6 +162,15 @@ body {
 .hover-text-muted:hover    { color: var(--color-text-muted) !important; }
 .hover-border-strong:hover { border-color: var(--color-text-faint) !important; }
 
+/* Card hover lift — MASTER.md spec.
+   Uses transform + box-shadow (no margin/padding change) to avoid layout shift.
+   Pair with a `transition-*` utility on the element; duration 200ms per spec. */
+.card-lift { will-change: transform; }
+.card-lift:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+}
+
 /* ─── Reduced motion ──────────────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/web/src/components/dashboard/health-breakdown.tsx
+++ b/web/src/components/dashboard/health-breakdown.tsx
@@ -152,10 +152,11 @@ function TabPills<T extends string>({ tabs, active, onSelect }: TabPillsProps<T>
         <button
           key={key}
           onClick={() => onSelect(key)}
-          className="px-2.5 py-1 rounded text-xs font-medium transition-colors cursor-pointer"
+          className="px-2.5 py-1 rounded text-xs font-medium transition-colors cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2"
           style={{
             background: active === key ? "var(--color-primary)" : "var(--color-surface-raised)",
             color:      active === key ? "var(--color-text-on-cta)" : "var(--color-text-muted)",
+            outlineColor: "var(--color-primary)",
           }}
         >
           {label}

--- a/web/src/components/ui/metric-card.tsx
+++ b/web/src/components/ui/metric-card.tsx
@@ -35,7 +35,7 @@ export function MetricCard({
 
   return (
     <div
-      className="rounded-xl p-5 transition-colors duration-200 hover-border-strong"
+      className="rounded-xl p-5 transition-all duration-200 hover-border-strong card-lift"
       style={{
         background: "var(--color-surface)",
         border: "1px solid var(--color-border)",


### PR DESCRIPTION
## Summary
- **H6** — `MetricCard` lifts on hover (`translateY(-2px)` + `shadow-lg`) per MASTER.md card spec. New `.card-lift` utility in `globals.css` (transform-based, no layout shift).
- **M13** — Health Breakdown tab pills get an explicit 2px primary-colored `focus-visible` outline; the global ring was too subtle on the dense pill row.

Closes #229.

## Test plan
- [ ] Hover a metric card on `/dashboard` → card rises ~2px with larger drop shadow, 200ms transition, no layout shift in the grid
- [ ] Keyboard-tab through Health Breakdown tab pills → visible primary-colored ring on each pill
- [ ] Verify in both light and dark modes
- [ ] `prefers-reduced-motion` — transition collapses per existing global override

🤖 Generated with [Claude Code](https://claude.com/claude-code)