### PR TITLE
fix: mobile dashboard header + sports card layout (#258, #259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
-### Added (PWA installability — issue #261, Phase 1)
+### Fixed (mobile dashboard layout — issues #258 + #259)
+- **Dashboard header stacks cleanly on mobile.** [web/src/components/dashboard/dashboard-header.tsx](web/src/components/dashboard/dashboard-header.tsx) now renders greeting + Sync button on line 1, date on line 2, weather on line 3 below the `lg:` (1024px) breakpoint; desktop row layout is preserved.
+- **Time-range pills stick to the top on mobile.** [web/src/app/(protected)/dashboard/page.tsx](web/src/app/(protected)/dashboard/page.tsx) renders a mobile-only sticky wrapper (`position: sticky; top: 0; background: var(--color-bg)`) containing the `WindowSelector` below the header, bleeding full-width via negative horizontal margins against the page's `px-5` padding. Desktop keeps the selector in the header's right column.
+- **Sports card team rows stack vertically on mobile.** [web/src/components/dashboard/sports-card.tsx](web/src/components/dashboard/sports-card.tsx) `TeamRow` reshapes below `lg:` to logo (left-anchored) + three-line text stack (team name, next game, last result) + chevron (self-centered, right-anchored). Team names no longer truncate at 375px — `break-words` wraps; `lg:truncate` restores the desktop behaviour. Removed the inline `<style>` block that hid `.sports-card-league` at max-width 480px; the league subtitle is now gated via `hidden lg:block`.
 - **`web/public/manifest.json` expanded** with 192/512 PNG icons, dark `theme_color` / `background_color` (`#0B0F19`), `start_url: /dashboard`, `display: standalone`, and `scope: /`.
 - **App-shell service worker at [web/public/sw.js](web/public/sw.js).** Cache-first for `/_next/static/*`, `/icon*`, `/manifest.json`, and Google Fonts origins. Skips API, auth, and navigation requests — no data caching. Registered via [web/src/components/service-worker-register.tsx](web/src/components/service-worker-register.tsx), production-only (dev builds never register a SW).
 - **`<meta name="theme-color">` wired via `viewport.themeColor`** in [web/src/app/layout.tsx](web/src/app/layout.tsx). Existing `metadata.manifest` and the auto-generated `<link rel="apple-touch-icon">` from `src/app/apple-icon.png` cover the remaining head tags.

--- a/web/src/app/(protected)/dashboard/page.tsx
+++ b/web/src/app/(protected)/dashboard/page.tsx
@@ -21,6 +21,7 @@ import ImportantEmails from "@/components/dashboard/important-emails";
 import TasksSummary from "@/components/dashboard/tasks-summary";
 import { WatchlistWidget } from "@/components/dashboard/watchlist-widget";
 import { SportsCard } from "@/components/dashboard/sports-card";
+import { WindowSelector } from "@/components/ui/window-selector";
 import { syncStocks } from "@/lib/sync/stocks";
 import { syncSports, type SportsFavorite } from "@/lib/sync/sports";
 import type { HabitLog, HabitRegistry, FitnessLog, RecoveryMetrics, Task, StocksCache, SportsCache } from "@/lib/types";
@@ -220,6 +221,23 @@ export default async function DashboardPage() {
 
       {/* ── Header: greeting + date + weather + sync + window ───────── */}
       <DashboardHeader greeting={greeting} dateStr={dateStr} windowKey={windowKey} />
+
+      {/* Mobile-only sticky time-range selector (desktop keeps it in header) */}
+      <div
+        className="lg:hidden"
+        style={{
+          position: "sticky",
+          top: 0,
+          zIndex: 10,
+          background: "var(--color-bg)",
+          borderBottom: "1px solid var(--color-border)",
+          marginLeft: "-20px",
+          marginRight: "-20px",
+          padding: "8px 20px",
+        }}
+      >
+        <WindowSelector current={windowKey} />
+      </div>
 
       {/* ── Birthday (conditionally rendered inside the widget) ──────── */}
       <UpcomingBirthdayWidget />

--- a/web/src/components/dashboard/dashboard-header.tsx
+++ b/web/src/components/dashboard/dashboard-header.tsx
@@ -43,11 +43,16 @@ export default function DashboardHeader({ greeting, dateStr, windowKey }: Props)
   const Icon = weather?.wmoCode != null ? (WMO_ICON[weather.wmoCode] ?? Cloudy) : Thermometer;
 
   return (
-    <div className="flex items-start justify-between gap-4">
-      <div>
-        <h1 className="font-heading font-semibold" style={{ fontSize: 24, color: "var(--color-text)" }}>
-          {greeting}
-        </h1>
+    <div className="flex flex-col gap-1 lg:flex-row lg:items-start lg:justify-between lg:gap-4">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-3 lg:justify-start">
+          <h1 className="font-heading font-semibold" style={{ fontSize: 24, color: "var(--color-text)" }}>
+            {greeting}
+          </h1>
+          <div className="lg:hidden">
+            <SyncButton />
+          </div>
+        </div>
         <p className="mt-0.5" style={{ fontSize: 13, color: "var(--color-text-muted)" }}>
           {dateStr}
         </p>
@@ -78,7 +83,7 @@ export default function DashboardHeader({ greeting, dateStr, windowKey }: Props)
         </p>
       </div>
 
-      <div className="flex items-center gap-3 flex-shrink-0">
+      <div className="hidden lg:flex lg:items-center lg:gap-3 lg:flex-shrink-0">
         <SyncButton />
         <WindowSelector current={windowKey} />
       </div>

--- a/web/src/components/dashboard/sports-card.tsx
+++ b/web/src/components/dashboard/sports-card.tsx
@@ -121,22 +121,34 @@ function TeamRow({ row, favorite }: {
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="w-full flex items-center gap-3 px-5 py-3 cursor-pointer text-left"
+        className="w-full flex items-start gap-3 px-5 py-3 cursor-pointer text-left lg:items-center"
         style={{ background: "transparent" }}
       >
         <TeamLogo src={favorite.badge ?? null} name={favorite.name} color={favorite.color} />
         <div className="flex-1 min-w-0">
           <p
-            className="font-heading font-semibold truncate"
+            className="font-heading font-semibold break-words lg:truncate"
             style={{ fontSize: 14, color: "var(--color-text)", letterSpacing: "0.02em" }}
           >
             {favorite.name}
           </p>
-          <p className="sports-card-league" style={{ fontSize: 10, color: "var(--color-text-faint)", marginTop: 2 }}>
+          <p
+            className="hidden lg:block"
+            style={{ fontSize: 10, color: "var(--color-text-faint)", marginTop: 2 }}
+          >
             {favorite.league}
           </p>
+          <p className="lg:hidden" style={{ fontSize: 12, color: "var(--color-text)", marginTop: 2 }}>
+            {nextGameLabel(next, favorite.league)}
+          </p>
+          <p
+            className="lg:hidden"
+            style={{ fontSize: 11, color: lastLabel?.color ?? "var(--color-text-faint)", marginTop: 2 }}
+          >
+            {lastLabel?.text ?? "No recent result"}
+          </p>
         </div>
-        <div className="flex-shrink-0 text-right" style={{ minWidth: 130 }}>
+        <div className="hidden lg:block flex-shrink-0 text-right" style={{ minWidth: 130 }}>
           <p style={{ fontSize: 12, color: "var(--color-text)" }}>
             {nextGameLabel(next, favorite.league)}
           </p>
@@ -144,7 +156,7 @@ function TeamRow({ row, favorite }: {
             {lastLabel?.text ?? "No recent result"}
           </p>
         </div>
-        <span style={{ color: "var(--color-text-faint)" }}>
+        <span className="self-center flex-shrink-0" style={{ color: "var(--color-text-faint)" }}>
           {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
         </span>
       </button>
@@ -214,80 +226,72 @@ export function SportsCard({ rows, favorites, refreshAction }: Props) {
   const rowsByTeamId = new Map(rows.map((r) => [`${r.team_id}|${r.league}`, r]));
 
   return (
-    <>
-      <style>{`
-        @media (max-width: 480px) {
-          .sports-card-league { display: none; }
-        }
-      `}</style>
-
+    <div
+      className="rounded-xl overflow-hidden transition-all duration-200 card-lift"
+      style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+    >
       <div
-        className="rounded-xl overflow-hidden transition-all duration-200 card-lift"
-        style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)" }}
+        className="flex items-center justify-between px-5 py-3.5"
+        style={{ borderBottom: "1px solid var(--color-border)" }}
       >
-        <div
-          className="flex items-center justify-between px-5 py-3.5"
-          style={{ borderBottom: "1px solid var(--color-border)" }}
+        <p
+          className="text-xs uppercase tracking-widest"
+          style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}
         >
-          <p
-            className="text-xs uppercase tracking-widest"
-            style={{ color: "var(--color-text-muted)", letterSpacing: "0.07em" }}
+          Sports
+        </p>
+        {favorites.length > 0 && (
+          <button
+            onClick={handleRefresh}
+            disabled={isPending}
+            className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs transition-colors duration-150 cursor-pointer disabled:opacity-40 disabled:cursor-default"
+            style={{
+              background: "var(--color-surface-raised)",
+              border: "1px solid var(--color-border)",
+              color: isPending ? "var(--color-primary)" : "var(--color-text-muted)",
+            }}
           >
-            Sports
-          </p>
-          {favorites.length > 0 && (
-            <button
-              onClick={handleRefresh}
-              disabled={isPending}
-              className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs transition-colors duration-150 cursor-pointer disabled:opacity-40 disabled:cursor-default"
-              style={{
-                background: "var(--color-surface-raised)",
-                border: "1px solid var(--color-border)",
-                color: isPending ? "var(--color-primary)" : "var(--color-text-muted)",
-              }}
-            >
-              {isPending ? <Loader2 size={11} className="animate-spin" /> : <RefreshCw size={11} />}
-              {isPending ? "Refreshing…" : "Refresh"}
-            </button>
-          )}
-        </div>
-
-        {favorites.length === 0 ? (
-          <div className="px-5">
-            <EmptyState
-              icon={Trophy}
-              actionHref="/settings#sports"
-              actionLabel="Add"
-            >
-              No teams on watchlist
-            </EmptyState>
-          </div>
-        ) : (
-          <div style={{ opacity: isPending ? 0.5 : 1, transition: "opacity 0.15s" }}>
-            {favorites.map((fav) => {
-              const row = rowsByTeamId.get(`${fav.team_id}|${fav.league}`);
-              if (!row) {
-                return (
-                  <div
-                    key={`${fav.league}-${fav.team_id}`}
-                    className="flex items-center gap-3 px-5 py-3"
-                    style={{ borderBottom: "1px solid var(--color-border)" }}
-                  >
-                    <TeamLogo src={fav.badge} name={fav.name} color={fav.color} />
-                    <div className="flex-1">
-                      <p style={{ fontSize: 14, color: "var(--color-text)" }}>{fav.name}</p>
-                      <p style={{ fontSize: 11, color: "var(--color-text-faint)", marginTop: 2 }}>
-                        Awaiting first sync — hit Refresh
-                      </p>
-                    </div>
-                  </div>
-                );
-              }
-              return <TeamRow key={`${fav.league}-${fav.team_id}`} row={row} favorite={fav} />;
-            })}
-          </div>
+            {isPending ? <Loader2 size={11} className="animate-spin" /> : <RefreshCw size={11} />}
+            {isPending ? "Refreshing…" : "Refresh"}
+          </button>
         )}
       </div>
-    </>
+
+      {favorites.length === 0 ? (
+        <div className="px-5">
+          <EmptyState
+            icon={Trophy}
+            actionHref="/settings#sports"
+            actionLabel="Add"
+          >
+            No teams on watchlist
+          </EmptyState>
+        </div>
+      ) : (
+        <div style={{ opacity: isPending ? 0.5 : 1, transition: "opacity 0.15s" }}>
+          {favorites.map((fav) => {
+            const row = rowsByTeamId.get(`${fav.team_id}|${fav.league}`);
+            if (!row) {
+              return (
+                <div
+                  key={`${fav.league}-${fav.team_id}`}
+                  className="flex items-center gap-3 px-5 py-3"
+                  style={{ borderBottom: "1px solid var(--color-border)" }}
+                >
+                  <TeamLogo src={fav.badge} name={fav.name} color={fav.color} />
+                  <div className="flex-1">
+                    <p style={{ fontSize: 14, color: "var(--color-text)" }}>{fav.name}</p>
+                    <p style={{ fontSize: 11, color: "var(--color-text-faint)", marginTop: 2 }}>
+                      Awaiting first sync — hit Refresh
+                    </p>
+                  </div>
+                </div>
+              );
+            }
+            return <TeamRow key={`${fav.league}-${fav.team_id}`} row={row} favorite={fav} />;
+          })}
+        </div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Bundled mobile-only layout fix for the dashboard. Closes #258 and #259 — they touch adjacent components and share breakpoint/styling conventions, so one PR / one review / one CHANGELOG entry.

- **Dashboard header (#258):** below `lg:` (1024px), stacks into three clean lines — greeting + Sync on line 1, date on line 2, weather on line 3. Time-range pills extracted into a mobile-only sticky wrapper in `dashboard/page.tsx` (`position: sticky; top: 0; background: var(--color-bg)`) so they remain reachable as the header scrolls out. Desktop row layout preserved — `Sync` + `WindowSelector` still in the header's right column.
- **Sports card (#259):** `TeamRow` reshapes below `lg:` to logo (left-anchored) + three-line text stack (team name, next game, last result) + chevron (`self-center`, right-anchored). Team names wrap via `break-words` instead of truncating at 375px; `lg:truncate` restores desktop behaviour. League subtitle now gated via `hidden lg:block`; the inline `<style>` block for `.sports-card-league` is gone.
- CSS variables only (`var(--color-*)`); no Tailwind color classes. No new dependencies.

## Test plan

- [ ] Mobile 375px: header is three clean lines; nothing wraps mid-line.
- [ ] Mobile 430px: same — three clean lines; weather fits on its row.
- [ ] Mobile scroll: time-range pills stick at the top with an opaque background once the header scrolls out.
- [ ] Mobile iOS Safari: sticky works (no ancestor `overflow:hidden` / `transform` breaking it).
- [ ] Mobile sports card: each team row is three stacked lines (name / next game / last result); full team names (e.g. "Golden State Warriors") never truncate.
- [ ] Logo anchors the left of each mobile sports row; chevron vertically centered on the right.
- [ ] Tablet 768px: still in the mobile treatment (stacked) — sensible fallback.
- [ ] Desktop ≥ 1024px: header row unchanged; sports row unchanged.

Closes #258, closes #259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)