### PR TITLE
fix: Weekly — uniform panel heights with internal scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed (Weekly — uniform panel heights with internal scroll)
+- **All six panels clamped to 440px height** in [web/src/app/(protected)/weekly/page.tsx](web/src/app/(protected)/weekly/page.tsx). In #310 the two-column grid inherited each panel's natural content height, so Tasks / Training towered over Body composition / Journal and the grid read as uneven. Each panel is now a fixed-height flex column (`height: 440px`), giving the grid a uniform set of cells.
+- **Overflow scrolls inside each panel** via a `scroll-fade-mask` body with `flex: 1; min-height: 0; overflow-y: auto`. The Phase B label stays pinned at top; content scrolls underneath with the existing 16px bottom fade so the scrollbar doesn't read as a hard edge.
+- **Task truncation dropped.** The `.slice(0, 8)` / `.slice(0, 5)` caps on completed + active tasks are gone along with the `+N more` tails — the user can scroll through the full week now, which is what the scroll container is for.
+- **Loading skeleton** updated to match (six hairline-separated `PanelSkeleton`s at the same 440px height).
+- **No UX changes.** All ten parallel Supabase queries and every computed value preserved byte-identical.
+
 ### Fixed (Weekly — switch to dashboard panel pattern, two columns)
 - **Card shells dropped, panels use the dashboard pattern** in [web/src/app/(protected)/weekly/page.tsx](web/src/app/(protected)/weekly/page.tsx). The `--color-surface` + `--color-border` + `--r-2` + `card-lift` wrappers shipped in #309 were replaced with flat `<section>` panels that match the live dashboard's vocabulary — `db-section-label` headers, no fill, no border, no rounded corners, no hover lift. The local `Card` helper is renamed `Panel` and simplified.
 - **Two-column layout preserved.** Panels remain arranged as three rows of two (`grid-cols-1 lg:grid-cols-2`) so each domain sits side-by-side with its pair (Habits | Tasks, Training | Recovery, Body composition | Journal). Row-to-row separation comes from a `border-bottom: 1px solid var(--rule-soft)` + `padding-bottom: var(--space-7)` treatment (the `.db-section` feel applied to a grid row), with the final row omitting the trailing rule.

