### PR TITLE
fix: dashboard widget polish bundle (#232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (dashboard widget polish bundle — issue #232)
+- **M6 — TodayScoresStrip layout shift.** [web/src/components/dashboard/today-scores-strip.tsx](web/src/components/dashboard/today-scores-strip.tsx) switches from `flex-wrap` to `flex-col sm:flex-row`, eliminating the wrap-induced height jump on narrow viewports.
+- **M8 — `WebkitLineClamp` standard fallback.** [web/src/components/dashboard/important-emails.tsx](web/src/components/dashboard/important-emails.tsx) snippet adds standard `lineClamp`, `textOverflow: ellipsis`, and `maxHeight: 2.6em` alongside the `-webkit-box` clamp for browsers without the WebKit prefix.
+- **M9 — Birthday Gift icon `aria-label`.** [web/src/components/dashboard/schedule-today.tsx](web/src/components/dashboard/schedule-today.tsx) and [web/src/components/dashboard/upcoming-birthday.tsx](web/src/components/dashboard/upcoming-birthday.tsx) add `aria-label="Birthday"` + `role="img"` to the standalone `Gift` icons used in place of a time/label.
+- **L2 — Demo banner truncation at 375px.** [web/src/components/nav.tsx](web/src/components/nav.tsx) demo banner gets `overflow-hidden text-ellipsis whitespace-nowrap` + `title` for full text on hover.
+- **L6 — Workout history "Page X of Y" indicator.** [web/src/components/fitness/workout-history-table.tsx](web/src/components/fitness/workout-history-table.tsx) appends `· Page X of Y` to the existing row-range counter.
+- **L7 — Habit toggle `aria-checked`.** [web/src/components/dashboard/habits-checkin.tsx](web/src/components/dashboard/habits-checkin.tsx) row button gets `role="checkbox"`, `aria-checked={done}`, and `aria-label={habit.name}` for screen-reader semantics.
+- **L8 — Watchlist refresh button `whitespace-nowrap`.** [web/src/components/dashboard/watchlist-widget.tsx](web/src/components/dashboard/watchlist-widget.tsx) prevents "Refreshing…" from wrapping on narrow mobile.
+
 ### Fixed (settings form polish — issue #231)
 - **M10 — unsaved-changes warning on Settings.** New [web/src/lib/use-unsaved-changes-warning.ts](web/src/lib/use-unsaved-changes-warning.ts) hook attaches a `beforeunload` listener and intercepts in-app anchor navigation with `window.confirm` when any field is dirty. [web/src/components/settings/profile-form.tsx](web/src/components/settings/profile-form.tsx) aggregates dirty state across every `FieldRow` and invokes the hook. `FieldRow` now tracks a post-save baseline so dirty clears correctly once saved.
 - **M11 — visible sheet header + focus-trap.** [web/src/components/ui/sheet.tsx](web/src/components/ui/sheet.tsx) renders a visible `Dialog.Title` + `Dialog.Close` by default; added `hideHeader` opt-out for callers with their own header ([web/src/components/chat/session-sheet.tsx](web/src/components/chat/session-sheet.tsx), [web/src/components/nav.tsx](web/src/components/nav.tsx) "More" sheet). Focus-trap verified via `@radix-ui/react-dialog@^1.1.15` (Radix provides trap + restore by default).

--- a/web/src/components/dashboard/habits-checkin.tsx
+++ b/web/src/components/dashboard/habits-checkin.tsx
@@ -95,6 +95,9 @@ export default function HabitsCheckin({ registry, todayLogs, streaks, toggleActi
               key={habit.id}
               onClick={() => handleToggle(habit.id)}
               disabled={isPending}
+              role="checkbox"
+              aria-checked={done}
+              aria-label={habit.name}
               className="w-full flex items-center gap-2 py-1.5 px-1.5 rounded-lg text-left transition-colors duration-150 hover-bg-raised"
               style={{
                 opacity: isPending ? 0.5 : 1,

--- a/web/src/components/dashboard/important-emails.tsx
+++ b/web/src/components/dashboard/important-emails.tsx
@@ -81,7 +81,10 @@ export default function ImportantEmails() {
                     display: "-webkit-box",
                     WebkitLineClamp: 2,
                     WebkitBoxOrient: "vertical",
+                    lineClamp: 2,
                     overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    maxHeight: "2.6em",
                   }}
                 >
                   {email.snippet}

--- a/web/src/components/dashboard/schedule-today.tsx
+++ b/web/src/components/dashboard/schedule-today.tsx
@@ -107,7 +107,7 @@ export default function ScheduleToday() {
                 <div key={idx} className={`flex gap-3 items-start transition-opacity ${isPast ? "opacity-40" : ""}`}>
                   <span className="text-xs font-mono shrink-0 w-16 pt-px flex items-center" style={muted}>
                     {event.isBirthday
-                      ? <Gift size={12} style={accent} />
+                      ? <Gift size={12} style={accent} aria-label="Birthday" role="img" />
                       : event.time}
                   </span>
                   <div className="min-w-0">

--- a/web/src/components/dashboard/today-scores-strip.tsx
+++ b/web/src/components/dashboard/today-scores-strip.tsx
@@ -55,7 +55,7 @@ export default function TodayScoresStrip({ today }: Props) {
       <div style={{ height: 2, background: accent, flexShrink: 0 }} />
 
       <div
-        className="flex items-center gap-4 px-5 py-3 flex-wrap"
+        className="flex flex-col sm:flex-row sm:items-center gap-4 px-5 py-3"
         style={{ minHeight: 48 }}
       >
         {/* TODAY tag */}

--- a/web/src/components/dashboard/upcoming-birthday.tsx
+++ b/web/src/components/dashboard/upcoming-birthday.tsx
@@ -42,7 +42,7 @@ export default function UpcomingBirthdayWidget() {
 
   return (
     <div className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm" style={containerStyle}>
-      <Gift size={13} style={{ color: "var(--color-cta)", flexShrink: 0 }} />
+      <Gift size={13} style={{ color: "var(--color-cta)", flexShrink: 0 }} aria-label="Birthday" role="img" />
       <span>
         <span style={{ color: isToday ? "var(--color-cta)" : "var(--color-text)", fontWeight: isToday ? 500 : 400 }}>
           {birthday.name}&apos;s birthday

--- a/web/src/components/dashboard/watchlist-widget.tsx
+++ b/web/src/components/dashboard/watchlist-widget.tsx
@@ -162,7 +162,7 @@ export function WatchlistWidget({ rows, hasApiKey, refreshAction }: Props) {
           <button
             onClick={handleRefresh}
             disabled={isPending || !hasApiKey}
-            className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs transition-colors duration-150 cursor-pointer disabled:opacity-40 disabled:cursor-default"
+            className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs whitespace-nowrap transition-colors duration-150 cursor-pointer disabled:opacity-40 disabled:cursor-default"
             style={{
               background: "var(--color-surface-raised)",
               border: "1px solid var(--color-border)",

--- a/web/src/components/fitness/workout-history-table.tsx
+++ b/web/src/components/fitness/workout-history-table.tsx
@@ -289,7 +289,7 @@ export function WorkoutHistoryTable({ workouts }: Props) {
             >
               <span style={{ fontSize: 12, color: "var(--color-text-muted)" }}>
                 {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, sorted.length)} of{" "}
-                {sorted.length}
+                {sorted.length} · Page {page + 1} of {totalPages}
               </span>
               <div className="flex gap-2">
                 <button

--- a/web/src/components/nav.tsx
+++ b/web/src/components/nav.tsx
@@ -169,8 +169,9 @@ export default function Nav() {
         {/* Demo banner — desktop */}
         {isDemo && (
           <div
-            className="mx-3 mb-4 px-3 py-2.5 rounded-lg text-xs"
+            className="mx-3 mb-4 px-3 py-2.5 rounded-lg text-xs overflow-hidden text-ellipsis whitespace-nowrap"
             style={{ background: "var(--color-primary-dim)", color: "var(--color-primary)" }}
+            title="Demo account — changes reset nightly"
           >
             Demo account — changes reset nightly
           </div>


### PR DESCRIPTION
## Summary
Bundles seven dashboard polish nits from the UI/UX audit (issue #232 / plan `graceful-singing-hellman.md`):

- **M6** [today-scores-strip.tsx](web/src/components/dashboard/today-scores-strip.tsx) — `flex-col sm:flex-row` removes wrap-induced height shift on mobile
- **M8** [important-emails.tsx](web/src/components/dashboard/important-emails.tsx) — adds standard `lineClamp` + `textOverflow: ellipsis` + `maxHeight` fallback alongside `-webkit-box` clamp
- **M9** [schedule-today.tsx](web/src/components/dashboard/schedule-today.tsx), [upcoming-birthday.tsx](web/src/components/dashboard/upcoming-birthday.tsx) — `aria-label="Birthday"` + `role="img"` on standalone Gift icons
- **L2** [nav.tsx](web/src/components/nav.tsx) — demo banner truncates with `overflow-hidden text-ellipsis whitespace-nowrap` + hover `title`
- **L6** [workout-history-table.tsx](web/src/components/fitness/workout-history-table.tsx) — appends `· Page X of Y` to existing row counter
- **L7** [habits-checkin.tsx](web/src/components/dashboard/habits-checkin.tsx) — habit row button gets `role="checkbox"`, `aria-checked={done}`, `aria-label={habit.name}`
- **L8** [watchlist-widget.tsx](web/src/components/dashboard/watchlist-widget.tsx) — `whitespace-nowrap` keeps "Refreshing…" on one line

Closes #232.

## Test plan
- [ ] Visual: dashboard at 375 / 768 / 1024 — confirm scores strip stacks cleanly, demo banner truncates, watchlist refresh button stays single-line
- [ ] Email snippet clamps to 2 lines in non-WebKit browsers (Firefox)
- [ ] Screen reader announces birthday icons + habit toggle checked state
- [ ] Workout history pager shows "Page 1 of N" correctly
- [ ] `npx tsc --noEmit` (passes locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)