### PR TITLE
feat: apply card-lift to canonical tile wrappers (#240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed (card-lift applied to canonical tile wrappers — issue #240)
+- Follow-up to #229 / #238. `.card-lift` was defined but only applied to `MetricCard`, which is an orphan (defined, never rendered) — so the lift was invisible on the real dashboard. Applied `transition-all duration-200 card-lift` to 13 canonical widget-shell wrappers:
+  - **dashboard/** — [recent-workouts-table.tsx](web/src/components/dashboard/recent-workouts-table.tsx), [schedule-today.tsx](web/src/components/dashboard/schedule-today.tsx), [habits-checkin.tsx](web/src/components/dashboard/habits-checkin.tsx), [trends-card.tsx](web/src/components/dashboard/trends-card.tsx), [sports-card.tsx](web/src/components/dashboard/sports-card.tsx), [watchlist-widget.tsx](web/src/components/dashboard/watchlist-widget.tsx), [today-scores-strip.tsx](web/src/components/dashboard/today-scores-strip.tsx), [health-breakdown.tsx](web/src/components/dashboard/health-breakdown.tsx)
+  - **fitness/** — [workout-history-table.tsx](web/src/components/fitness/workout-history-table.tsx), [body-comp-dual-chart.tsx](web/src/components/fitness/body-comp-dual-chart.tsx), [weight-goal-chart.tsx](web/src/components/fitness/weight-goal-chart.tsx), [weekly-workout-plan.tsx](web/src/components/fitness/weekly-workout-plan.tsx)
+  - **meals/** — [MacroSummaryCard.tsx](web/src/components/meals/MacroSummaryCard.tsx)
+- List rows, chart sub-panels inside a tile, and chat/settings/modal panels were intentionally excluded — lifting them would re-introduce dense-data jitter.
+
 ### Changed (card hover lift + tab focus ring — issue #229)
 - **`web/src/app/globals.css`** — added `.card-lift` utility (`hover: translateY(-2px) + box-shadow: var(--shadow-lg)`), pairs with `transition-all duration-200` per MASTER.md card spec. Uses `transform` so no layout shift.
 - **`web/src/components/ui/metric-card.tsx`** (H6) — swapped `transition-colors` → `transition-all`, added `.card-lift` so metric cards lift on hover alongside the existing border-color change.

--- a/web/src/components/dashboard/habits-checkin.tsx
+++ b/web/src/components/dashboard/habits-checkin.tsx
@@ -48,7 +48,7 @@ export default function HabitsCheckin({ registry, todayLogs, streaks, toggleActi
 
   return (
     <div
-      className="rounded-xl p-4"
+      className="rounded-xl p-4 transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       <p

--- a/web/src/components/dashboard/health-breakdown.tsx
+++ b/web/src/components/dashboard/health-breakdown.tsx
@@ -444,7 +444,7 @@ export default function HealthBreakdown({ recovery, trends, fitnessData, windowL
 
   return (
     <div
-      className="rounded-xl overflow-hidden flex flex-col"
+      className="rounded-xl overflow-hidden flex flex-col transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       {/* Colored top bar */}

