### PR TITLE
fix: Weekly — switch to dashboard panel pattern, two columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (Weekly — switch to dashboard panel pattern, two columns)
+- **Card shells dropped, panels use the dashboard pattern** in [web/src/app/(protected)/weekly/page.tsx](web/src/app/(protected)/weekly/page.tsx). The `--color-surface` + `--color-border` + `--r-2` + `card-lift` wrappers shipped in #309 were replaced with flat `<section>` panels that match the live dashboard's vocabulary — `db-section-label` headers, no fill, no border, no rounded corners, no hover lift. The local `Card` helper is renamed `Panel` and simplified.
+- **Two-column layout preserved.** Panels remain arranged as three rows of two (`grid-cols-1 lg:grid-cols-2`) so each domain sits side-by-side with its pair (Habits | Tasks, Training | Recovery, Body composition | Journal). Row-to-row separation comes from a `border-bottom: 1px solid var(--rule-soft)` + `padding-bottom: var(--space-7)` treatment (the `.db-section` feel applied to a grid row), with the final row omitting the trailing rule.
+- **Spacing lifted to `--space-7`** for both the inter-row gap and the intra-row column gap so each panel breathes like a dashboard section instead of feeling crowded inside a card.
+- **Hairline tables preserved inside each panel** — tabular numerics, 14×14 habit heatmap squares, `.delta-good` / `.delta-bad` utilities, Mon-Sun header, today flag, Prior measurement hint are all unchanged.
+- **Loading skeleton** rebuilt as three hairline-separated two-column rows of flat `PanelSkeleton` placeholders so hydration does not shift.
+- **No UX changes.** All ten parallel Supabase queries and every computed value preserved byte-identical.
+
 ### Fixed (Weekly — restore card shells, drop narrative recap)
 - **Cards restored around each metrics section** in [web/src/app/(protected)/weekly/page.tsx](web/src/app/(protected)/weekly/page.tsx). The Phase B flat-sections-with-hairlines treatment shipped in #308 rendered as a wall of text on Weekly — six distinct domains (Habits, Tasks, Training, Recovery, Body composition, Journal) stacked as flat `<section>` blocks lost the spatial chunking the surface needs. Each section is now wrapped in a `--color-surface` + `--color-border` + `--r-2` + `--space-5` card with `card-lift` hover, arranged in a 3-row × 2-column grid (`grid-cols-1 lg:grid-cols-2`, `--space-6` gap) — matching the pre-#308 layout rhythm.
 - **Narrative recap removed.** The `.prose-column` six-paragraph summary intro was replaced by inline `.meta` summaries on each card's `db-section-label` header (e.g. "Habits · 11/35 · 31%", "Training · 3 sessions · 1h 50m · 589 kcal", "Recovery · 7 days · readiness 74 · sleep 69 · HRV 45ms") — the section labels already carry the narrative; paragraphs added noise.

