### PR TITLE
fix: route all date-only strings through timezone helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (UTC date regressions — Fitness "TODAY" off-by-one)
+- **Fitness weekly plan highlighted the wrong day after ~5pm PT.** [web/src/components/fitness/weekly-workout-plan.tsx](web/src/components/fitness/weekly-workout-plan.tsx) used `new Date().toISOString().slice(0,10)` (UTC) to determine "today" and to build the Mon–Sun week. After UTC rolled over, the "TODAY" badge jumped to tomorrow. Now routed through `todayString()` + `addDays()` from [web/src/lib/timezone.ts](web/src/lib/timezone.ts).
+- **Repo-wide sweep for the same UTC slice pattern.** Replaced UTC-derived date strings in:
+  - [web/src/components/fitness/active-cal-goal-chart.tsx](web/src/components/fitness/active-cal-goal-chart.tsx), [web/src/components/fitness/workout-freq-chart.tsx](web/src/components/fitness/workout-freq-chart.tsx) — daily/weekly bucket keys and labels.
+  - [web/src/app/(protected)/fitness/page.tsx](web/src/app/(protected)/fitness/page.tsx) — Mon–Sun week bounds for the workout-plans query.
+  - [web/src/components/dashboard/trends-card.tsx](web/src/components/dashboard/trends-card.tsx) — window cutoff.
+  - [web/src/lib/sync/stocks.ts](web/src/lib/sync/stocks.ts), [web/src/lib/sync/fitbit.ts](web/src/lib/sync/fitbit.ts), [web/src/lib/sync/oura.ts](web/src/lib/sync/oura.ts) — external-API date-range params (and Polygon bar timestamps via `Intl.DateTimeFormat` in `USER_TZ`).
+  - [web/src/app/api/cron/reset-demo/route.ts](web/src/app/api/cron/reset-demo/route.ts) — demo seed dates and weekday detection.
+  - [web/src/app/api/chat/route.ts](web/src/app/api/chat/route.ts) — demo calendar events and the `get_workout_plans` weekly tool query.
+  - [web/src/app/api/google/calendar/route.ts](web/src/app/api/google/calendar/route.ts) — removed dead `today` constant.
+
 ### Fixed (chat agent loop — issue #223)
 - **Bridge no longer ends a turn silently.** [web/src/app/api/chat/route.ts](web/src/app/api/chat/route.ts) `onFinish` previously skipped the DB write when the model produced no text (which happens when the AI SDK loop exhausts `maxSteps` on a tool step). It now synthesizes a deterministic summary from the executed `toolCalls` (e.g. *"Done. I updated a calendar event, created a calendar event."*) and persists that as the assistant turn, with a parenthetical note when the step or token cap was the cause. If no tools ran either, it persists a visible *"I hit a snag generating a response — please try again."* so the user is never left staring at silence.
 - **Step cap raised 12 → 20 with a token-budget guardrail.** Multi-step calendar/task flows were regularly hitting the old cap on the summary step. New `TOKEN_BUDGET = 150_000` tracked across steps via `onStepFinish`; when exceeded, an `AbortController` aborts the loop and the fallback-summary path takes over so cost stays bounded.

