### PR TITLE
fix: settings form polish — unsaved warning, sheet header, sports Enter (#231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (settings form polish — issue #231)
+- **M10 — unsaved-changes warning on Settings.** New [web/src/lib/use-unsaved-changes-warning.ts](web/src/lib/use-unsaved-changes-warning.ts) hook attaches a `beforeunload` listener and intercepts in-app anchor navigation with `window.confirm` when any field is dirty. [web/src/components/settings/profile-form.tsx](web/src/components/settings/profile-form.tsx) aggregates dirty state across every `FieldRow` and invokes the hook. `FieldRow` now tracks a post-save baseline so dirty clears correctly once saved.
+- **M11 — visible sheet header + focus-trap.** [web/src/components/ui/sheet.tsx](web/src/components/ui/sheet.tsx) renders a visible `Dialog.Title` + `Dialog.Close` by default; added `hideHeader` opt-out for callers with their own header ([web/src/components/chat/session-sheet.tsx](web/src/components/chat/session-sheet.tsx), [web/src/components/nav.tsx](web/src/components/nav.tsx) "More" sheet). Focus-trap verified via `@radix-ui/react-dialog@^1.1.15` (Radix provides trap + restore by default).
+- **M12 — Enter-to-submit on sports search.** [web/src/components/settings/sports-settings.tsx](web/src/components/settings/sports-settings.tsx) adds `onKeyDown` that adds the first search result on Enter, matching the Enter behaviour in `profile-form`, `watchlist-settings`, and `add-task-form`.
+
 <<<<<<< HEAD
 ### Fixed (card-lift missed tiles — follow-up to #240)
 - Applied `transition-all duration-200 card-lift` to tile wrappers the first sweep missed (Link-wrapped tile, empty-state branches, weekly `Card` helper, fitness chart panels that weren't in the first scan):

--- a/web/src/components/chat/session-sheet.tsx
+++ b/web/src/components/chat/session-sheet.tsx
@@ -43,6 +43,7 @@ export default function SessionSheet({
       open={open}
       onOpenChange={(o) => { if (!o) onClose(); }}
       title="Chat history"
+      hideHeader
       contentClassName="flex flex-col"
       contentStyle={{ maxHeight: "60vh" }}
     >

--- a/web/src/components/nav.tsx
+++ b/web/src/components/nav.tsx
@@ -236,7 +236,7 @@ export default function Nav() {
       </nav>
 
       {/* ── More bottom sheet ────────────────────────────────────────── */}
-      <Sheet open={showMore} onOpenChange={setShowMore} title="More navigation">
+      <Sheet open={showMore} onOpenChange={setShowMore} title="More navigation" hideHeader>
         <>
           {/* Handle + header */}
           <div className="flex items-center justify-between px-5 pt-4 pb-3">

--- a/web/src/components/settings/profile-form.tsx
+++ b/web/src/components/settings/profile-form.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useCallback, useEffect, useState, useTransition } from "react";
 import { Check, Loader2, X } from "lucide-react";
+import { useUnsavedChangesWarning } from "@/lib/use-unsaved-changes-warning";
 
 interface Field {
   key: string;
@@ -284,29 +285,40 @@ function FieldRow({
   initialValue,
   updateAction,
   deleteAction,
+  onDirtyChange,
 }: {
   field: Field;
   initialValue: string;
   updateAction: (key: string, value: string) => Promise<void>;
   deleteAction: (key: string) => Promise<void>;
+  onDirtyChange?: (key: string, dirty: boolean) => void;
 }) {
   const [value, setValue] = useState(initialValue);
+  const [baseline, setBaseline] = useState(initialValue);
   const [saved, setSaved] = useState(false);
   const [isPending, startTransition] = useTransition();
 
+  const isDirty = value !== baseline;
+
+  useEffect(() => {
+    onDirtyChange?.(field.key, isDirty);
+    return () => onDirtyChange?.(field.key, false);
+  }, [isDirty, field.key, onDirtyChange]);
+
   async function handleSave() {
     startTransition(async () => {
-      if (value.trim() === "") {
+      const trimmed = value.trim();
+      if (trimmed === "") {
         await deleteAction(field.key);
       } else {
-        await updateAction(field.key, value.trim());
+        await updateAction(field.key, trimmed);
       }
+      setValue(trimmed);
+      setBaseline(trimmed);
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     });
   }
-
-  const isDirty = value !== initialValue;
 
   return (
     <div className="px-5 py-4" style={{ borderBottom: "1px solid var(--color-border)" }}>
@@ -378,6 +390,19 @@ function RecalculateLink({ deleteAction }: { deleteAction: (key: string) => Prom
 }
 
 export function ProfileForm({ values, updateAction, deleteAction }: Props) {
+  const [dirtyKeys, setDirtyKeys] = useState<Set<string>>(new Set());
+  const handleDirtyChange = useCallback((key: string, dirty: boolean) => {
+    setDirtyKeys((prev) => {
+      const has = prev.has(key);
+      if (dirty === has) return prev;
+      const next = new Set(prev);
+      if (dirty) next.add(key);
+      else next.delete(key);
+      return next;
+    });
+  }, []);
+  useUnsavedChangesWarning(dirtyKeys.size > 0);
+
   return (
     <div className="space-y-6">
       <div
@@ -396,6 +421,7 @@ export function ProfileForm({ values, updateAction, deleteAction }: Props) {
             initialValue={values[field.key] ?? ""}
             updateAction={updateAction}
             deleteAction={deleteAction}
+            onDirtyChange={handleDirtyChange}
           />
         ))}
       </div>
@@ -416,6 +442,7 @@ export function ProfileForm({ values, updateAction, deleteAction }: Props) {
             initialValue={values[field.key] ?? ""}
             updateAction={updateAction}
             deleteAction={deleteAction}
+            onDirtyChange={handleDirtyChange}
           />
         ))}
       </div>
@@ -440,6 +467,7 @@ export function ProfileForm({ values, updateAction, deleteAction }: Props) {
             initialValue={values[field.key] ?? ""}
             updateAction={updateAction}
             deleteAction={deleteAction}
+            onDirtyChange={handleDirtyChange}
           />
         ))}
       </div>

--- a/web/src/components/settings/sports-settings.tsx
+++ b/web/src/components/settings/sports-settings.tsx
@@ -98,6 +98,12 @@ export function SportsSettings({ favorites, saveAction }: Props) {
           <input
             value={query}
             onChange={(e) => { setQuery(e.target.value); setError(null); }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && results.length > 0) {
+                e.preventDefault();
+                handleAdd(results[0]);
+              }
+            }}
             placeholder="Search teams (e.g. Warriors, 49ers, Arsenal)"
             className="flex-1 rounded-lg px-3 py-2 text-sm transition-colors duration-150 focus:outline-none"
             style={{

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as Dialog from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
 import { ReactNode } from "react";
 
 interface SheetProps {
@@ -10,6 +11,12 @@ interface SheetProps {
   children: ReactNode;
   contentClassName?: string;
   contentStyle?: React.CSSProperties;
+  /**
+   * Hide the default visible header (title + close button). Use when the
+   * consumer renders its own header. Radix focus-trap and labelling are
+   * preserved either way (@radix-ui/react-dialog >= 1.1 provides focus-trap).
+   */
+  hideHeader?: boolean;
 }
 
 export default function Sheet({
@@ -19,6 +26,7 @@ export default function Sheet({
   children,
   contentClassName,
   contentStyle,
+  hideHeader,
 }: SheetProps) {
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -40,7 +48,35 @@ export default function Sheet({
           }}
           aria-describedby={undefined}
         >
-          <Dialog.Title className="sr-only">{title}</Dialog.Title>
+          {hideHeader ? (
+            <Dialog.Title className="sr-only">{title}</Dialog.Title>
+          ) : (
+            <div
+              className="flex items-center justify-between px-5 pt-4 pb-3"
+              style={{ borderBottom: "1px solid var(--color-border)" }}
+            >
+              <Dialog.Title
+                className="text-sm font-semibold"
+                style={{ color: "var(--color-text)" }}
+              >
+                {title}
+              </Dialog.Title>
+              <Dialog.Close
+                aria-label="Close"
+                className="flex items-center justify-center rounded transition-colors cursor-pointer"
+                style={{
+                  color: "var(--color-text-muted)",
+                  background: "transparent",
+                  border: "none",
+                  padding: 8,
+                  minWidth: 44,
+                  minHeight: 44,
+                }}
+              >
+                <X size={18} />
+              </Dialog.Close>
+            </div>
+          )}
           {children}
         </Dialog.Content>
       </Dialog.Portal>

--- a/web/src/lib/use-unsaved-changes-warning.ts
+++ b/web/src/lib/use-unsaved-changes-warning.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+
+const MESSAGE = "You have unsaved changes. Leave anyway?";
+
+export function useUnsavedChangesWarning(dirty: boolean) {
+  useEffect(() => {
+    if (!dirty) return;
+
+    function onBeforeUnload(e: BeforeUnloadEvent) {
+      e.preventDefault();
+      e.returnValue = MESSAGE;
+      return MESSAGE;
+    }
+
+    function onAnchorClick(e: MouseEvent) {
+      if (e.defaultPrevented) return;
+      if (e.button !== 0) return;
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+      const target = e.target as HTMLElement | null;
+      const anchor = target?.closest?.("a") as HTMLAnchorElement | null;
+      if (!anchor) return;
+      if (anchor.target && anchor.target !== "_self") return;
+      const href = anchor.getAttribute("href");
+      if (!href || href.startsWith("#")) return;
+      if (anchor.origin && anchor.origin !== window.location.origin) return;
+      if (anchor.pathname === window.location.pathname) return;
+      if (!window.confirm(MESSAGE)) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    }
+
+    window.addEventListener("beforeunload", onBeforeUnload);
+    document.addEventListener("click", onAnchorClick, true);
+    return () => {
+      window.removeEventListener("beforeunload", onBeforeUnload);
+      document.removeEventListener("click", onAnchorClick, true);
+    };
+  }, [dirty]);
+}


### PR DESCRIPTION
## Summary
- **M10** — `useUnsavedChangesWarning` hook (`beforeunload` + in-app anchor-click intercept) wired into `ProfileForm` via aggregated `FieldRow` dirty state. `FieldRow` now tracks a post-save baseline so dirty clears after save.
- **M11** — `Sheet` renders a visible `Dialog.Title` + `Dialog.Close` by default; `hideHeader` opt-out for existing consumers (`session-sheet`, nav "More" sheet). Radix focus-trap verified via `@radix-ui/react-dialog@^1.1.15`.
- **M12** — Enter on sports search adds the first result, matching peer forms.

Closes #231.

## Test plan
- [ ] Type into a Profile field, attempt page refresh → browser confirm appears.
- [ ] Type into a Profile field, click a nav link → confirm dialog; cancel stays, OK navigates.
- [ ] Save a field → dirty clears (no spurious warning on navigation).
- [ ] Mobile: open a sheet → visible header + close button; Escape closes; focus returns to trigger.
- [ ] Sports search: type "Warriors", press Enter → adds Warriors.
- [ ] Tab through every settings form — order coherent, Enter submits in every text input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)