### PR TITLE
chore: allowlist logo.tsx in token-lint

### DIFF
--- a/scripts/lint-tokens.sh
+++ b/scripts/lint-tokens.sh
@@ -56,6 +56,7 @@ fi
 # ── 4. No raw hex colors outside token definitions ───────────────────────
 # Allowlist: globals.css (token defs), FoodPhotoAnalyzer (own cleanup issue),
 # chart-colors.ts (canvas/SVG needs raw hex), icon.svg (SVG markup),
+# logo.tsx (SVG markup — static fill can't reference CSS vars),
 # MealsClient.tsx (CSS var fallbacks — var(--token, #hex)),
 # layout.tsx (viewport.themeColor must be a static hex — can't reference CSS vars).
 # Only scans .tsx/.css to avoid false positives from issue numbers in .ts.
@@ -65,6 +66,7 @@ HEX_HITS=$(grep -rn '#[0-9a-fA-F]\{3,8\}\b' "$WEB_SRC" \
   | grep -v 'FoodPhoto' \
   | grep -v 'chart-colors' \
   | grep -v 'icon\.svg' \
+  | grep -v 'logo\.tsx' \
   | grep -v 'MealsClient' \
   | grep -v 'layout\.tsx' \
   || true)


### PR DESCRIPTION
## Summary

`scripts/lint-tokens.sh` Guard 4 has been failing on every PR since the amber logo landed in commit 59ad7172 (e.g. #316, #318, #320 all merged red). The single hit is `web/src/components/ui/logo.tsx:18` — `fill="#261C13"` — which is legitimately required by static SVG markup (CSS vars don't work in SVG `fill`). `icon.svg` is already allowlisted for the same reason.

Adds `logo.tsx` to the file-level `grep -v` allowlist so the check actually tells us something next time.

## Test plan

- [x] `bash scripts/lint-tokens.sh` → `All token guards passed.`
- [ ] CI lint-tokens job passes green on this PR