--- a/web/src/app/(protected)/fitness/page.tsx
+++ b/web/src/app/(protected)/fitness/page.tsx
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
-import { daysAgoString } from "@/lib/timezone";
+import { daysAgoString, todayString, addDays } from "@/lib/timezone";
 import { getWindow } from "@/lib/window";
 
 export const metadata: Metadata = {
@@ -24,15 +24,11 @@ export default async function FitnessPage() {
   const { key: windowKey, days } = await getWindow();
   const weekCount = Math.ceil(days / 7);
 
-  // Current ISO week bounds (Mon–Sun)
-  const today = new Date();
-  const dow = (today.getDay() + 6) % 7; // 0=Mon, 6=Sun
-  const monday = new Date(today);
-  monday.setDate(today.getDate() - dow);
-  const sunday = new Date(monday);
-  sunday.setDate(monday.getDate() + 6);
-  const mondayStr = monday.toISOString().slice(0, 10);
-  const sundayStr = sunday.toISOString().slice(0, 10);
+  // Current ISO week bounds (Mon–Sun) in user's local timezone
+  const todayStr = todayString();
+  const dow = (new Date(`${todayStr}T12:00:00Z`).getUTCDay() + 6) % 7; // 0=Mon, 6=Sun
+  const mondayStr = addDays(todayStr, -dow);
+  const sundayStr = addDays(mondayStr, 6);
 
   const [fitnessRes, workoutsRes, recoveryRes, profileRes, weeklyPlansRes] = await Promise.all([
     supabase

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -1185,7 +1185,7 @@ ${userName ? `Address the user as "${userName}" — use their name naturally in 
           .lte("date", sunday)
           .order("date", { ascending: true });
         if (error) return { error: error.message };
-        return { week: `${fmt(monday)} – ${fmt(sunday)}`, plans: data ?? [] };
+        return { week: `${monday} – ${sunday}`, plans: data ?? [] };
       },
     }),
 

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -50,10 +50,10 @@ const DEMO_EMAILS = [
 ];
 
 const DEMO_CALENDAR_EVENTS = [
-  { title: "Morning run", start: `${new Date().toISOString().slice(0, 10)}T06:30:00`, end: `${new Date().toISOString().slice(0, 10)}T07:15:00`, allDay: false, calendar: "Alex Chen", calendarType: "primary", location: null },
-  { title: "Team standup", start: `${new Date().toISOString().slice(0, 10)}T09:00:00`, end: `${new Date().toISOString().slice(0, 10)}T09:30:00`, allDay: false, calendar: "Alex Chen", calendarType: "primary", location: "Google Meet" },
-  { title: "Lunch w/ Priya", start: `${new Date().toISOString().slice(0, 10)}T12:30:00`, end: `${new Date().toISOString().slice(0, 10)}T13:30:00`, allDay: false, calendar: "Alex Chen", calendarType: "primary", location: "Tartine Manufactory" },
-  { title: "Gym — push day", start: `${new Date().toISOString().slice(0, 10)}T18:00:00`, end: `${new Date().toISOString().slice(0, 10)}T19:00:00`, allDay: false, calendar: "Alex Chen", calendarType: "primary", location: "Equinox SoMa" },
+  { title: "Morning run", start: `${todayString()}T06:30:00`, end: `${todayString()}T07:15:00`, allDay: false, calendar: "Alex Chen", calendarType: "primary", location: null },
+  { title: "Team standup", start: `${todayString()}T09:00:00`, end: `${todayString()}T09:30:00`, allDay: false, calendar: "Alex Chen", calendarType: "primary", location: "Google Meet" },
+  { title: "Lunch w/ Priya", start: `${todayString()}T12:30:00`, end: `${todayString()}T13:30:00`, allDay: false, calendar: "Alex Chen", calendarType: "primary", location: "Tartine Manufactory" },
+  { title: "Gym — push day", start: `${todayString()}T18:00:00`, end: `${todayString()}T19:00:00`, allDay: false, calendar: "Alex Chen", calendarType: "primary", location: "Equinox SoMa" },
 ];
 
 const retryOnOverload: LanguageModelV1Middleware = {
@@ -1173,19 +1173,16 @@ ${userName ? `Address the user as "${userName}" — use their name naturally in 
       execute: async () => {
         if (!userId) return { error: "Not authenticated" };
         if (isDemo) return { demo: true, note: "Demo mode — no real workout plans." };
-        const today = new Date();
-        const dow = (today.getDay() + 6) % 7; // 0=Mon, 6=Sun
-        const monday = new Date(today);
-        monday.setDate(today.getDate() - dow);
-        const sunday = new Date(monday);
-        sunday.setDate(monday.getDate() + 6);
-        const fmt = (d: Date) => d.toISOString().slice(0, 10);
+        const todayStr = todayString();
+        const dow = (new Date(`${todayStr}T12:00:00Z`).getUTCDay() + 6) % 7; // 0=Mon, 6=Sun
+        const monday = addDays(todayStr, -dow);
+        const sunday = addDays(monday, 6);
         const { data, error } = await supabase
           .from("workout_plans")
           .select("*")
           .eq("user_id", userId)
-          .gte("date", fmt(monday))
-          .lte("date", fmt(sunday))
+          .gte("date", monday)
+          .lte("date", sunday)
           .order("date", { ascending: true });
         if (error) return { error: error.message };
         return { week: `${fmt(monday)} – ${fmt(sunday)}`, plans: data ?? [] };

--- a/web/src/app/api/cron/reset-demo/route.ts
+++ b/web/src/app/api/cron/reset-demo/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createServiceClient } from "@/lib/supabase/service";
+import { todayString, addDays } from "@/lib/timezone";
 
 // Tables to wipe (children first to respect FK constraints)
 const TABLES = [
@@ -59,12 +60,8 @@ export async function GET(req: Request) {
 type SupabaseClient = ReturnType<typeof createServiceClient>;
 
 async function seedDemoData(supabase: SupabaseClient, uid: string) {
-  const today = new Date();
-  const daysAgo = (n: number) => {
-    const d = new Date(today);
-    d.setDate(d.getDate() - n);
-    return d.toISOString().slice(0, 10);
-  };
+  const today = todayString();
+  const daysAgo = (n: number) => addDays(today, -n);
 
   // Profile
   const profileRows = [
@@ -193,9 +190,9 @@ async function seedDemoData(supabase: SupabaseClient, uid: string) {
   // Recovery metrics — 30 nights
   const recoveryRows = [];
   for (let dago = 30; dago > 0; dago--) {
-    const d = new Date(today);
-    d.setDate(d.getDate() - dago);
-    const isWeekend = d.getDay() === 0 || d.getDay() === 6;
+    const dateStr = addDays(today, -dago);
+    const dow = new Date(`${dateStr}T12:00:00Z`).getUTCDay();
+    const isWeekend = dow === 0 || dow === 6;
     const hashA = ((dago * 11) % 10) / 10;
     const hashB = ((dago * 17) % 10) / 10;
     recoveryRows.push({

--- a/web/src/app/api/google/calendar/route.ts
+++ b/web/src/app/api/google/calendar/route.ts
@@ -25,15 +25,12 @@ function formatTime(dateTimeStr: string | null | undefined, dateStr: string | nu
   });
 }
 
-const today = new Date().toISOString().slice(0, 10);
 const DEMO_EVENTS: CalendarEvent[] = [
   { time: "6:30 AM",  title: "Morning run",    calendarName: "Alex Chen", isPrimary: true, isBirthday: false },
   { time: "9:00 AM",  title: "Team standup",   calendarName: "Alex Chen", isPrimary: true, isBirthday: false, location: "Google Meet" },
   { time: "12:30 PM", title: "Lunch w/ Priya", calendarName: "Alex Chen", isPrimary: true, isBirthday: false, location: "Tartine Manufactory" },
   { time: "6:00 PM",  title: "Gym — push day", calendarName: "Alex Chen", isPrimary: true, isBirthday: false, location: "Equinox SoMa" },
 ];
-// suppress unused variable warning from linter
-void today;
 
 export async function GET() {
   const serverClient = await createClient();

--- a/web/src/components/dashboard/trends-card.tsx
+++ b/web/src/components/dashboard/trends-card.tsx
@@ -15,6 +15,7 @@ import {
 } from "recharts";
 import type { FitnessLog, RecoveryMetrics, WorkoutSession } from "@/lib/types";
 import { useChartColors } from "@/lib/chart-colors";
+import { daysAgoString } from "@/lib/timezone";
 
 interface Props {
   fitnessData: FitnessLog[];
@@ -76,11 +77,7 @@ export default function TrendsCard({ fitnessData, recoveryData, recentWorkout }:
   } as const;
   const legendWrapperStyle = { fontSize: "11px", color: c.textMuted, paddingTop: "8px" };
 
-  const cutoff = useMemo(() => {
-    const d = new Date();
-    d.setDate(d.getDate() - WINDOW_DAYS[window]);
-    return d.toISOString().slice(0, 10);
-  }, [window]);
+  const cutoff = useMemo(() => daysAgoString(WINDOW_DAYS[window]), [window]);
 
   const bodyCompData = useMemo(
     () =>

--- a/web/src/components/fitness/active-cal-goal-chart.tsx
+++ b/web/src/components/fitness/active-cal-goal-chart.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { GranularityToggle } from "@/components/ui/granularity-toggle";
 import { formatDate, computeDailyTicks, computeWeeklyTicks, daysToWindowKey } from "@/lib/chart-utils";
 import { useChartColors } from "@/lib/chart-colors";
+import { todayString, addDays } from "@/lib/timezone";
 
 interface DataPoint {
   date: string;
@@ -22,26 +23,21 @@ interface Props {
   days: number;
 }
 
-function getISOWeekLabel(dateStr: string): string {
-  const d = new Date(dateStr + "T00:00:00");
-  const day = d.getDay();
+function getISOWeekKey(dateStr: string): string {
+  const day = new Date(`${dateStr}T12:00:00Z`).getUTCDay();
   const diff = (day === 0 ? -6 : 1) - day;
-  const monday = new Date(d);
-  monday.setDate(d.getDate() + diff);
-  return monday.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  return addDays(dateStr, diff);
 }
 
-function getISOWeekKey(dateStr: string): string {
-  const d = new Date(dateStr + "T00:00:00");
-  const day = d.getDay();
-  const diff = (day === 0 ? -6 : 1) - day;
-  const monday = new Date(d);
-  monday.setDate(d.getDate() + diff);
-  return monday.toISOString().slice(0, 10);
+function getISOWeekLabel(dateStr: string): string {
+  const monday = getISOWeekKey(dateStr);
+  return new Date(`${monday}T12:00:00Z`).toLocaleDateString("en-US", {
+    month: "short", day: "numeric", timeZone: "UTC",
+  });
 }
 
 function dayOfWeek(dateStr: string): number {
-  return new Date(dateStr + "T00:00:00").getDay();
+  return new Date(`${dateStr}T12:00:00Z`).getUTCDay();
 }
 
 export function ActiveCalGoalChart({ data, goal, days }: Props) {
@@ -67,16 +63,14 @@ export function ActiveCalGoalChart({ data, goal, days }: Props) {
     setAnimate(!mq.matches);
   }, []);
 
-  const now = new Date();
+  const today = todayString();
   const hasGoal = goal != null && goal > 0;
 
   // ── Weekly mode ──────────────────────────────────────────────────────────
   const weekSlots: { key: string; label: string; total: number }[] = [];
   if (granularity === "weekly") {
     for (let i = weekCount - 1; i >= 0; i--) {
-      const d = new Date(now);
-      d.setDate(d.getDate() - i * 7);
-      const dateStr = d.toISOString().slice(0, 10);
+      const dateStr = addDays(today, -i * 7);
       const key = getISOWeekKey(dateStr);
       if (!weekSlots.find((w) => w.key === key)) {
         weekSlots.push({ key, label: getISOWeekLabel(dateStr), total: 0 });
@@ -94,9 +88,7 @@ export function ActiveCalGoalChart({ data, goal, days }: Props) {
   const daySlots: { key: string; label: string; total: number | null; isMonday: boolean }[] = [];
   if (granularity === "daily") {
     for (let i = days - 1; i >= 0; i--) {
-      const d = new Date(now);
-      d.setDate(d.getDate() - i);
-      const dateStr = d.toISOString().slice(0, 10);
+      const dateStr = addDays(today, -i);
       daySlots.push({
         key: dateStr,
         label: formatDate(dateStr),

--- a/web/src/components/fitness/weekly-workout-plan.tsx
+++ b/web/src/components/fitness/weekly-workout-plan.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { ChevronUp, ChevronDown } from "lucide-react";
 import type { WorkoutPlan, WorkoutExercise } from "@/lib/types";
+import { todayString, addDays } from "@/lib/timezone";
 
 interface Props {
   plans: WorkoutPlan[];
@@ -18,18 +19,14 @@ interface DaySlot {
 }
 
 function buildWeekDays(plans: WorkoutPlan[], completedDates: string[]): DaySlot[] {
-  const today = new Date();
-  const todayStr = today.toISOString().slice(0, 10);
-  const dow = (today.getDay() + 6) % 7; // 0=Mon, 6=Sun
-  const monday = new Date(today);
-  monday.setDate(today.getDate() - dow);
+  const todayStr = todayString();
+  const dow = (new Date(`${todayStr}T12:00:00Z`).getUTCDay() + 6) % 7; // 0=Mon, 6=Sun
+  const mondayStr = addDays(todayStr, -dow);
 
   const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
   return DAY_LABELS.map((label, i) => {
-    const d = new Date(monday);
-    d.setDate(monday.getDate() + i);
-    const date = d.toISOString().slice(0, 10);
+    const date = addDays(mondayStr, i);
     return {
       label,
       date,
@@ -98,7 +95,7 @@ function PhaseSection({ label, exercises }: { label: string; exercises: WorkoutE
 
 export function WeeklyWorkoutPlan({ plans, completedDates }: Props) {
   const days = buildWeekDays(plans, completedDates);
-  const todayDate = new Date().toISOString().slice(0, 10);
+  const todayDate = todayString();
 
   const [open, setOpen] = useState<Record<string, boolean>>(() => ({
     [todayDate]: true,

--- a/web/src/components/fitness/workout-freq-chart.tsx
+++ b/web/src/components/fitness/workout-freq-chart.tsx
@@ -11,6 +11,7 @@ import Link from "next/link";
 import { GranularityToggle } from "@/components/ui/granularity-toggle";
 import { formatDate, computeDailyTicks, computeWeeklyTicks, daysToWindowKey } from "@/lib/chart-utils";
 import { useChartColors, type ChartColors } from "@/lib/chart-colors";
+import { todayString, addDays } from "@/lib/timezone";
 
 interface Props {
   sessions: WorkoutSession[];
@@ -18,22 +19,17 @@ interface Props {
   goal?: number | null;
 }
 
-function getISOWeekLabel(dateStr: string): string {
-  const d = new Date(dateStr + "T00:00:00");
-  const day = d.getDay();
+function getISOWeekKey(dateStr: string): string {
+  const day = new Date(`${dateStr}T12:00:00Z`).getUTCDay();
   const diff = (day === 0 ? -6 : 1) - day;
-  const monday = new Date(d);
-  monday.setDate(d.getDate() + diff);
-  return monday.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  return addDays(dateStr, diff);
 }
 
-function getISOWeekKey(dateStr: string): string {
-  const d = new Date(dateStr + "T00:00:00");
-  const day = d.getDay();
-  const diff = (day === 0 ? -6 : 1) - day;
-  const monday = new Date(d);
-  monday.setDate(d.getDate() + diff);
-  return monday.toISOString().slice(0, 10);
+function getISOWeekLabel(dateStr: string): string {
+  const monday = getISOWeekKey(dateStr);
+  return new Date(`${monday}T12:00:00Z`).toLocaleDateString("en-US", {
+    month: "short", day: "numeric", timeZone: "UTC",
+  });
 }
 
 function barColor(count: number, goal: number, c: ChartColors): string {
@@ -43,7 +39,7 @@ function barColor(count: number, goal: number, c: ChartColors): string {
 }
 
 function dayOfWeek(dateStr: string): number {
-  return new Date(dateStr + "T00:00:00").getDay(); // 0 = Sunday, 1 = Monday
+  return new Date(`${dateStr}T12:00:00Z`).getUTCDay(); // 0 = Sunday, 1 = Monday
 }
 
 export function WorkoutFreqChart({ sessions, days, goal }: Props) {
@@ -70,16 +66,14 @@ export function WorkoutFreqChart({ sessions, days, goal }: Props) {
     setAnimate(!mq.matches);
   }, []);
 
-  const now = new Date();
+  const today = todayString();
   const hasGoal = goal != null && goal > 0;
 
   // ── Weekly mode ──────────────────────────────────────────────────────────
   const weekSlots: { key: string; label: string; count: number }[] = [];
   if (granularity === "weekly") {
     for (let i = weekCount - 1; i >= 0; i--) {
-      const d = new Date(now);
-      d.setDate(d.getDate() - i * 7);
-      const dateStr = d.toISOString().slice(0, 10);
+      const dateStr = addDays(today, -i * 7);
       const key = getISOWeekKey(dateStr);
       if (!weekSlots.find((w) => w.key === key)) {
         weekSlots.push({ key, label: getISOWeekLabel(dateStr), count: 0 });
@@ -96,9 +90,7 @@ export function WorkoutFreqChart({ sessions, days, goal }: Props) {
   const daySlots: { key: string; label: string; count: number; isMonday: boolean }[] = [];
   if (granularity === "daily") {
     for (let i = days - 1; i >= 0; i--) {
-      const d = new Date(now);
-      d.setDate(d.getDate() - i);
-      const dateStr = d.toISOString().slice(0, 10);
+      const dateStr = addDays(today, -i);
       daySlots.push({
         key: dateStr,
         label: formatDate(dateStr),

--- a/web/src/lib/sync/fitbit.ts
+++ b/web/src/lib/sync/fitbit.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { logSync } from "./log";
+import { todayString, daysAgoString } from "@/lib/timezone";
 
 const FITBIT_TOKEN_URL = "https://api.fitbit.com/oauth2/token";
 const FITBIT_API_BASE = "https://api.fitbit.com";
@@ -138,11 +139,8 @@ export async function syncFitbit(db: SupabaseClient, userId: string): Promise<Fi
 
   const accessToken = await refreshFitbitToken(db, clientId, clientSecret, refreshToken, userId);
 
-  const now = new Date();
-  const past = new Date(now);
-  past.setDate(past.getDate() - SYNC_DAYS);
-  const startStr = past.toISOString().slice(0, 10);
-  const endStr = now.toISOString().slice(0, 10);
+  const startStr = daysAgoString(SYNC_DAYS);
+  const endStr = todayString();
 
   // Fetch body comp and workouts in parallel
   const weightUnit = (process.env.FITBIT_WEIGHT_UNIT ?? "lbs").toLowerCase();

--- a/web/src/lib/sync/oura.ts
+++ b/web/src/lib/sync/oura.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { logSync } from "./log";
+import { todayString, daysAgoString } from "@/lib/timezone";
 
 const OURA_BASE = "https://api.ouraring.com/v2/usercollection";
 
@@ -53,11 +54,8 @@ export async function syncOura(db: SupabaseClient, userId: string, days = 3): Pr
   const token = process.env.OURA_ACCESS_TOKEN;
   if (!token) throw new Error("OURA_ACCESS_TOKEN not configured");
 
-  const now = new Date();
-  const past = new Date(now);
-  past.setDate(past.getDate() - days);
-  const startStr = past.toISOString().slice(0, 10);
-  const endStr = now.toISOString().slice(0, 10);
+  const startStr = daysAgoString(days);
+  const endStr = todayString();
 
   const [
     sleepData,

--- a/web/src/lib/sync/stocks.ts
+++ b/web/src/lib/sync/stocks.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { todayString, daysAgoString, USER_TZ } from "@/lib/timezone";
 
 const POLYGON_BASE = "https://api.polygon.io";
 
@@ -42,11 +43,8 @@ export async function syncStocks(
   if (!apiKey) throw new Error("POLYGON_API_KEY not configured");
 
   // Sparkline range: 45 calendar days back to guarantee ≥30 trading days
-  const now = new Date();
-  const fromDate = new Date(now);
-  fromDate.setDate(fromDate.getDate() - 45);
-  const from = fromDate.toISOString().slice(0, 10);
-  const to = now.toISOString().slice(0, 10);
+  const from = daysAgoString(45);
+  const to = todayString();
 
   let rateLimited = false;
   const rows = await Promise.all(
@@ -67,7 +65,7 @@ export async function syncStocks(
       const rangeBars = (rangeData?.results as PolygonBar[] | undefined) ?? [];
       // Keep last 30 trading days (~6 weeks of context)
       const sparkline = rangeBars.slice(-30).map((bar) => ({
-        date: new Date(bar.t).toISOString().slice(0, 10),
+        date: new Intl.DateTimeFormat("en-CA", { timeZone: USER_TZ }).format(new Date(bar.t)),
         close: bar.c,
       }));
 


### PR DESCRIPTION
## Summary
- Fitness "TODAY" badge was highlighting tomorrow after ~5pm PT because `weekly-workout-plan.tsx` derived "today" via `new Date().toISOString().slice(0,10)` (UTC).
- Same UTC slice pattern had crept back into 11 other call sites across fitness charts, dashboard trends, week-bound queries, sync scripts (stocks/fitbit/oura), demo seed, and chat-tool code paths.
- All date-only strings now flow through `todayString` / `addDays` / `daysAgoString` from [lib/timezone.ts](web/src/lib/timezone.ts).

## Test plan
- [ ] Load `/fitness` after 5pm PT (or with system clock past UTC midnight) — verify the "TODAY" badge is on the correct local day and the Mon–Sun week range is correct.
- [ ] `/dashboard` Trends card 7d/30d/90d/1y windows still filter correctly.
- [ ] Run `scripts/run-syncs.py` — fitbit/oura/stocks ranges still pull the expected windows.
- [ ] `/api/cron/reset-demo` reseeds with dates anchored to local today.
- [ ] Chat tool `get_workout_plans` returns the current local week's plans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)