### PR TITLE
test: mutating-tool + multi-turn smoke specs

### DIFF
--- a/web/smoke/specs/calendar-mutate-smoke.spec.ts
+++ b/web/smoke/specs/calendar-mutate-smoke.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "../fixtures/auth";
+
+test("calendar mutate — create then delete Smoke Test event", async ({
+  signedInPage: page,
+  consoleErrors,
+}) => {
+  await page.goto("/chat");
+
+  // Start fresh to avoid appending to a prior turn's session.
+  await page.getByRole("button", { name: "New chat" }).first().click();
+  await expect(page.getByPlaceholder("Ask Mr. Bridge...")).toBeVisible();
+
+  const sendButton = page.getByRole("button", { name: "Send" });
+
+  // — Turn 1: create —
+  await page
+    .getByPlaceholder("Ask Mr. Bridge...")
+    .fill("Create a calendar event called Smoke Test tomorrow at 10am");
+
+  const [, createResponse] = await Promise.all([
+    page.waitForRequest(
+      (req) => req.url().includes("/api/chat") && req.method() === "POST",
+    ),
+    page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/chat") && resp.request().method() === "POST",
+    ),
+    sendButton.click(),
+  ]);
+
+  expect(createResponse.status()).toBe(200);
+  await createResponse.finished();
+  await expect(sendButton).toBeVisible({ timeout: 30_000 });
+
+  const createBubble = page.locator('[data-print-message="assistant"]').last();
+  await expect(createBubble).toBeVisible();
+  const createText = await createBubble.textContent();
+  console.log("Create reply:", createText?.slice(0, 300));
+  expect(createText?.toLowerCase()).toMatch(/creat|schedul|add/);
+
+  // — Turn 2: delete —
+  await page
+    .getByPlaceholder("Ask Mr. Bridge...")
+    .fill("Delete the Smoke Test event tomorrow");
+
+  const [, deleteResponse] = await Promise.all([
+    page.waitForRequest(
+      (req) => req.url().includes("/api/chat") && req.method() === "POST",
+    ),
+    page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/chat") && resp.request().method() === "POST",
+    ),
+    sendButton.click(),
+  ]);
+
+  expect(deleteResponse.status()).toBe(200);
+  await deleteResponse.finished();
+  await expect(sendButton).toBeVisible({ timeout: 30_000 });
+
+  const deleteBubble = page.locator('[data-print-message="assistant"]').last();
+  await expect(deleteBubble).toBeVisible();
+  const deleteText = await deleteBubble.textContent();
+  console.log("Delete reply:", deleteText?.slice(0, 300));
+  expect(deleteText?.toLowerCase()).toMatch(/delet|remov|cancel/);
+
+  expect(
+    consoleErrors,
+    `console errors during test: ${consoleErrors.join("\n")}`,
+  ).toHaveLength(0);
+});

--- a/web/smoke/specs/chat-multi-turn-smoke.spec.ts
+++ b/web/smoke/specs/chat-multi-turn-smoke.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from "../fixtures/auth";
+import {
+  createSmokeAdminClient,
+  getMessagesForSession,
+} from "../utils/supabase-verify";
+
+test("chat multi-turn — conversation history is threaded", async ({
+  signedInPage,
+  consoleErrors,
+}) => {
+  const page = signedInPage;
+
+  await page.goto("/chat");
+
+  // Fresh session — SSR hydrates the most recent session without this.
+  await page.getByRole("button", { name: "New chat" }).first().click();
+
+  const sendButton = page.getByRole("button", { name: "Send" });
+
+  // — Turn 1: "What's 2+2?" —
+  await page.getByPlaceholder("Ask Mr. Bridge...").fill("What's 2+2?");
+
+  const [turn1Request, turn1Response] = await Promise.all([
+    page.waitForRequest(
+      (req) => req.url().includes("/api/chat") && req.method() === "POST",
+    ),
+    page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/chat") && resp.request().method() === "POST",
+    ),
+    sendButton.click(),
+  ]);
+
+  expect(turn1Response.status()).toBe(200);
+  await turn1Response.finished();
+
+  // Capture sessionId from the first POST body — the second POST will reuse it,
+  // proving both turns share the same conversation thread.
+  const postData = turn1Request.postData();
+  expect(postData, "POST /api/chat had no body").toBeTruthy();
+  const { sessionId } = JSON.parse(postData as string) as {
+    sessionId?: string;
+  };
+  expect(sessionId, "sessionId missing from POST body").toBeTruthy();
+
+  await expect(sendButton).toBeVisible({ timeout: 30_000 });
+
+  // — Turn 2: "Double that answer" — must resolve to 8 via conversation history —
+  await page
+    .getByPlaceholder("Ask Mr. Bridge...")
+    .fill("Double that answer");
+
+  const [, turn2Response] = await Promise.all([
+    page.waitForRequest(
+      (req) => req.url().includes("/api/chat") && req.method() === "POST",
+    ),
+    page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/chat") && resp.request().method() === "POST",
+    ),
+    sendButton.click(),
+  ]);
+
+  expect(turn2Response.status()).toBe(200);
+  await turn2Response.finished();
+  await expect(sendButton).toBeVisible({ timeout: 30_000 });
+
+  // DB is authoritative for short/numeric replies — the markdown renderer can
+  // turn a bare "8" into an empty list marker in the DOM (pre-existing edge case).
+  const admin = createSmokeAdminClient();
+  const rows = await getMessagesForSession(admin, sessionId as string);
+
+  // Two turns = user1, assistant1, user2, assistant2
+  expect(rows.length, "expected at least 4 rows (2 full turns)").toBeGreaterThanOrEqual(4);
+
+  const assistant2 = rows[rows.length - 1];
+  expect(assistant2.role).toBe("assistant");
+  expect(assistant2.content).toMatch(/8/);
+
+  expect(
+    consoleErrors,
+    `console errors during test: ${consoleErrors.join("\n")}`,
+  ).toHaveLength(0);
+});


### PR DESCRIPTION
## Summary

- Adds `calendar-mutate-smoke.spec.ts`: signs in as the smoke user, sends "Create a calendar event called Smoke Test tomorrow at 10am", asserts assistant confirms creation, then sends "Delete the Smoke Test event tomorrow", asserts deletion language in reply. Exercises the `create_event` → `delete_event` round-trip against the real smoke Google account.
- Adds `chat-multi-turn-smoke.spec.ts`: sends "What's 2+2?" then "Double that answer" in the same session, verifies the second assistant DB row contains "8" (using the `supabase-verify` admin client to avoid the markdown numeric renderer edge case). Proves conversation history is threaded across turns.

## Test plan

- [x] `npx playwright test smoke/specs/calendar-mutate-smoke.spec.ts smoke/specs/chat-multi-turn-smoke.spec.ts` — both passed (18.7s, 6.3s) against local dev server with `SMOKE_TEST_EMAIL`/`SMOKE_TEST_PASSWORD` from `.env.local`
- [x] Branch cut from `origin/main`
- [x] No changes to app code — spec files only

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)