--- a/web/src/components/dashboard/recent-workouts-table.tsx
+++ b/web/src/components/dashboard/recent-workouts-table.tsx
@@ -24,7 +24,7 @@ function fmtDate(d: string) {
 export function RecentWorkoutsTable({ workouts }: Props) {
   return (
     <div
-      className="rounded-xl p-5"
+      className="rounded-xl p-5 transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       <div className="flex items-center justify-between mb-4">

--- a/web/src/components/dashboard/schedule-today.tsx
+++ b/web/src/components/dashboard/schedule-today.tsx
@@ -69,7 +69,7 @@ export default function ScheduleToday() {
 
   return (
     <div
-      className="rounded-xl p-4 h-full"
+      className="rounded-xl p-4 h-full transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       <div className="flex items-center gap-2 mb-3">

--- a/web/src/components/dashboard/sports-card.tsx
+++ b/web/src/components/dashboard/sports-card.tsx
@@ -222,7 +222,7 @@ export function SportsCard({ rows, favorites, refreshAction }: Props) {
       `}</style>
 
       <div
-        className="rounded-xl overflow-hidden"
+        className="rounded-xl overflow-hidden transition-all duration-200 card-lift"
         style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
       >
         <div

--- a/web/src/components/dashboard/today-scores-strip.tsx
+++ b/web/src/components/dashboard/today-scores-strip.tsx
@@ -48,7 +48,7 @@ export default function TodayScoresStrip({ today }: Props) {
 
   return (
     <div
-      className="rounded-xl overflow-hidden"
+      className="rounded-xl overflow-hidden transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       {/* 2px colored top bar keyed to readiness */}

--- a/web/src/components/dashboard/trends-card.tsx
+++ b/web/src/components/dashboard/trends-card.tsx
@@ -134,7 +134,7 @@ export default function TrendsCard({ fitnessData, recoveryData, recentWorkout }:
 
   return (
     <div
-      className="rounded-xl p-4 h-full"
+      className="rounded-xl p-4 h-full transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       {/* Header row */}

--- a/web/src/components/dashboard/watchlist-widget.tsx
+++ b/web/src/components/dashboard/watchlist-widget.tsx
@@ -145,7 +145,7 @@ export function WatchlistWidget({ rows, hasApiKey, refreshAction }: Props) {
       `}</style>
 
       <div
-        className="rounded-xl overflow-hidden"
+        className="rounded-xl overflow-hidden transition-all duration-200 card-lift"
         style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
       >
         {/* Header */}

--- a/web/src/components/fitness/body-comp-dual-chart.tsx
+++ b/web/src/components/fitness/body-comp-dual-chart.tsx
@@ -46,7 +46,7 @@ export function BodyCompDualChart({ data, windowLabel = "90D", windowKey }: Prop
   if (chartData.length === 0) {
     return (
       <div
-        className="rounded-xl p-5"
+        className="rounded-xl p-5 transition-all duration-200 card-lift"
         style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
       >
         <p className="text-xs uppercase tracking-widest mb-4" style={{ color: "var(--color-text-muted)" }}>
@@ -61,7 +61,7 @@ export function BodyCompDualChart({ data, windowLabel = "90D", windowKey }: Prop
 
   return (
     <div
-      className="rounded-xl p-5"
+      className="rounded-xl p-5 transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       <p className="text-xs uppercase tracking-widest mb-4" style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}>

--- a/web/src/components/fitness/weekly-workout-plan.tsx
+++ b/web/src/components/fitness/weekly-workout-plan.tsx
@@ -112,7 +112,7 @@ export function WeeklyWorkoutPlan({ plans, completedDates }: Props) {
 
   return (
     <div
-      className="rounded-xl p-5"
+      className="rounded-xl p-5 transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       {/* Header */}

--- a/web/src/components/fitness/weight-goal-chart.tsx
+++ b/web/src/components/fitness/weight-goal-chart.tsx
@@ -54,7 +54,7 @@ export function WeightGoalChart({ data, goal, windowLabel = "90D", windowKey }: 
 
   return (
     <div
-      className="rounded-xl p-5"
+      className="rounded-xl p-5 transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       <div className="flex items-start justify-between gap-3 mb-4">

--- a/web/src/components/fitness/workout-history-table.tsx
+++ b/web/src/components/fitness/workout-history-table.tsx
@@ -112,7 +112,7 @@ export function WorkoutHistoryTable({ workouts }: Props) {
 
   return (
     <div
-      className="rounded-xl p-5"
+      className="rounded-xl p-5 transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       <p

--- a/web/src/components/meals/MacroSummaryCard.tsx
+++ b/web/src/components/meals/MacroSummaryCard.tsx
@@ -131,7 +131,7 @@ export default async function MacroSummaryCard() {
 
   return (
     <div
-      className="rounded-xl p-5"
+      className="rounded-xl p-5 transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       <p


### PR DESCRIPTION
## Summary
- Follow-up to #229 / #238. The previously-added \`.card-lift\` utility was only applied to \`MetricCard\`, which is an orphan component — so the hover lift was invisible in the running app.
- Applied \`transition-all duration-200 card-lift\` to 13 canonical widget-shell wrappers across dashboard, fitness, and meals.
- Deliberately excluded list rows, chart sub-panels inside a tile, and chat/settings/modal surfaces.

Closes #240.

## Test plan
- [ ] Hover each tile on /dashboard, /fitness, /meals → rises ~2px with shadow-lg, 200ms transition, no layout shift
- [ ] Both light and dark mode
- [ ] prefers-reduced-motion collapses transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)