--- a/web/src/app/(protected)/weekly/loading.tsx
+++ b/web/src/app/(protected)/weekly/loading.tsx
@@ -1,15 +1,8 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
-function CardSkeleton() {
+function PanelSkeleton() {
   return (
-    <div
-      style={{
-        background: "var(--color-surface)",
-        border: "1px solid var(--color-border)",
-        borderRadius: "var(--r-2)",
-        padding: "var(--space-5)",
-      }}
-    >
+    <div className="flex flex-col">
       <Skeleton className="h-3 w-28" style={{ marginBottom: "var(--space-4)" }} />
       <div className="flex flex-col" style={{ gap: "var(--space-3)" }}>
         {[1, 2, 3, 4].map((r) => (
@@ -21,25 +14,34 @@ function CardSkeleton() {
 }
 
 export default function Loading() {
+  const rowStyle = {
+    gap: "var(--space-7)",
+    paddingBottom: "var(--space-7)",
+    borderBottom: "1px solid var(--rule-soft)",
+  } as const;
+  const rowStyleLast = { gap: "var(--space-7)" } as const;
+
   return (
-    <div className="flex flex-col" style={{ gap: "var(--space-6)" }}>
+    <div className="flex flex-col" style={{ gap: "var(--space-7)" }}>
       {/* Header */}
       <div>
         <Skeleton className="h-8 w-44" />
         <Skeleton className="h-3 w-36" style={{ marginTop: "var(--space-2)" }} />
       </div>
 
-      {/* Three rows of two cards */}
-      {[1, 2, 3].map((row) => (
-        <div
-          key={row}
-          className="grid grid-cols-1 lg:grid-cols-2"
-          style={{ gap: "var(--space-6)" }}
-        >
-          <CardSkeleton />
-          <CardSkeleton />
-        </div>
-      ))}
+      {/* Three rows of two flat panels, hairline-separated */}
+      <div className="grid grid-cols-1 lg:grid-cols-2" style={rowStyle}>
+        <PanelSkeleton />
+        <PanelSkeleton />
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2" style={rowStyle}>
+        <PanelSkeleton />
+        <PanelSkeleton />
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2" style={rowStyleLast}>
+        <PanelSkeleton />
+        <PanelSkeleton />
+      </div>
     </div>
   );
 }

--- a/web/src/app/(protected)/weekly/page.tsx
+++ b/web/src/app/(protected)/weekly/page.tsx
@@ -67,7 +67,7 @@ function fmtDuration(mins: number): string {
 
 // ── Card wrapper ──────────────────────────────────────────────────────────────
 
-function Card({
+function Panel({
   title,
   meta,
   children,
@@ -77,16 +77,7 @@ function Card({
   children: React.ReactNode;
 }) {
   return (
-    <section
-      className="flex flex-col card-lift"
-      style={{
-        background: "var(--color-surface)",
-        border: "1px solid var(--color-border)",
-        borderRadius: "var(--r-2)",
-        padding: "var(--space-5)",
-        transition: "transform var(--motion-fast) var(--ease-out-quart), box-shadow var(--motion-fast) var(--ease-out-quart)",
-      }}
-    >
+    <section className="flex flex-col" style={{ minWidth: 0 }}>
       <h2 className="db-section-label">
         {title}
         {meta && <span className="meta">{meta}</span>}
@@ -282,10 +273,17 @@ export default async function WeeklyPage() {
         avgHrv != null ? ` · HRV ${fmtNum(avgHrv)}ms` : ""
       }`;
 
+  const rowStyle: React.CSSProperties = {
+    gap: "var(--space-7)",
+    paddingBottom: "var(--space-7)",
+    borderBottom: "1px solid var(--rule-soft)",
+  };
+  const rowStyleLast: React.CSSProperties = { gap: "var(--space-7)" };
+
   return (
     <div
       className="flex flex-col"
-      style={{ gap: "var(--space-6)" }}
+      style={{ gap: "var(--space-7)" }}
     >
       {/* ── Header ──────────────────────────────────────────────────── */}
       <header>
@@ -316,9 +314,9 @@ export default async function WeeklyPage() {
       {/* ── Row 1: Habits + Tasks ───────────────────────────────────── */}
       <div
         className="grid grid-cols-1 lg:grid-cols-2"
-        style={{ gap: "var(--space-6)" }}
+        style={rowStyle}
       >
-        <Card
+        <Panel
           title="Habits"
           meta={
             habitRegistry.length === 0
@@ -407,9 +405,9 @@ export default async function WeeklyPage() {
               </table>
             </div>
           )}
-        </Card>
+        </Panel>
 
-        <Card
+        <Panel
           title="Tasks"
           meta={` · ${completedTasks.length} done · ${activeTasks.length} active${
             overdueTasks.length > 0 ? ` · ${overdueTasks.length} overdue` : ""
@@ -553,15 +551,15 @@ export default async function WeeklyPage() {
               )}
             </div>
           )}
-        </Card>
+        </Panel>
       </div>
 
       {/* ── Row 2: Training + Recovery ──────────────────────────────── */}
       <div
         className="grid grid-cols-1 lg:grid-cols-2"
-        style={{ gap: "var(--space-6)" }}
+        style={rowStyle}
       >
-        <Card title="Training" meta={trainingMeta}>
+        <Panel title="Training" meta={trainingMeta}>
           {allWorkouts.length === 0 ? (
             <p style={{ fontSize: "var(--t-micro)", color: "var(--color-text-faint)" }}>
               No sessions logged this week.
@@ -648,9 +646,9 @@ export default async function WeeklyPage() {
               )}
             </div>
           )}
-        </Card>
+        </Panel>
 
-        <Card title="Recovery" meta={recoveryMeta}>
+        <Panel title="Recovery" meta={recoveryMeta}>
           {recoveryRows.length === 0 ? (
             <p style={{ fontSize: "var(--t-micro)", color: "var(--color-text-faint)" }}>
               No recovery data for this week.
@@ -733,15 +731,15 @@ export default async function WeeklyPage() {
               </table>
             </div>
           )}
-        </Card>
+        </Panel>
       </div>
 
       {/* ── Row 3: Body composition + Journal ───────────────────────── */}
       <div
         className="grid grid-cols-1 lg:grid-cols-2"
-        style={{ gap: "var(--space-6)" }}
+        style={rowStyleLast}
       >
-        <Card
+        <Panel
           title="Body composition"
           meta={fitnessLatest ? ` · ${fmtDate(fitnessLatest.date)}` : " · no data"}
         >
@@ -837,9 +835,9 @@ export default async function WeeklyPage() {
               )}
             </>
           )}
-        </Card>
+        </Panel>
 
-        <Card
+        <Panel
           title="Journal"
           meta={` · ${journalCount} entr${journalCount === 1 ? "y" : "ies"}${
             journalMissed > 0 ? ` · ${journalMissed} missed` : ""
@@ -889,7 +887,7 @@ export default async function WeeklyPage() {
               </p>
             </div>
           </div>
-        </Card>
+        </Panel>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Follow-up to #309. The filled `--color-surface` + `--color-border` + `--r-2` + `card-lift` wrapper restored in #309 felt heavier than the refined dashboard aesthetic. This PR swaps the cards for flat `<section>` panels matching the live dashboard's vocabulary, while keeping the two-column layout so Weekly doesn't collapse into a wall-of-text scroll.

- **Card → Panel.** Flat `<section>` with `db-section-label` header — no fill, no border, no rounded corners, no hover lift.
- **Two-column layout preserved** (`grid-cols-1 lg:grid-cols-2`, three rows of two): Habits | Tasks · Training | Recovery · Body composition | Journal.
- **Row separation** via `border-bottom: 1px solid var(--rule-soft)` + `padding-bottom: var(--space-7)` on each grid row (final row omits the trailing rule) — the `.db-section` feel applied to a grid.
- **Gaps bumped to `--space-7`** both intra-row and inter-row so panels breathe like dashboard sections instead of feeling crowded inside a card.
- **Hairline tables unchanged** inside each panel — tabular numerics, 14×14 habit heatmap squares, `.delta-good` / `.delta-bad` utilities, today flag, prior-measurement hint.
- **Loading skeleton** rebuilt as three hairline-separated two-column rows of flat `PanelSkeleton` placeholders.
- **No UX changes.** All ten parallel Supabase queries and every computed value preserved byte-identical.

## Test plan

- [ ] `/weekly` renders as 3 hairline-separated rows of two flat panels on desktop, single-column on mobile, both themes
- [ ] Each `db-section-label` meta line correctly reflects live data
- [ ] Habit row squares align visually with the Habits page heatmap
- [ ] Recovery table flags today; missing days render `—` faint
- [ ] Body-comp delta cells color correctly on weight / body fat movement
- [ ] Tasks panel caps at 8 completed / 5 active with "+N more" tail
- [ ] Loading skeleton matches post-hydration layout (no shift)
- [ ] Final row has no trailing hairline rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)