### PR TITLE
feat: dark-mode OLED glow on headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (dark-mode OLED glow — issue #257)
+- **Subtle text glow on headings in dark mode.** New `--text-glow` CSS token (`0 0 12px rgba(248,250,252,0.3)` in dark, `none` in light) applied to all `.font-heading` elements. Covers page titles, metric card values, score numbers, and nav labels. MASTER.md Key Effects updated to match.
+
 ### Fixed (UI/UX mop-up — issues #253 + #254)
 - **Inline hover handlers replaced.** 5 remaining `onMouseOver/Out` sites in settings (profile-form, watchlist-settings, sports-settings) and dashboard (watchlist-widget) now use CSS utility classes (`hover-text-muted`, `hover-text-danger`, `hover-bg-subtle`, `hover-text-brighten`) instead of writing `.style.*` directly.
 - **Hardcoded `color: "white"` tokenized.** 10 sites across chat, tasks, error pages, notifications, and layout now use `var(--color-text-on-cta)`.

--- a/design-system/mr-bridge/MASTER.md
+++ b/design-system/mr-bridge/MASTER.md
@@ -178,7 +178,7 @@ Dark mode is the default (per style: Dark Mode OLED). Light mode tokens provided
 
 **Best For:** Night-mode apps, coding platforms, entertainment, eye-strain prevention, OLED devices, low-light
 
-**Key Effects:** Minimal glow (text-shadow: 0 0 10px), dark-to-light transitions, low white emission, high readability, visible focus
+**Key Effects:** Minimal glow (`text-shadow: var(--text-glow)` on `.font-heading`, dark mode only), dark-to-light transitions, low white emission, high readability, visible focus
 
 ### Page Pattern
 

--- a/web/design-system/mr.-bridge/MASTER.md
+++ b/web/design-system/mr.-bridge/MASTER.md
@@ -337,6 +337,7 @@ const chartDefaults = {
 **Style:** Dark Professional Dashboard (Linear/Raycast-inspired)
 
 **Key Effects:**
+- Text glow: `text-shadow: var(--text-glow)` on `.font-heading` — dark mode only (`0 0 12px rgba(248,250,252,0.3)`; light: `none`)
 - Transitions: 150–200ms ease for interactive elements
 - Hover: border-color shift, no layout-shifting transforms
 - Focus: visible indigo ring (`box-shadow: 0 0 0 3px #6366F120`)

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -40,6 +40,7 @@
   --shadow-md:   0 4px 12px rgba(0,0,0,0.5);
   --shadow-lg:   0 8px 24px rgba(0,0,0,0.6);
   --shadow-glow: 0 0 0 3px var(--color-primary-dim);
+  --text-glow:   0 0 12px rgba(248, 250, 252, 0.3);
 
   --header-height: 8rem;
 }
@@ -81,6 +82,7 @@
   --shadow-md:   0 4px 6px rgba(15,23,42,0.08);
   --shadow-lg:   0 10px 15px rgba(15,23,42,0.10);
   --shadow-glow: 0 0 0 3px var(--color-primary-dim);
+  --text-glow:   none;
 }
 
 html {
@@ -103,6 +105,7 @@ body {
 
 .font-heading {
   font-family: 'DM Sans', system-ui, sans-serif;
+  text-shadow: var(--text-glow);
 }
 
 /* ─── Focus visible (global) ──────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Adds `--text-glow` CSS token: `0 0 12px rgba(248,250,252,0.3)` in dark mode, `none` in light
- Applied to all `.font-heading` elements (page titles, metric values, score numbers, nav labels)
- Updated Key Effects in both MASTER.md files to reflect the implemented spec

Closes #257

## Test plan
- [x] Dark mode: headings show subtle white glow
- [x] Light mode: no glow visible
- [x] Contrast unaffected (glow is additive light on dark bg)
- [ ] Verify on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)