### PR TITLE
perf: Lighthouse + bundle optimization pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added (performance profiling — issue #260)
+- **`@next/bundle-analyzer` wired into `next.config.ts`.** Run `ANALYZE=true npm run build` to generate interactive treemap reports in `.next/analyze/`.
+- **Lighthouse audit baseline captured across all 11 pages** (login, dashboard, chat, settings, fitness, habits, journal, meals, notifications, tasks, weekly) in both mobile and desktop modes.
+
+### Fixed (performance profiling — issue #260)
+- **Dashboard CLS 0.68 → 0.006 (desktop), 0.106 → 0.034 (mobile).** Weather line in `dashboard-header.tsx` now renders inside a fixed-height `<p>` with a `minHeight` placeholder during loading instead of conditionally mounting. `upcoming-birthday.tsx` returns a height-stable placeholder while loading instead of `null`.
+- **Dashboard desktop Lighthouse score 73 → 100.** Driven entirely by the CLS fix above.
+- **FoodPhotoAnalyzer lazy-loaded.** `MealsClient.tsx` now imports via `next/dynamic` with `ssr: false`, reducing meals First Load JS from 118kB to 114kB.
+
 ### Added (dark-mode OLED glow — issue #257)
 - **Subtle text glow on headings in dark mode.** New `--text-glow` CSS token (`0 0 12px rgba(248,250,252,0.3)` in dark, `none` in light) applied to all `.font-heading` elements. Covers page titles, metric card values, score numbers, and nav labels. MASTER.md Key Effects updated to match.
 

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,4 +1,9 @@
 import type { NextConfig } from "next";
+import withBundleAnalyzer from "@next/bundle-analyzer";
+
+const withAnalyze = withBundleAnalyzer({
+  enabled: process.env.ANALYZE === "true",
+});
 
 const nextConfig: NextConfig = {
   experimental: {
@@ -13,4 +18,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+export default withAnalyze(nextConfig);

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -26,6 +26,7 @@
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
+        "@next/bundle-analyzer": "^16.2.4",
         "@tailwindcss/postcss": "^4.1.5",
         "@types/node": "^22.15.18",
         "@types/react": "^19.1.3",
@@ -157,6 +158,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -733,6 +744,16 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@next/bundle-analyzer": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-16.2.4.tgz",
+      "integrity": "sha512-EAA9xTDv0P1IiUcZaASJJPkNDjRvL7OMTha6XN8MBzALYGfn7I52Mn7vRiyjVfNrtUPi2qiacY+eFVXe3lKCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webpack-bundle-analyzer": "4.10.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "15.5.15",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
@@ -887,6 +908,13 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
@@ -1775,6 +1803,32 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2003,6 +2057,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -2152,6 +2216,13 @@
         "node": ">= 12"
       }
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2255,6 +2326,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -2565,6 +2643,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -2628,6 +2722,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
@@ -2730,6 +2831,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/jiti": {
@@ -3973,6 +4084,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4144,6 +4265,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/parse-entities": {
@@ -4662,6 +4793,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4787,6 +4933,16 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -5036,6 +5192,69 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "is-plain-object": "^5.0.0",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/ws": {

--- a/web/package.json
+++ b/web/package.json
@@ -27,6 +27,7 @@
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "^16.2.4",
     "@tailwindcss/postcss": "^4.1.5",
     "@types/node": "^22.15.18",
     "@types/react": "^19.1.3",

--- a/web/src/components/dashboard/dashboard-header.tsx
+++ b/web/src/components/dashboard/dashboard-header.tsx
@@ -51,30 +51,31 @@ export default function DashboardHeader({ greeting, dateStr, windowKey }: Props)
         <p className="mt-0.5" style={{ fontSize: 13, color: "var(--color-text-muted)" }}>
           {dateStr}
         </p>
-        {!weather && weatherError && (
-          <p
-            className="mt-0.5 flex items-center gap-1.5"
-            style={{ fontSize: 13, color: "var(--color-danger)" }}
-            role="status"
-          >
-            <AlertTriangle size={14} aria-hidden />
-            <span>Weather unavailable</span>
-          </p>
-        )}
-        {weather && (
-          <p className="mt-0.5 flex flex-wrap items-center gap-x-1.5 gap-y-0" style={{ fontSize: 13, color: "var(--color-text-muted)" }}>
-            <Icon size={14} style={{ color: "var(--color-text-muted)", flexShrink: 0 }} aria-hidden />
-            {weather.temp != null && (
-              <span style={{ color: "var(--color-text)" }}>{Math.round(weather.temp)}°</span>
-            )}
-            <span>{weather.condition}</span>
-            {(weather.high != null || weather.low != null) && (
-              <span style={{ color: "var(--color-text-faint)", whiteSpace: "nowrap" }}>
-                · H {weather.high != null ? `${Math.round(weather.high)}°` : "—"} L {weather.low != null ? `${Math.round(weather.low)}°` : "—"}
-              </span>
-            )}
-          </p>
-        )}
+        {/* Reserve a fixed line-height so content below never shifts */}
+        <p className="mt-0.5 flex flex-wrap items-center gap-x-1.5 gap-y-0" style={{ fontSize: 13, minHeight: "1.25rem" }}>
+          {!weather && weatherError ? (
+            <span className="flex items-center gap-1.5" style={{ color: "var(--color-danger)" }} role="status">
+              <AlertTriangle size={14} aria-hidden />
+              <span>Weather unavailable</span>
+            </span>
+          ) : weather ? (
+            <>
+              <Icon size={14} style={{ color: "var(--color-text-muted)", flexShrink: 0 }} aria-hidden />
+              {weather.temp != null && (
+                <span style={{ color: "var(--color-text)" }}>{Math.round(weather.temp)}°</span>
+              )}
+              <span style={{ color: "var(--color-text-muted)" }}>{weather.condition}</span>
+              {(weather.high != null || weather.low != null) && (
+                <span style={{ color: "var(--color-text-faint)", whiteSpace: "nowrap" }}>
+                  · H {weather.high != null ? `${Math.round(weather.high)}°` : "—"} L {weather.low != null ? `${Math.round(weather.low)}°` : "—"}
+                </span>
+              )}
+            </>
+          ) : (
+            /* Invisible placeholder while loading — same height as weather text */
+            <span>&nbsp;</span>
+          )}
+        </p>
       </div>
 
       <div className="flex items-center gap-3 flex-shrink-0">

--- a/web/src/components/dashboard/upcoming-birthday.tsx
+++ b/web/src/components/dashboard/upcoming-birthday.tsx
@@ -21,7 +21,13 @@ export default function UpcomingBirthdayWidget() {
       .finally(() => setLoading(false));
   }, []);
 
-  if (loading || !birthday) return null;
+  // Return an empty but height-stable container while loading to prevent CLS.
+  // Once loaded, collapse if there's no birthday (no shift — loading skeleton
+  // already occupies the slot).
+  if (loading) {
+    return <div style={{ minHeight: "2.25rem" }} />;
+  }
+  if (!birthday) return null;
 
   const isToday = birthday.daysUntil === 0;
   const label = isToday

--- a/web/src/components/meals/MealsClient.tsx
+++ b/web/src/components/meals/MealsClient.tsx
@@ -4,7 +4,12 @@ import { useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { MessageSquare, ChevronDown, ChevronUp, RefreshCw, Loader2 } from "lucide-react";
 import Link from "next/link";
-import FoodPhotoAnalyzer from "@/app/(protected)/meals/FoodPhotoAnalyzer";
+import dynamic from "next/dynamic";
+
+const FoodPhotoAnalyzer = dynamic(
+  () => import("@/app/(protected)/meals/FoodPhotoAnalyzer"),
+  { ssr: false }
+);
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Fix dashboard CLS regression (0.68 → 0.006 desktop, 0.106 → 0.034 mobile) by reserving layout space for async-loaded weather line and birthday widget
- Lazy-load `FoodPhotoAnalyzer` via `next/dynamic` (meals First Load JS 118kB → 114kB)
- Add `@next/bundle-analyzer` gated behind `ANALYZE=true` for ongoing profiling

## Lighthouse Before/After (all pages)

| Page | Desktop Before → After | Mobile Before → After | Key Delta |
|------|----------------------|---------------------|-----------|
| login | 100 → 100 | 98 → 98 | — |
| **dashboard** | **73 → 100** | **88 → 79** | **CLS 0.68 → 0.006 (desktop)** |
| chat | 100 → 100 | 83 → 88 | — |
| settings | 100 → 100 | 98 → 87 | — |
| fitness | 100 → 100 | 94 → 76 | run variance |
| habits | 100 → 100 | 79 → 80 | — |
| journal | 100 → 100 | 85 → 84 | — |
| meals | 100 → 100 | 86 → 86 | — |
| notifications | 100 → 100 | 86 → 85 | — |
| tasks | 100 → 100 | 84 → 83 | — |
| weekly | 100 → 100 | 85 → 83 | — |

> Mobile scores fluctuate ±5–10pts between runs due to simulated 4G throttling and SSR latency variance. Desktop scores are stable.

## Bundle Analysis
- No chunk exceeds 200KB gzipped (largest: recharts at 100.9KB gz)
- emoji-picker-react (70.6KB gz) already lazy-loaded via `next/dynamic`
- Lucide icons: all named imports, no barrel imports
- No raw `<img>` tags — all use Next.js Image or CSS

## Test plan
- [x] `ANALYZE=true npm run build` generates reports in `.next/analyze/`
- [x] Dashboard loads without visible layout shift (weather + birthday)
- [x] Meals page FoodPhotoAnalyzer still functions after lazy-load
- [x] Lighthouse desktop ≥ 90 on dashboard and chat
- [x] Lighthouse mobile ≥ 75 on dashboard and chat
- [x] No single JS chunk > 200KB gzipped

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)