### PR TITLE
fix: apply card-lift to tiles missed by first sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (card-lift missed tiles — follow-up to #240)
+- Applied `transition-all duration-200 card-lift` to tile wrappers the first sweep missed (Link-wrapped tile, empty-state branches, weekly `Card` helper, fitness chart panels that weren't in the first scan):
+  - [dashboard/tasks-summary.tsx](web/src/components/dashboard/tasks-summary.tsx) — Active Tasks tile (wrapper is `<Link>`, not `<div>`)
+  - [fitness/workout-freq-chart.tsx](web/src/components/fitness/workout-freq-chart.tsx), [fitness/active-cal-chart.tsx](web/src/components/fitness/active-cal-chart.tsx), [fitness/active-cal-goal-chart.tsx](web/src/components/fitness/active-cal-goal-chart.tsx), [fitness/body-fat-goal-chart.tsx](web/src/components/fitness/body-fat-goal-chart.tsx)
+  - [habits/heatmap.tsx](web/src/components/habits/heatmap.tsx), [habits/streak-chart.tsx](web/src/components/habits/streak-chart.tsx), [habits/radial-completion.tsx](web/src/components/habits/radial-completion.tsx) — both empty-state and data-state wrappers
+  - [(protected)/weekly/page.tsx](web/src/app/(protected)/weekly/page.tsx) — shared `Card` component used by every tile on the weekly view
+
 ### Changed (card-lift applied to canonical tile wrappers — issue #240)
 - Follow-up to #229 / #238. `.card-lift` was defined but only applied to `MetricCard`, which is an orphan (defined, never rendered) — so the lift was invisible on the real dashboard. Applied `transition-all duration-200 card-lift` to 13 canonical widget-shell wrappers:
   - **dashboard/** — [recent-workouts-table.tsx](web/src/components/dashboard/recent-workouts-table.tsx), [schedule-today.tsx](web/src/components/dashboard/schedule-today.tsx), [habits-checkin.tsx](web/src/components/dashboard/habits-checkin.tsx), [trends-card.tsx](web/src/components/dashboard/trends-card.tsx), [sports-card.tsx](web/src/components/dashboard/sports-card.tsx), [watchlist-widget.tsx](web/src/components/dashboard/watchlist-widget.tsx), [today-scores-strip.tsx](web/src/components/dashboard/today-scores-strip.tsx), [health-breakdown.tsx](web/src/components/dashboard/health-breakdown.tsx)

--- a/web/src/app/(protected)/weekly/page.tsx
+++ b/web/src/app/(protected)/weekly/page.tsx
@@ -66,7 +66,7 @@ function Card({
 }) {
   return (
     <div
-      className="rounded-xl overflow-hidden flex flex-col"
+      className="rounded-xl overflow-hidden flex flex-col transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       {accent && <div style={{ height: 3, background: accent, flexShrink: 0 }} />}

--- a/web/src/components/dashboard/tasks-summary.tsx
+++ b/web/src/components/dashboard/tasks-summary.tsx
@@ -29,7 +29,7 @@ export default function TasksSummary({ tasks }: Props) {
   return (
     <Link
       href="/tasks"
-      className="block rounded-xl p-4 transition-colors"
+      className="block rounded-xl p-4 transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       <p

--- a/web/src/components/fitness/active-cal-chart.tsx
+++ b/web/src/components/fitness/active-cal-chart.tsx
@@ -46,7 +46,7 @@ export function ActiveCalChart({ data, windowLabel = "30D" }: Props) {
 
   return (
     <div
-      className="rounded-xl p-5"
+      className="rounded-xl p-5 transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       <p className="text-xs uppercase tracking-widest mb-4" style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}>

--- a/web/src/components/fitness/active-cal-goal-chart.tsx
+++ b/web/src/components/fitness/active-cal-goal-chart.tsx
@@ -121,7 +121,7 @@ export function ActiveCalGoalChart({ data, goal, days }: Props) {
 
   return (
     <div
-      className="rounded-xl p-5"
+      className="rounded-xl p-5 transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       <div className="flex items-center justify-between mb-4">

--- a/web/src/components/fitness/body-fat-goal-chart.tsx
+++ b/web/src/components/fitness/body-fat-goal-chart.tsx
@@ -54,7 +54,7 @@ export function BodyFatGoalChart({ data, goal, windowLabel = "90D", windowKey }:
 
   return (
     <div
-      className="rounded-xl p-5"
+      className="rounded-xl p-5 transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       <div className="flex items-start justify-between gap-3 mb-4">

--- a/web/src/components/fitness/workout-freq-chart.tsx
+++ b/web/src/components/fitness/workout-freq-chart.tsx
@@ -121,7 +121,7 @@ export function WorkoutFreqChart({ sessions, days, goal }: Props) {
 
   return (
     <div
-      className="rounded-xl p-5"
+      className="rounded-xl p-5 transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       <div className="flex items-center justify-between mb-4">

--- a/web/src/components/habits/heatmap.tsx
+++ b/web/src/components/habits/heatmap.tsx
@@ -24,7 +24,7 @@ export function HabitHeatmap({ habits, registry, logs, dates }: Props) {
   if (habits.length === 0 || dates.length === 0) {
     return (
       <div
-        className="rounded-xl p-5"
+        className="rounded-xl p-5 transition-all duration-200 card-lift"
         style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
       >
         <p className="text-xs uppercase tracking-widest mb-3" style={{ color: "var(--color-text-muted)" }}>
@@ -71,7 +71,7 @@ export function HabitHeatmap({ habits, registry, logs, dates }: Props) {
 
   return (
     <div
-      className="rounded-xl p-5"
+      className="rounded-xl p-5 transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       <p className="text-xs uppercase tracking-widest mb-4" style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}>

--- a/web/src/components/habits/radial-completion.tsx
+++ b/web/src/components/habits/radial-completion.tsx
@@ -56,7 +56,7 @@ export function RadialCompletion({ habits, weekLogs }: Props) {
   if (habits.length === 0) {
     return (
       <div
-        className="rounded-xl p-5"
+        className="rounded-xl p-5 transition-all duration-200 card-lift"
         style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
       >
         <p className="text-xs uppercase tracking-widest mb-3" style={{ color: "var(--color-text-muted)" }}>
@@ -69,7 +69,7 @@ export function RadialCompletion({ habits, weekLogs }: Props) {
 
   return (
     <div
-      className="rounded-xl p-5"
+      className="rounded-xl p-5 transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       <p className="text-xs uppercase tracking-widest mb-2" style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}>

--- a/web/src/components/habits/streak-chart.tsx
+++ b/web/src/components/habits/streak-chart.tsx
@@ -45,7 +45,7 @@ export function StreakChart({ habits, streaks }: Props) {
   if (data.every((d) => d.current === 0 && d.best === 0)) {
     return (
       <div
-        className="rounded-xl p-5"
+        className="rounded-xl p-5 transition-all duration-200 card-lift"
         style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
       >
         <p className="text-xs uppercase tracking-widest mb-3" style={{ color: "var(--color-text-muted)" }}>
@@ -60,7 +60,7 @@ export function StreakChart({ habits, streaks }: Props) {
 
   return (
     <div
-      className="rounded-xl p-5"
+      className="rounded-xl p-5 transition-all duration-200 card-lift"
       style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
     >
       <p className="text-xs uppercase tracking-widest mb-4" style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}>


### PR DESCRIPTION
## Summary
Follow-up to #241. First sweep missed:
- Link-wrapped tile (\`tasks-summary.tsx\` — Active Tasks)
- Empty-state branches of habits/fitness chart widgets
- Shared weekly \`Card\` helper (covers every tile on /weekly)
- Four fitness chart wrappers not in the first scan (workout-freq, active-cal, active-cal-goal, body-fat-goal)

## Test plan
- [ ] Hover Active Tasks tile on /dashboard → lifts
- [ ] Hover each tile on /fitness → lifts
- [ ] Hover each tile on /weekly → lifts
- [ ] Hover habit widgets (heatmap, streak, radial) both with and without data → lifts in both states
- [ ] Both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)