### PR TITLE
fix: UI/UX mop-up — tokenization tail, inline hovers, CI guards

### DIFF
--- a/.github/workflows/lint-tokens.yml
+++ b/.github/workflows/lint-tokens.yml
@@ -1,0 +1,15 @@
+name: Lint — Design Tokens
+
+on:
+  pull_request:
+    paths:
+      - 'web/src/**'
+      - 'scripts/lint-tokens.sh'
+
+jobs:
+  lint-tokens:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run token guards
+        run: bash scripts/lint-tokens.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (UI/UX mop-up — issues #253 + #254)
+- **Inline hover handlers replaced.** 5 remaining `onMouseOver/Out` sites in settings (profile-form, watchlist-settings, sports-settings) and dashboard (watchlist-widget) now use CSS utility classes (`hover-text-muted`, `hover-text-danger`, `hover-bg-subtle`, `hover-text-brighten`) instead of writing `.style.*` directly.
+- **Hardcoded `color: "white"` tokenized.** 10 sites across chat, tasks, error pages, notifications, and layout now use `var(--color-text-on-cta)`.
+- **`color-mix()` removed from MealsClient.** Replaced with existing subtle tokens (`--color-primary-dim`, `--color-positive-subtle`) for Safari <16.4 compatibility.
+- **Mobile demo banner wrap-safety.** Added `overflow-hidden text-ellipsis whitespace-nowrap` to match the desktop variant.
+- **Form focus/blur inline styles migrated.** New `.input-focus-ring` CSS utility in `globals.css` replaces `onFocus/onBlur` handlers in profile-form, watchlist-settings, and sports-settings.
+- **CI token guards added.** `scripts/lint-tokens.sh` with 4 grep guards (onMouseOver/Out, hardcoded white, color-mix outside globals.css, raw hex outside allowlist) wired into GitHub Actions on PRs touching `web/src/`.
+
 ### Fixed (update_workout_exercise silent no-op on swaps — issue #239)
 - **Bridge claimed it had swapped an exercise but the Fitness tab still showed the old name.** The `update_workout_exercise` tool's `updates` schema in [web/src/app/api/chat/route.ts](web/src/app/api/chat/route.ts) only accepted `sets | reps | weight_lbs | notes` — there was no way to change the exercise name. When asked to "replace Bent Over Row with DB Reverse Fly", the rename was dropped by JSON-schema validation, the UPDATE ran with an unchanged array, and Bridge confidently reported success. Schema now accepts `updates.exercise` for swaps/renames, and the tool returns an error when `updates` is empty so Bridge can tell the user truthfully instead of falsely confirming.
 

--- a/scripts/lint-tokens.sh
+++ b/scripts/lint-tokens.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# lint-tokens.sh — CI guard to prevent tokenization + inline-hover regressions.
+# Closes #254. Run from repo root: bash scripts/lint-tokens.sh
+
+set -euo pipefail
+
+WEB_SRC="web/src"
+FAIL=0
+
+# ── 1. No inline onMouseOver/onMouseOut hover handlers ──────────────────
+# Allowlist: heatmap.tsx (tooltip state), message-bubble.tsx (reaction
+# popover), slash-command-menu.tsx (highlight state). These use the handlers
+# for non-style state tracking, not inline-style toggling.
+HOVER_HITS=$(grep -rn 'onMouseOver\|onMouseOut' "$WEB_SRC" \
+  --include='*.tsx' --include='*.ts' \
+  | grep -v 'heatmap\.tsx' \
+  | grep -v 'message-bubble\.tsx' \
+  | grep -v 'slash-command-menu\.tsx' \
+  || true)
+
+if [[ -n "$HOVER_HITS" ]]; then
+  echo "❌ Guard 1 FAILED: onMouseOver/onMouseOut found outside allowlist"
+  echo "$HOVER_HITS"
+  FAIL=1
+else
+  echo "✅ Guard 1 passed: no inline hover handlers"
+fi
+
+# ── 2. No hardcoded color: "white" ──────────────────────────────────────
+WHITE_HITS=$(grep -rn 'color:.*["'"'"']white["'"'"']' "$WEB_SRC" \
+  --include='*.tsx' --include='*.ts' \
+  || true)
+
+if [[ -n "$WHITE_HITS" ]]; then
+  echo "❌ Guard 2 FAILED: hardcoded color: \"white\" found"
+  echo "$WHITE_HITS"
+  FAIL=1
+else
+  echo "✅ Guard 2 passed: no hardcoded white"
+fi
+
+# ── 3. No color-mix() outside globals.css ────────────────────────────────
+COLORMIX_HITS=$(grep -rn 'color-mix(' "$WEB_SRC" \
+  --include='*.tsx' --include='*.ts' --include='*.css' \
+  | grep -v 'globals\.css' \
+  || true)
+
+if [[ -n "$COLORMIX_HITS" ]]; then
+  echo "❌ Guard 3 FAILED: color-mix() used outside globals.css"
+  echo "$COLORMIX_HITS"
+  FAIL=1
+else
+  echo "✅ Guard 3 passed: no color-mix() outside globals.css"
+fi
+
+# ── 4. No raw hex colors outside token definitions ───────────────────────
+# Allowlist: globals.css (token defs), FoodPhotoAnalyzer (own cleanup issue),
+# chart-colors.ts (canvas/SVG needs raw hex), icon.svg (SVG markup),
+# MealsClient.tsx (CSS var fallbacks — var(--token, #hex)).
+# Only scans .tsx/.css to avoid false positives from issue numbers in .ts.
+HEX_HITS=$(grep -rn '#[0-9a-fA-F]\{3,8\}\b' "$WEB_SRC" \
+  --include='*.tsx' --include='*.css' \
+  | grep -v 'globals\.css' \
+  | grep -v 'FoodPhoto' \
+  | grep -v 'chart-colors' \
+  | grep -v 'icon\.svg' \
+  | grep -v 'MealsClient' \
+  || true)
+
+if [[ -n "$HEX_HITS" ]]; then
+  echo "❌ Guard 4 FAILED: raw hex colors found outside allowlist"
+  echo "$HEX_HITS"
+  FAIL=1
+else
+  echo "✅ Guard 4 passed: no raw hex colors outside allowlist"
+fi
+
+if [[ "$FAIL" -ne 0 ]]; then
+  echo ""
+  echo "Token lint failed. Fix the violations above or update the allowlist in scripts/lint-tokens.sh."
+  exit 1
+fi
+
+echo ""
+echo "All token guards passed."

--- a/web/src/app/(protected)/error.tsx
+++ b/web/src/app/(protected)/error.tsx
@@ -34,7 +34,7 @@ export default function ProtectedError({
           className="inline-flex items-center gap-2 rounded-lg"
           style={{
             background: "var(--color-primary)",
-            color: "white",
+            color: "var(--color-text-on-cta)",
             border: "none",
             padding: "10px 16px",
             fontSize: 14,

--- a/web/src/app/(protected)/layout.tsx
+++ b/web/src/app/(protected)/layout.tsx
@@ -26,7 +26,7 @@ export default async function ProtectedLayout({
         className="sr-only focus:not-sr-only focus:fixed focus:top-3 focus:left-3 focus:z-[100] focus:rounded-lg"
         style={{
           background: "var(--color-primary)",
-          color: "white",
+          color: "var(--color-text-on-cta)",
           padding: "10px 14px",
           fontSize: 14,
           fontWeight: 500,

--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -37,7 +37,7 @@ export default function GlobalError({
           className="inline-flex items-center gap-2 rounded-lg"
           style={{
             background: "var(--color-primary)",
-            color: "white",
+            color: "var(--color-text-on-cta)",
             border: "none",
             padding: "10px 16px",
             fontSize: 14,

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -164,6 +164,14 @@ body {
 .hover-text-muted:hover    { color: var(--color-text-muted) !important; }
 .hover-border-strong:hover { border-color: var(--color-text-faint) !important; }
 
+/* ─── Input focus ring ───────────────────────────────────────────────── */
+/* Replaces inline onFocus/onBlur style handlers. Works with inline
+   border/boxShadow base styles — !important wins over inline. */
+.input-focus-ring:focus {
+  border-color: var(--color-primary) !important;
+  box-shadow: 0 0 0 3px var(--color-primary-dim) !important;
+}
+
 /* Card hover lift — MASTER.md spec.
    Uses transform + box-shadow (no margin/padding change) to avoid layout shift.
    Pair with a `transition-*` utility on the element; duration 200ms per spec. */

--- a/web/src/components/chat/chat-interface.tsx
+++ b/web/src/components/chat/chat-interface.tsx
@@ -394,7 +394,7 @@ export default function ChatInterface({ sessionId, initialMessages, onMessageSen
           type="submit"
           disabled={isLoading || !input.trim()}
           className="rounded-xl px-3.5 py-2.5 cursor-pointer transition-opacity duration-150 hover:opacity-85 disabled:opacity-30 disabled:cursor-default disabled:hover:opacity-30"
-          style={{ background: "var(--color-primary)", color: "white" }}
+          style={{ background: "var(--color-primary)", color: "var(--color-text-on-cta)" }}
         >
           <Send size={16} />
         </button>

--- a/web/src/components/chat/chat-page-client.tsx
+++ b/web/src/components/chat/chat-page-client.tsx
@@ -474,7 +474,7 @@ function ChatPageClientInner({
             height: 48,
             borderRadius: 24,
             background: "var(--color-primary)",
-            color: "white",
+            color: "var(--color-text-on-cta)",
             border: "none",
             boxShadow: "var(--shadow-md)",
             cursor: "pointer",

--- a/web/src/components/chat/session-sheet.tsx
+++ b/web/src/components/chat/session-sheet.tsx
@@ -91,7 +91,7 @@ export default function SessionSheet({
               className="flex items-center gap-2 w-full cursor-pointer transition-colors duration-150"
               style={{
                 background: "var(--color-primary)",
-                color: "white",
+                color: "var(--color-text-on-cta)",
                 border: "none",
                 borderRadius: 10,
                 padding: "12px 16px",
@@ -328,7 +328,7 @@ export default function SessionSheet({
                   style={{
                     background: "var(--color-danger)",
                     border: "none",
-                    color: "white",
+                    color: "var(--color-text-on-cta)",
                     padding: "8px 14px",
                     borderRadius: 8,
                     fontSize: 13,

--- a/web/src/components/chat/session-sidebar.tsx
+++ b/web/src/components/chat/session-sidebar.tsx
@@ -62,7 +62,7 @@ export default function SessionSidebar({
           className="flex items-center gap-2 w-full cursor-pointer transition-opacity duration-150 hover:opacity-85"
           style={{
             background: "var(--color-primary)",
-            color: "white",
+            color: "var(--color-text-on-cta)",
             border: "none",
             borderRadius: 8,
             padding: "10px 14px",

--- a/web/src/components/dashboard/watchlist-widget.tsx
+++ b/web/src/components/dashboard/watchlist-widget.tsx
@@ -162,17 +162,11 @@ export function WatchlistWidget({ rows, hasApiKey, refreshAction }: Props) {
           <button
             onClick={handleRefresh}
             disabled={isPending || !hasApiKey}
-            className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs whitespace-nowrap transition-colors duration-150 cursor-pointer disabled:opacity-40 disabled:cursor-default"
+            className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs whitespace-nowrap transition-colors duration-150 cursor-pointer disabled:opacity-40 disabled:cursor-default hover-text-brighten"
             style={{
               background: "var(--color-surface-raised)",
               border: "1px solid var(--color-border)",
               color: isPending ? "var(--color-primary)" : "var(--color-text-muted)",
-            }}
-            onMouseOver={(e) => {
-              if (!isPending && hasApiKey) e.currentTarget.style.color = "var(--color-text)";
-            }}
-            onMouseOut={(e) => {
-              if (!isPending) e.currentTarget.style.color = "var(--color-text-muted)";
             }}
           >
             {isPending ? (

--- a/web/src/components/meals/MealsClient.tsx
+++ b/web/src/components/meals/MealsClient.tsx
@@ -814,7 +814,7 @@ function RecipesTab({ recipes }: { recipes: RecipeRow[] }) {
                           className="rounded-full px-2 py-0.5"
                           style={{
                             fontSize: 11,
-                            background: "color-mix(in srgb, var(--color-primary) 12%, transparent)",
+                            background: "var(--color-primary-dim)",
                             color: "var(--color-primary)",
                           }}
                         >
@@ -1070,7 +1070,7 @@ function PlanTab({
                     className="rounded-full px-2 py-0.5 inline-block mb-2"
                     style={{
                       fontSize: 11,
-                      background: "color-mix(in srgb, var(--color-positive) 15%, transparent)",
+                      background: "var(--color-positive-subtle)",
                       color: "var(--color-positive)",
                     }}
                   >

--- a/web/src/components/nav.tsx
+++ b/web/src/components/nav.tsx
@@ -186,7 +186,7 @@ export default function Nav() {
       {/* Demo banner — mobile (above tab bar). Hidden on /chat to avoid overlapping the composer. */}
       {isDemo && !pathname?.startsWith("/chat") && (
         <div
-          className="lg:hidden fixed left-0 right-0 z-40 px-4 py-1.5 text-center text-xs"
+          className="lg:hidden fixed left-0 right-0 z-40 px-4 py-1.5 text-center text-xs overflow-hidden text-ellipsis whitespace-nowrap"
           style={{ bottom: 56, background: "var(--color-primary-dim)", color: "var(--color-primary)" }}
         >
           Demo account — changes reset nightly

--- a/web/src/components/notifications/notification-list.tsx
+++ b/web/src/components/notifications/notification-list.tsx
@@ -69,7 +69,7 @@ export default function NotificationList({ notifications }: Props) {
               className="px-3 py-1 rounded-full text-xs font-medium transition-colors duration-150 cursor-pointer"
               style={{
                 background: active ? "var(--color-primary)" : "var(--color-surface)",
-                color: active ? "white" : "var(--color-text-muted)",
+                color: active ? "var(--color-text-on-cta)" : "var(--color-text-muted)",
                 border: active ? "1px solid var(--color-primary)" : "1px solid var(--color-border)",
               }}
             >

--- a/web/src/components/settings/profile-form.tsx
+++ b/web/src/components/settings/profile-form.tsx
@@ -196,10 +196,8 @@ function SuggestedNutritionCard({
         onClick={dismiss}
         disabled={isDismissPending}
         title="Dismiss"
-        className="absolute top-2 right-2 flex items-center justify-center w-5 h-5 rounded transition-colors cursor-pointer disabled:opacity-40"
+        className="absolute top-2 right-2 flex items-center justify-center w-5 h-5 rounded transition-colors cursor-pointer disabled:opacity-40 hover-text-muted"
         style={{ color: "var(--color-text-faint)" }}
-        onMouseOver={(e) => { e.currentTarget.style.color = "var(--color-text-muted)"; }}
-        onMouseOut={(e) => { e.currentTarget.style.color = "var(--color-text-faint)"; }}
       >
         <X size={13} />
       </button>
@@ -335,19 +333,11 @@ function FieldRow({
           value={value}
           onChange={(e) => { setValue(e.target.value); setSaved(false); }}
           placeholder={field.placeholder}
-          className="flex-1 rounded-lg px-3 py-2 text-sm transition-colors duration-150 focus:outline-none"
+          className="flex-1 rounded-lg px-3 py-2 text-sm transition-colors duration-150 focus:outline-none input-focus-ring"
           style={{
             background: "var(--color-surface-raised)",
             border: "1px solid var(--color-border)",
             color: "var(--color-text)",
-          }}
-          onFocus={(e) => {
-            e.currentTarget.style.borderColor = "var(--color-primary)";
-            e.currentTarget.style.boxShadow = "0 0 0 3px var(--color-primary-dim)";
-          }}
-          onBlur={(e) => {
-            e.currentTarget.style.borderColor = "var(--color-border)";
-            e.currentTarget.style.boxShadow = "none";
           }}
           onKeyDown={(e) => { if (e.key === "Enter") handleSave(); }}
         />

--- a/web/src/components/settings/sports-settings.tsx
+++ b/web/src/components/settings/sports-settings.tsx
@@ -105,7 +105,7 @@ export function SportsSettings({ favorites, saveAction }: Props) {
               }
             }}
             placeholder="Search teams (e.g. Warriors, 49ers, Arsenal)"
-            className="flex-1 rounded-lg px-3 py-2 text-sm transition-colors duration-150 focus:outline-none"
+            className="flex-1 rounded-lg px-3 py-2 text-sm transition-colors duration-150 focus:outline-none input-focus-ring"
             style={{
               background: "var(--color-surface-raised)",
               border: `1px solid ${error ? "var(--color-danger)" : "var(--color-border)"}`,
@@ -124,10 +124,8 @@ export function SportsSettings({ favorites, saveAction }: Props) {
                 key={`${t.league}-${t.team_id}`}
                 type="button"
                 onClick={() => handleAdd(t)}
-                className="w-full flex items-center gap-3 px-3 py-2 text-left cursor-pointer transition-colors"
+                className="w-full flex items-center gap-3 px-3 py-2 text-left cursor-pointer transition-colors hover-bg-subtle"
                 style={{ background: "var(--color-surface-raised)", borderBottom: "1px solid var(--color-border)" }}
-                onMouseOver={(e) => { e.currentTarget.style.background = "var(--color-surface)"; }}
-                onMouseOut={(e) => { e.currentTarget.style.background = "var(--color-surface-raised)"; }}
               >
                 {t.badge ? (
                   // eslint-disable-next-line @next/next/no-img-element
@@ -166,10 +164,8 @@ export function SportsSettings({ favorites, saveAction }: Props) {
             <button
               onClick={() => handleRemove(fav.team_id, fav.league)}
               disabled={isPending}
-              className="flex items-center justify-center w-6 h-6 rounded transition-colors cursor-pointer disabled:opacity-40"
+              className="flex items-center justify-center w-6 h-6 rounded transition-colors cursor-pointer disabled:opacity-40 hover-text-danger"
               style={{ color: "var(--color-text-faint)" }}
-              onMouseOver={(e) => { e.currentTarget.style.color = "var(--color-danger)"; }}
-              onMouseOut={(e) => { e.currentTarget.style.color = "var(--color-text-faint)"; }}
               title={`Remove ${fav.name}`}
             >
               <X size={13} />

--- a/web/src/components/settings/watchlist-settings.tsx
+++ b/web/src/components/settings/watchlist-settings.tsx
@@ -109,23 +109,13 @@ export function WatchlistSettings({ watchlist, saveAction, hasApiKey }: Props) {
             onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); }}
             placeholder="e.g. AAPL"
             maxLength={12}
-            className="flex-1 rounded-lg px-3 py-2 text-sm transition-colors duration-150 focus:outline-none"
+            className="flex-1 rounded-lg px-3 py-2 text-sm transition-colors duration-150 focus:outline-none input-focus-ring"
             style={{
               background: "var(--color-surface-raised)",
               border: `1px solid ${error ? "var(--color-danger)" : "var(--color-border)"}`,
               color: "var(--color-text)",
               fontFamily: "monospace",
               letterSpacing: "0.05em",
-            }}
-            onFocus={(e) => {
-              if (!error) {
-                e.currentTarget.style.borderColor = "var(--color-primary)";
-                e.currentTarget.style.boxShadow = "0 0 0 3px var(--color-primary-dim)";
-              }
-            }}
-            onBlur={(e) => {
-              e.currentTarget.style.borderColor = error ? "var(--color-danger)" : "var(--color-border)";
-              e.currentTarget.style.boxShadow = "none";
             }}
           />
           <button
@@ -179,10 +169,8 @@ export function WatchlistSettings({ watchlist, saveAction, hasApiKey }: Props) {
             <button
               onClick={() => handleRemove(ticker)}
               disabled={isPending}
-              className="flex items-center justify-center w-6 h-6 rounded transition-colors cursor-pointer disabled:opacity-40"
+              className="flex items-center justify-center w-6 h-6 rounded transition-colors cursor-pointer disabled:opacity-40 hover-text-danger"
               style={{ color: "var(--color-text-faint)" }}
-              onMouseOver={(e) => { e.currentTarget.style.color = "var(--color-danger)"; }}
-              onMouseOut={(e) => { e.currentTarget.style.color = "var(--color-text-faint)"; }}
               title={`Remove ${ticker}`}
             >
               <X size={13} />

--- a/web/src/components/tasks/task-item.tsx
+++ b/web/src/components/tasks/task-item.tsx
@@ -359,7 +359,7 @@ export default function TaskItem({
               });
             }}
             className="text-xs px-2 py-1 rounded-lg"
-            style={{ background: "var(--color-primary)", color: "white" }}
+            style={{ background: "var(--color-primary)", color: "var(--color-text-on-cta)" }}
           >
             Save
           </button>


### PR DESCRIPTION
## Summary
- Replace 5 `onMouseOver/Out` inline-style hover handlers with CSS utility classes (`hover-text-muted`, `hover-text-danger`, `hover-bg-subtle`, `hover-text-brighten`)
- Swap 10 hardcoded `color: "white"` → `var(--color-text-on-cta)` across chat, tasks, error pages, notifications, layout
- Replace 2 `color-mix()` calls in MealsClient with existing subtle tokens (`--color-primary-dim`, `--color-positive-subtle`)
- Add `whitespace-nowrap text-ellipsis overflow-hidden` to mobile demo banner
- Migrate form `onFocus/onBlur` inline styles to new `.input-focus-ring` CSS utility
- Add `scripts/lint-tokens.sh` with 4 grep guards + GitHub Actions CI workflow on PRs

Closes #253, closes #254.

## Test plan
- [ ] All 4 grep guards pass: `bash scripts/lint-tokens.sh`
- [ ] Next.js build succeeds
- [ ] Light-mode walk at 375 + 1024: error pages, chat send/FAB, session sheet, task save, settings hovers, Meals category tints — nothing disappears
- [ ] Deliberately break a guard (e.g. add `color: "white"` to a component), verify CI fails, revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)