--- a/web/src/app/(protected)/weekly/loading.tsx
+++ b/web/src/app/(protected)/weekly/loading.tsx
@@ -1,11 +1,13 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
+const PANEL_HEIGHT = 440;
+
 function PanelSkeleton() {
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col" style={{ height: PANEL_HEIGHT }}>
       <Skeleton className="h-3 w-28" style={{ marginBottom: "var(--space-4)" }} />
-      <div className="flex flex-col" style={{ gap: "var(--space-3)" }}>
-        {[1, 2, 3, 4].map((r) => (
+      <div className="flex flex-col" style={{ gap: "var(--space-3)", flex: 1 }}>
+        {[1, 2, 3, 4, 5, 6].map((r) => (
           <Skeleton key={r} style={{ height: 20 }} />
         ))}
       </div>
@@ -29,7 +31,7 @@ export default function Loading() {
         <Skeleton className="h-3 w-36" style={{ marginTop: "var(--space-2)" }} />
       </div>
 
-      {/* Three rows of two flat panels, hairline-separated */}
+      {/* Three rows of two uniform-height panels, hairline-separated */}
       <div className="grid grid-cols-1 lg:grid-cols-2" style={rowStyle}>
         <PanelSkeleton />
         <PanelSkeleton />

--- a/web/src/app/(protected)/weekly/page.tsx
+++ b/web/src/app/(protected)/weekly/page.tsx
@@ -65,7 +65,13 @@ function fmtDuration(mins: number): string {
   return m > 0 ? `${h}h ${m}m` : `${h}h`;
 }
 
-// ── Card wrapper ──────────────────────────────────────────────────────────────
+// ── Panel wrapper ─────────────────────────────────────────────────────────────
+
+// Every panel on the page is clamped to this height so the 2-column grid reads
+// as a uniform set of cells. Overflowing content scrolls inside the panel with
+// a bottom fade mask so tall sections (Tasks, Training) don't push the page
+// height past short sections (Body composition, Journal).
+const PANEL_HEIGHT = 440;
 
 function Panel({
   title,
@@ -77,12 +83,25 @@ function Panel({
   children: React.ReactNode;
 }) {
   return (
-    <section className="flex flex-col" style={{ minWidth: 0 }}>
-      <h2 className="db-section-label">
+    <section
+      className="flex flex-col"
+      style={{ minWidth: 0, height: PANEL_HEIGHT }}
+    >
+      <h2 className="db-section-label" style={{ flexShrink: 0 }}>
         {title}
         {meta && <span className="meta">{meta}</span>}
       </h2>
-      {children}
+      <div
+        className="scroll-fade-mask"
+        style={{
+          flex: 1,
+          minHeight: 0,
+          overflowY: "auto",
+          paddingBottom: "var(--space-4)",
+        }}
+      >
+        {children}
+      </div>
     </section>
   );
 }
@@ -434,7 +453,7 @@ export default async function WeeklyPage() {
                     Closed this week
                   </p>
                   <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
-                    {completedTasks.slice(0, 8).map((t) => (
+                    {completedTasks.map((t) => (
                       <li
                         key={t.id}
                         className="flex items-baseline"
@@ -457,18 +476,6 @@ export default async function WeeklyPage() {
                       </li>
                     ))}
                   </ul>
-                  {completedTasks.length > 8 && (
-                    <p
-                      className="tnum"
-                      style={{
-                        marginTop: "var(--space-2)",
-                        fontSize: "var(--t-micro)",
-                        color: "var(--color-text-faint)",
-                      }}
-                    >
-                      +{completedTasks.length - 8} more
-                    </p>
-                  )}
                 </div>
               )}
 
@@ -487,7 +494,7 @@ export default async function WeeklyPage() {
                     Still active
                   </p>
                   <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
-                    {activeTasks.slice(0, 5).map((t) => {
+                    {activeTasks.map((t) => {
                       const overdue = t.due_date != null && t.due_date < today;
                       return (
                         <li
@@ -535,18 +542,6 @@ export default async function WeeklyPage() {
                       );
                     })}
                   </ul>
-                  {activeTasks.length > 5 && (
-                    <p
-                      className="tnum"
-                      style={{
-                        marginTop: "var(--space-2)",
-                        fontSize: "var(--t-micro)",
-                        color: "var(--color-text-faint)",
-                      }}
-                    >
-                      +{activeTasks.length - 5} more
-                    </p>
-                  )}
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary

Follow-up to #310. The 2-col grid inherited each panel's natural content height, so Tasks and Training towered over Body composition and Journal — the grid read as uneven cells. This PR clamps every panel to the same height and scrolls overflowing content inside.

- **All six panels = 440px height.** Panel becomes a fixed-height flex column; the `db-section-label` stays pinned at top and the body scrolls underneath.
- **Internal scroll via `scroll-fade-mask`** (existing utility) with `flex: 1; min-height: 0; overflow-y: auto` on the body — a 16px bottom fade softens the scroll boundary so it doesn't read as a hard cutoff.
- **Task truncation dropped.** The `.slice(0, 8)` / `.slice(0, 5)` caps on completed + active tasks are gone along with the `+N more` tails — content scrolls now, so the caps served no purpose.
- **Loading skeleton** updated (six hairline-separated `PanelSkeleton`s at 440px).
- **No UX changes.** All ten parallel Supabase queries and every computed value preserved byte-identical.

## Test plan

- [ ] `/weekly` renders as 3 hairline-separated rows of two 440px-tall panels on desktop, both themes
- [ ] Tasks panel scrolls through all completed + active tasks (not capped at 8/5 anymore)
- [ ] Training panel scrolls through sessions + walks when they overflow
- [ ] Recovery / Habits / Body comp / Journal panels still fit without scroll (content ≤ 440px)
- [ ] Bottom of each scrollable panel fades (scroll-fade-mask) rather than hard-clipping
- [ ] Mobile (`grid-cols-1`) still works — panels stack full-width at 440px
- [ ] Loading skeleton matches post-hydration layout (no shift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)