### PR TITLE
Chat polish bundle (#230)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (chat polish bundle — issue #230)
+- **H7 — login redirect drops `next`.** [web/src/app/login/page.tsx](web/src/app/login/page.tsx) now reads `next` from the URL and pushes to it on successful sign-in; default is `/dashboard`. [web/src/app/auth/callback/route.ts](web/src/app/auth/callback/route.ts) defaults to `/dashboard` and validates `next` starts with `/` and not `//` (open-redirect guard).
+- **M1 — chat SSR + client double-fetch.** [web/src/components/chat/chat-page-client.tsx](web/src/components/chat/chat-page-client.tsx) no longer refetches messages for the most-recent session when SSR already provided them (skip when `mostRecent.id === initialSessionId`). Sessions list fetch is retained for the sidebar.
+- **M3 — restore doesn't resync server list.** [web/src/components/chat/chat-page-client.tsx](web/src/components/chat/chat-page-client.tsx) `handleRestoreSession` now calls `fetchSessions()` after a successful `/restore` POST.
+- **M4 — unread badge flickers on route change.** [web/src/components/nav.tsx](web/src/components/nav.tsx) fetches `/api/notifications/unread-count` once on mount + on `visibilitychange` (tab regains focus), instead of on every `pathname` change.
+- **L1 — slash-command menu typography.** [web/src/components/chat/slash-command-menu.tsx](web/src/components/chat/slash-command-menu.tsx) dropped monospace font family on the command name so it matches the description's system sans.
+- **L3 — magic `8rem` header offset.** Added `--header-height: 8rem` to [web/src/app/globals.css](web/src/app/globals.css); [web/src/components/chat/session-sidebar.tsx](web/src/components/chat/session-sidebar.tsx) `maxHeight` now uses `calc(100dvh - var(--header-height))`.
+- **L4 — cursor-pointer on section toggles.** Added inline `cursor: "pointer"` to both "Older" and "Recently deleted" toggle buttons in [web/src/components/chat/session-sidebar.tsx](web/src/components/chat/session-sidebar.tsx).
+
 ### Changed (card-lift applied to canonical tile wrappers — issue #240)
 - Follow-up to #229 / #238. `.card-lift` was defined but only applied to `MetricCard`, which is an orphan (defined, never rendered) — so the lift was invisible on the real dashboard. Applied `transition-all duration-200 card-lift` to 13 canonical widget-shell wrappers:
   - **dashboard/** — [recent-workouts-table.tsx](web/src/components/dashboard/recent-workouts-table.tsx), [schedule-today.tsx](web/src/components/dashboard/schedule-today.tsx), [habits-checkin.tsx](web/src/components/dashboard/habits-checkin.tsx), [trends-card.tsx](web/src/components/dashboard/trends-card.tsx), [sports-card.tsx](web/src/components/dashboard/sports-card.tsx), [watchlist-widget.tsx](web/src/components/dashboard/watchlist-widget.tsx), [today-scores-strip.tsx](web/src/components/dashboard/today-scores-strip.tsx), [health-breakdown.tsx](web/src/components/dashboard/health-breakdown.tsx)

--- a/web/src/app/auth/callback/route.ts
+++ b/web/src/app/auth/callback/route.ts
@@ -5,7 +5,11 @@ import { NextRequest, NextResponse } from "next/server";
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
-  const next = searchParams.get("next") ?? "/";
+  const nextParam = searchParams.get("next");
+  const next =
+    nextParam && nextParam.startsWith("/") && !nextParam.startsWith("//")
+      ? nextParam
+      : "/dashboard";
 
   if (code) {
     const cookieStore = await cookies();

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -40,6 +40,8 @@
   --shadow-md:   0 4px 12px rgba(0,0,0,0.5);
   --shadow-lg:   0 8px 24px rgba(0,0,0,0.6);
   --shadow-glow: 0 0 0 3px var(--color-primary-dim);
+
+  --header-height: 8rem;
 }
 
 :root[data-theme="light"] {

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -19,6 +19,11 @@ function LoginForm() {
   const [errorMsg, setErrorMsg] = useState("");
   const searchParams = useSearchParams();
   const hasAuthError = searchParams.get("error") === "auth_error";
+  const nextParam = searchParams.get("next");
+  const redirectTo =
+    nextParam && nextParam.startsWith("/") && !nextParam.startsWith("//")
+      ? nextParam
+      : "/dashboard";
   const router = useRouter();
 
   async function signIn(e: string, p: string) {
@@ -31,7 +36,7 @@ function LoginForm() {
       setState("error");
     } else {
       router.refresh();
-      router.push("/");
+      router.push(redirectTo);
     }
   }
 

--- a/web/src/components/chat/chat-page-client.tsx
+++ b/web/src/components/chat/chat-page-client.tsx
@@ -112,7 +112,12 @@ function ChatPageClientInner({
 
         const active = list.filter((s) => !s.deleted_at);
         const mostRecent = active[0];
-        if (mostRecent && mostRecent.id !== activeSessionIdRef.current) {
+        // SSR already loaded messages for initialSessionId; skip the refetch when it matches.
+        if (
+          mostRecent &&
+          mostRecent.id !== activeSessionIdRef.current &&
+          mostRecent.id !== initialSessionId
+        ) {
           setLoadingSession(true);
           try {
             const msgRes = await fetch(`/api/chat/sessions/${mostRecent.id}`);
@@ -303,16 +308,20 @@ function ChatPageClientInner({
     [allSessions, activeSessionId, loadSession, handleNewChat, toast, fetchSessions]
   );
 
-  const handleRestoreSession = useCallback(async (sessionId: string) => {
-    setAllSessions((prev) =>
-      prev.map((s) => (s.id === sessionId ? { ...s, deleted_at: null } : s))
-    );
-    try {
-      await fetch(`/api/chat/sessions/${sessionId}/restore`, { method: "POST" });
-    } catch {
-      // non-fatal
-    }
-  }, []);
+  const handleRestoreSession = useCallback(
+    async (sessionId: string) => {
+      setAllSessions((prev) =>
+        prev.map((s) => (s.id === sessionId ? { ...s, deleted_at: null } : s))
+      );
+      try {
+        const res = await fetch(`/api/chat/sessions/${sessionId}/restore`, { method: "POST" });
+        if (res.ok) fetchSessions();
+      } catch {
+        // non-fatal
+      }
+    },
+    [fetchSessions]
+  );
 
   return (
     <div className="flex flex-col flex-1 min-h-0">

--- a/web/src/components/chat/session-sidebar.tsx
+++ b/web/src/components/chat/session-sidebar.tsx
@@ -53,7 +53,7 @@ export default function SessionSidebar({
         flexDirection: "column",
         overflow: "hidden",
         alignSelf: "flex-start",
-        maxHeight: "calc(100dvh - 8rem)",
+        maxHeight: "calc(100dvh - var(--header-height))",
       }}
     >
       <div style={{ padding: "12px 12px 8px" }}>
@@ -102,6 +102,7 @@ export default function SessionSidebar({
                 textTransform: "uppercase",
                 padding: "8px 8px 4px",
                 minHeight: 40,
+                cursor: "pointer",
               }}
             >
               <span style={{ transform: olderExpanded ? "rotate(90deg)" : "none", display: "inline-block", transition: "transform 150ms" }}>
@@ -140,6 +141,7 @@ export default function SessionSidebar({
                 minHeight: 40,
                 marginTop: 4,
                 borderTop: "1px solid var(--color-border)",
+                cursor: "pointer",
               }}
             >
               <span style={{ transform: archivedExpanded ? "rotate(90deg)" : "none", display: "inline-block", transition: "transform 150ms" }}>

--- a/web/src/components/chat/slash-command-menu.tsx
+++ b/web/src/components/chat/slash-command-menu.tsx
@@ -73,7 +73,6 @@ export default function SlashCommandMenu({ commands, activeIndex, onSelect, onHo
               fontSize: 13,
               fontWeight: 500,
               color: "var(--color-primary)",
-              fontFamily: "ui-monospace, monospace",
               flexShrink: 0,
             }}
           >

--- a/web/src/components/nav.tsx
+++ b/web/src/components/nav.tsx
@@ -64,17 +64,25 @@ export default function Nav() {
   }, []);
 
   useEffect(() => {
-    fetch("/api/notifications/unread-count")
-      .then((r) => {
-        if (!r.ok) throw new Error("unread-count fetch failed");
-        return r.json();
-      })
-      .then((d) => {
-        setUnreadCount(d.count ?? 0);
-        setUnreadError(false);
-      })
-      .catch(() => setUnreadError(true));
-  }, [pathname]);
+    const load = () => {
+      fetch("/api/notifications/unread-count")
+        .then((r) => {
+          if (!r.ok) throw new Error("unread-count fetch failed");
+          return r.json();
+        })
+        .then((d) => {
+          setUnreadCount(d.count ?? 0);
+          setUnreadError(false);
+        })
+        .catch(() => setUnreadError(true));
+    };
+    load();
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") load();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => document.removeEventListener("visibilitychange", onVisibility);
+  }, []);
 
   // Is the current page one of the "More" pages? If so, highlight the More button.
   const moreIsActive = MOBILE_MORE.some((item) => isActive(pathname, item.href));


### PR DESCRIPTION
## Summary

Seven small, related polish fixes to the chat surface, auth redirect, and global nav — bundled to avoid churn. Closes #230.

- **H7** — login redirect now propagates `?next=`; default `/dashboard`; `auth/callback` hardened against `//` open-redirect.
- **M1** — chat page no longer refetches messages for the SSR-loaded most-recent session on client mount.
- **M3** — `handleRestoreSession` refetches the sessions list after a successful `/restore` so the sidebar shows authoritative server state.
- **M4** — unread badge fetches on mount + `visibilitychange` (tab regains focus), not on every `pathname` change.
- **L1** — slash-command menu: dropped monospace on command name for a single, consistent font family.
- **L3** — added `--header-height: 8rem` token; sidebar `maxHeight` uses `calc(100dvh - var(--header-height))`.
- **L4** — added `cursor: pointer` to "Older" / "Recently deleted" toggles.

## Test plan

- [ ] `/login?next=/tasks` → lands on `/tasks` after sign-in; bare `/login` → `/dashboard`; `/login?next=//evil.com` → `/dashboard`.
- [ ] `/chat` initial load: Network tab shows no duplicate `/api/chat/sessions/<id>` messages fetch when SSR returned a session.
- [ ] Archive a session → restore → Network shows a `/api/chat/sessions` GET after the `/restore` POST; sidebar reflects server truth.
- [ ] Unread badge: navigate between pages → no refetch flicker; hide tab / switch back → badge refetches once on visibility.
- [ ] Slash-command menu: command name + description share font family.
- [ ] Sidebar `max-height` resolves to `calc(100dvh - 8rem)` via CSS var.
- [ ] Older / Recently-deleted toggles: cursor is pointer on hover.
- [ ] `npm run build` passes (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)