### PR TITLE
fix: allow update_workout_exercise to rename exercises (#239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (update_workout_exercise silent no-op on swaps — issue #239)
+- **Bridge claimed it had swapped an exercise but the Fitness tab still showed the old name.** The `update_workout_exercise` tool's `updates` schema in [web/src/app/api/chat/route.ts](web/src/app/api/chat/route.ts) only accepted `sets | reps | weight_lbs | notes` — there was no way to change the exercise name. When asked to "replace Bent Over Row with DB Reverse Fly", the rename was dropped by JSON-schema validation, the UPDATE ran with an unchanged array, and Bridge confidently reported success. Schema now accepts `updates.exercise` for swaps/renames, and the tool returns an error when `updates` is empty so Bridge can tell the user truthfully instead of falsely confirming.
+
 ### Fixed (UTC date regressions — Fitness "TODAY" off-by-one)
 - **Fitness weekly plan highlighted the wrong day after ~5pm PT.** [web/src/components/fitness/weekly-workout-plan.tsx](web/src/components/fitness/weekly-workout-plan.tsx) used `new Date().toISOString().slice(0,10)` (UTC) to determine "today" and to build the Mon–Sun week. After UTC rolled over, the "TODAY" badge jumped to tomorrow. Now routed through `todayString()` + `addDays()` from [web/src/lib/timezone.ts](web/src/lib/timezone.ts).
 - **Repo-wide sweep for the same UTC slice pattern.** Replaced UTC-derived date strings in:

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -1290,23 +1290,24 @@ ${userName ? `Address the user as "${userName}" — use their name naturally in 
     }),
 
     update_workout_exercise: tool({
-      description: "Patch a single exercise in one phase of an existing workout plan. Fetches the row, finds the exercise by name (case-insensitive), merges the updates, upserts back, and refreshes the calendar event description.",
+      description: "Patch a single exercise in one phase of an existing workout plan. Fetches the row, finds the exercise by name (case-insensitive), merges the updates, upserts back, and refreshes the calendar event description. Supports renaming/swapping the exercise via updates.exercise.",
       parameters: jsonSchema<{
         date: string;
         phase: "warmup" | "workout" | "cooldown";
         exercise_name: string;
-        updates: { sets?: number; reps?: string; weight_lbs?: number; notes?: string };
+        updates: { exercise?: string; sets?: number; reps?: string; weight_lbs?: number; notes?: string };
       }>({
         type: "object",
         required: ["date", "phase", "exercise_name", "updates"],
         properties: {
           date: { type: "string", description: "YYYY-MM-DD date of the plan to edit." },
           phase: { type: "string", enum: ["warmup", "workout", "cooldown"], description: "Which phase the exercise is in." },
-          exercise_name: { type: "string", description: "Exercise name to match (case-insensitive)." },
+          exercise_name: { type: "string", description: "Existing exercise name to match (case-insensitive)." },
           updates: {
             type: "object",
-            description: "Fields to merge into the matched exercise object.",
+            description: "Fields to merge into the matched exercise object. Use `exercise` to rename/swap.",
             properties: {
+              exercise: { type: "string", description: "New exercise name (for swaps/renames)." },
               sets: { type: "number" },
               reps: { type: "string" },
               weight_lbs: { type: "number" },
@@ -1330,6 +1331,9 @@ ${userName ? `Address the user as "${userName}" — use their name naturally in 
         const arr: WorkoutExercise[] = [...(row[phase] as WorkoutExercise[])];
         const idx = arr.findIndex((e) => e.exercise.toLowerCase() === exercise_name.toLowerCase());
         if (idx === -1) return { error: `Exercise "${exercise_name}" not found in ${phase}.` };
+        if (!updates || Object.keys(updates).length === 0) {
+          return { error: "No fields provided to update. Specify at least one of: exercise, sets, reps, weight_lbs, notes." };
+        }
         arr[idx] = { ...arr[idx], ...updates };
 
         const { data: updated, error: upErr } = await supabase


### PR DESCRIPTION
Closes #239.

## Root cause

Diagnosed through all five hypotheses from the issue:

- Tool and Fitness tab hit the **same table + same row** (`workout_plans`, filtered by `user_id` + `date`) → rules out A (wrong table), B (scoping), C (template vs instance).
- Fitness page uses `export const dynamic = "force-dynamic"` → rules out E (caching).
- The `update_workout_exercise` tool's `updates` JSON schema only accepted `sets | reps | weight_lbs | notes` — **no field for the exercise name**. When asked "replace Bent Over Row with DB Reverse Fly", the model's rename was stripped by schema validation, the spread merged an empty/nameless object into the exercise, and the UPDATE committed an unchanged row. The tool returned a truthful "success" to Bridge, which confirmed to the user — but nothing changed. Hypothesis D (silent no-op) plus a missing feature.

## Changes

[web/src/app/api/chat/route.ts](web/src/app/api/chat/route.ts) — `update_workout_exercise`:

1. Add optional `updates.exercise` (string) to the JSON schema and TS type so the existing spread at the merge site picks up renames.
2. Return `{ error: "No fields provided to update…" }` when `updates` is empty, so Bridge reports failure truthfully instead of confirming a no-op.

[CHANGELOG.md](CHANGELOG.md) updated under `[Unreleased]`.

## Not doing

- No `revalidatePath('/fitness')` — page is already `force-dynamic`.
- No schema redesign (template vs instance) — out of scope per issue.
- No rowCount check around the UPDATE — the pre-fetch `.single()` at line 1322 already guarantees the row exists.

## Test plan

- [ ] `cd web && npm run dev`
- [ ] In chat: "Replace Bent Over Row with DB Reverse Fly in today's workout." Bridge calls the tool with `updates.exercise = "DB Reverse Fly"`.
- [ ] Fitness tab → hard refresh → shows DB Reverse Fly.
- [ ] Supabase row (`select workout from workout_plans where user_id=<uid> and date=<today>`) shows the new name.
- [ ] Negative: ask "update my bench press" with no fields → Bridge reports failure (empty-updates guard).
- [ ] Negative: ask to edit an exercise not in today's plan → existing "not found" error still fires.
- [ ] `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)