### PR TITLE
fix: prevent silent turn endings in chat agent loop (#223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (chat agent loop — issue #223)
+- **Bridge no longer ends a turn silently.** [web/src/app/api/chat/route.ts](web/src/app/api/chat/route.ts) `onFinish` previously skipped the DB write when the model produced no text (which happens when the AI SDK loop exhausts `maxSteps` on a tool step). It now synthesizes a deterministic summary from the executed `toolCalls` (e.g. *"Done. I updated a calendar event, created a calendar event."*) and persists that as the assistant turn, with a parenthetical note when the step or token cap was the cause. If no tools ran either, it persists a visible *"I hit a snag generating a response — please try again."* so the user is never left staring at silence.
+- **Step cap raised 12 → 20 with a token-budget guardrail.** Multi-step calendar/task flows were regularly hitting the old cap on the summary step. New `TOKEN_BUDGET = 150_000` tracked across steps via `onStepFinish`; when exceeded, an `AbortController` aborts the loop and the fallback-summary path takes over so cost stays bounded.
+- **Diagnostic log on every turn completion.** `[chat] turn complete session=… steps=N/20 tokens=… durationMs=… finishReason=… hitStepCap=… budgetExceeded=… synthesized=…` so we can see step-cap hits and fallback synthesis in production logs.
+
 ### Fixed (dashboard widget polish bundle — issue #232)
 - **M6 — TodayScoresStrip layout shift.** [web/src/components/dashboard/today-scores-strip.tsx](web/src/components/dashboard/today-scores-strip.tsx) switches from `flex-wrap` to `flex-col sm:flex-row`, eliminating the wrap-induced height jump on narrow viewports.
 - **M8 — `WebkitLineClamp` standard fallback.** [web/src/components/dashboard/important-emails.tsx](web/src/components/dashboard/important-emails.tsx) snippet adds standard `lineClamp`, `textOverflow: ellipsis`, and `maxHeight: 2.6em` alongside the `-webkit-box` clamp for browsers without the WebKit prefix.

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -140,7 +140,7 @@ Quantify wherever possible. Conservative estimates. Lead with the answer, then r
 Do not narrate before calling tools — never say things like "Let me check that", "Let me grab that now", "One moment", etc. Call the tool directly and respond after.
 When making sequential tool calls, always start each status update on a new line — never run status messages together without a line break.
 When creating multiple calendar events, work one week at a time. After completing each week, stop and report what was created, then wait for the user to confirm before continuing to the next week. Never attempt to create more than 7 events in a single response.
-If a task will require more than 12 sequential tool calls, stop before hitting the limit, summarize what you've done so far, and ask the user to break the remaining work into smaller requests. Never let the step limit cut you off silently mid-task.
+If a task will require more than 20 sequential tool calls, stop before hitting the limit, summarize what you've done so far, and ask the user to break the remaining work into smaller requests. Never let the step limit cut you off silently mid-task.
 Before calling get_session_history, ask the user: "Should I pull earlier messages from this session for more context?" Only call the tool if they confirm.
 
 Calendar pre-flight rules (apply before every create_calendar_event or assign_workout call):
@@ -194,6 +194,43 @@ When asked what to cook or for recipe ideas:
 6. Always provide at least one concrete, actionable recipe recommendation. Include estimated calories, protein, carbs, and fat. Flag if the meal is a poor nutritional fit for current fitness context.`;
 
 export const maxDuration = 60;
+
+// Issue #223: when the agent loop ends without an assistant text message
+// (step-cap exhaustion, token-budget abort, or a quiet model), build a short
+// human-readable summary from the tool calls that did execute so the user
+// sees acknowledgement instead of silence.
+const TOOL_PHRASING: Record<string, string> = {
+  add_task: "added a task",
+  complete_task: "marked a task complete",
+  log_habit: "logged a habit",
+  update_profile: "updated your profile",
+  create_calendar_event: "created a calendar event",
+  update_calendar_event: "updated a calendar event",
+  delete_calendar_event: "deleted a calendar event",
+  assign_workout: "assigned a workout",
+  update_workout_exercise: "updated a workout exercise",
+};
+function synthesizeFallbackSummary(
+  toolNames: string[],
+  flags: { hitStepCap: boolean; budgetExceeded: boolean }
+): string {
+  const counts = new Map<string, number>();
+  for (const name of toolNames) counts.set(name, (counts.get(name) ?? 0) + 1);
+  const phrases: string[] = [];
+  for (const [name, n] of counts) {
+    const phrase = TOOL_PHRASING[name];
+    if (phrase) phrases.push(n > 1 ? `${phrase} (×${n})` : phrase);
+  }
+  const body = phrases.length > 0
+    ? `Done. I ${phrases.join(", ")}.`
+    : `Done — completed ${toolNames.length} action${toolNames.length === 1 ? "" : "s"}.`;
+  const reason = flags.budgetExceeded
+    ? " (Hit my token budget before I could write a longer summary — let me know if you need detail.)"
+    : flags.hitStepCap
+      ? " (Hit my step limit before I could write a longer summary — let me know if you need detail.)"
+      : "";
+  return body + reason;
+}
 
 export async function POST(req: Request) {
   const { messages, sessionId, model: modelOverride } = await req.json() as {
@@ -1505,19 +1542,69 @@ ${userName ? `Address the user as "${userName}" — use their name naturally in 
     ? demoSystemPrompt
     : `${STATIC_SYSTEM_PROMPT}\n\n${dynamicPromptBlock}`;
 
+  // Per-turn safeguards (issue #223): raise step cap from 12→20 so multi-step
+  // calendar/task flows can finish their summary, but bound cost with a token
+  // budget. If the budget is exceeded mid-turn, abort the loop and let onFinish
+  // synthesize a deterministic summary from whatever tools already ran.
+  const MAX_STEPS = 20;
+  const TOKEN_BUDGET = 150_000;
+  const turnStartedAt = Date.now();
+  let cumulativeTokens = 0;
+  let budgetExceeded = false;
+  const turnAbort = new AbortController();
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const streamOptions: Parameters<typeof streamText>[0] = {
     model: selectedModel as any,
     system: systemValue,
     messages: [...contextMessages, ...cleanMessages],
     tools,
-    maxSteps: 12,
+    maxSteps: MAX_STEPS,
+    abortSignal: turnAbort.signal,
     onError: ({ error }) => {
       console.error("[chat] streamText error:", JSON.stringify(error));
     },
-    onFinish: async ({ text }) => {
+    onStepFinish: ({ usage }) => {
+      const stepTotal = (usage?.promptTokens ?? 0) + (usage?.completionTokens ?? 0);
+      cumulativeTokens += stepTotal;
+      if (cumulativeTokens > TOKEN_BUDGET && !budgetExceeded) {
+        budgetExceeded = true;
+        console.warn(`[chat] token budget exceeded session=${sessionId} tokens=${cumulativeTokens} budget=${TOKEN_BUDGET} — aborting turn`);
+        turnAbort.abort();
+      }
+    },
+    onFinish: async ({ text, steps, finishReason }) => {
       if (!sessionId || !userId) return;
-      if (!text.trim()) return; // Don't persist empty assistant responses (failed/tool-only steps)
+
+      const stepCount = steps?.length ?? 0;
+      const hitStepCap = stepCount >= MAX_STEPS;
+      const durationMs = Date.now() - turnStartedAt;
+
+      // Determine what to persist. Three cases:
+      //   1. Model produced text → persist as-is (normal path).
+      //   2. Empty text + tool calls ran → synthesize a deterministic summary from steps.
+      //   3. Empty text + nothing ran → persist a visible error so the user isn't left in silence.
+      let contentToPersist = text.trim();
+      let synthesized = false;
+
+      if (!contentToPersist) {
+        const toolNames = (steps ?? [])
+          .flatMap((s) => s.toolCalls ?? [])
+          .map((c) => c.toolName);
+        if (toolNames.length > 0) {
+          contentToPersist = synthesizeFallbackSummary(toolNames, { hitStepCap, budgetExceeded });
+          synthesized = true;
+        } else {
+          contentToPersist = "I hit a snag generating a response — please try again.";
+          synthesized = true;
+        }
+      }
+
+      console.log(
+        `[chat] turn complete session=${sessionId} steps=${stepCount}/${MAX_STEPS} ` +
+        `tokens=${cumulativeTokens} durationMs=${durationMs} finishReason=${finishReason} ` +
+        `hitStepCap=${hitStepCap} budgetExceeded=${budgetExceeded} synthesized=${synthesized}`
+      );
 
       try {
         // Update session last_active_at to reflect completed turn.
@@ -1540,7 +1627,7 @@ ${userName ? `Address the user as "${userName}" — use their name naturally in 
           session_id: sessionId,
           user_id: userId,
           role: "assistant",
-          content: text,
+          content: contentToPersist,
           position: nextPos,
         });
         if (insertError) throw insertError;


### PR DESCRIPTION
## Root cause
Closes #223. Bridge stalls after a user confirms a multi-step plan because [web/src/app/api/chat/route.ts](web/src/app/api/chat/route.ts) `onFinish` had an `if (!text.trim()) return;` guard that silently skipped the DB write when the AI SDK loop exhausted `maxSteps: 12` on a tool step. The calendar tools ran successfully, but no assistant message was ever persisted — so the UI stream just ended with nothing to display, and the model's follow-up "I didn't get a chance to execute" was a hallucination from a fresh context that never saw its own prior tool results.

Hypotheses B (stream close) and C (silent tool failure) ruled out during diagnosis: stream lifecycle is straightforward and tool errors are already structured back to the model.

## Changes
- **No more silent turns.** Empty model text now triggers a deterministic fallback summary built from the executed `toolCalls` (e.g. *"Done. I updated a calendar event, created a calendar event."*), persisted as the assistant message. Step-cap or token-budget cutoffs append a parenthetical note. Empty text + zero tools persists *"I hit a snag generating a response — please try again."*
- **`maxSteps` 12 → 20** with a `TOKEN_BUDGET = 150_000` enforced via `onStepFinish` + `AbortController` so cost stays bounded.
- **Per-turn completion log** capturing `steps`, `tokens`, `durationMs`, `finishReason`, `hitStepCap`, `budgetExceeded`, `synthesized`.
- System prompt updated to reference the new 20-step ceiling.

## Test plan
- [ ] Repro the original failing flow (multi-step calendar plan with conflict resolution + new event creation) and confirm a final assistant summary appears in the UI and lands in `chat_messages` with `role=assistant`.
- [ ] Force a step-cap hit (contrived prompt requesting ≥20 sequential tool calls); confirm fallback summary is generated and persisted, and the new completion log shows `hitStepCap=true synthesized=true`.
- [ ] Force a token-budget abort (long context turn); confirm log shows `budgetExceeded=true` and a fallback summary lands.
- [ ] Regression: normal single-step chat turn still flows model text through unchanged (`synthesized=false`).
- [ ] Supabase: query `chat_messages` for repro session and confirm no turn ends on `role=tool` without a following `role=assistant`.

## Out of scope
Stream-side "turn complete" marker (Hypothesis B mitigation) — only worth adding if we see further evidence after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)