### PR TITLE
Food Analyzer: optional dish description for better macro estimates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Added
+- **Optional dish description field on Food Analyzer (#371).** An optional textarea ("Tell Bridge what's in the dish (optional)") appears above the camera/library buttons on the Food Analyzer landing view. User text (max 500 chars) is injected as an untrusted reference note in the user-turn slot of the vision model for more accurate macro estimates. The value persists on each `ScanItem` through re-estimates and inline edits, is stored in a new `meal_log.user_context` column, and flows through the Bridge chat log path. Users who skip the field see no change in behavior.
+
 - **Pre-commit hook via husky + lint-staged (#354).** ESLint (--fix) and Prettier run on staged files before every local commit. All four token guards (hover handlers, hardcoded white, color-mix(), raw hex) also run via `scripts/lint-tokens.sh` so local behaviour matches CI. The hook is non-interactive and bypassed cleanly by `git commit --no-verify`. Installed automatically on `cd web && npm install`.
 - **Prettier code-formatting with explicit config (#355).** `printWidth: 100`, `trailingComma: "all"` (all other defaults kept). `eslint-config-prettier` added as the last entry in `web/eslint.config.mjs` to disable conflicting stylistic ESLint rules. CI enforces formatting via `npm run format:check` added to the `eslint` workflow job. Use `cd web && npm run format` to reformat locally.
 

--- a/supabase/migrations/20260421000003_add_user_context_to_meal_log.sql
+++ b/supabase/migrations/20260421000003_add_user_context_to_meal_log.sql
@@ -1,0 +1,1 @@
+alter table meal_log add column if not exists user_context text;

--- a/web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx
+++ b/web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx
@@ -41,6 +41,8 @@ export interface ScanItem {
   fatManuallyEdited?: boolean;
   fiberManuallyEdited?: boolean;
   sugarManuallyEdited?: boolean;
+  // User-supplied dish description at capture time (#371).
+  user_context?: string;
 }
 
 function roundOrDash(v: number | null, digits = 0): string {
@@ -228,6 +230,10 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
   // ── Inline chat state ────────────────────────────────────────────────────
   const [showInlineChat, setShowInlineChat] = useState(false);
 
+  // ── User context (optional dish description, #371) ───────────────────────
+  const [userContext, setUserContext] = useState("");
+  const scanCtaRef = useRef<HTMLDivElement>(null);
+
   // ── Derived totals ────────────────────────────────────────────────────────
   const combined = items.reduce(
     (acc, item) => ({
@@ -339,6 +345,8 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
     const formData = new FormData();
     formData.append("image", imageBlob, "photo.jpg");
     formData.append("mode", analyzerMode);
+    const trimmedContext = userContext.trim();
+    if (trimmedContext) formData.append("user_context", trimmedContext);
 
     try {
       const res = await fetch("/api/meals/analyze-photo", {
@@ -367,6 +375,7 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
             fiber_g: data.fiber_g ?? null,
             sugar_g: data.sugar_g ?? null,
             sodium_mg: data.sodium_mg ?? undefined,
+            user_context: trimmedContext || undefined,
           });
         } else {
           addItem({
@@ -381,6 +390,7 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
             sugar_g: data.sugar_g ?? null,
             sodium_mg: data.sodium_mg ?? undefined,
             ingredients: data.ingredients ?? undefined,
+            user_context: trimmedContext || undefined,
           });
         }
         setScanPhase("idle");
@@ -400,31 +410,29 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
   // ── Per-item re-estimation ────────────────────────────────────────────────
   async function handleReestimateItem(id: string, ingredients: string) {
     setReestimatingId(id);
+    const item = items.find((i) => i.id === id);
     try {
       const res = await fetch("/api/meals/estimate-macros", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ingredients }),
+        body: JSON.stringify({ ingredients, user_context: item?.user_context }),
       });
       const data = await res.json();
       if (!res.ok || data.error) throw new Error(data.error ?? "Re-estimation failed");
       // Respect per-field manual-edit flags — don't clobber anything the user typed (#302).
       setItems((prev) =>
-        prev.map((item) => {
-          if (item.id !== id) return item;
+        prev.map((it) => {
+          if (it.id !== id) return it;
           return {
-            ...item,
-            label: item.labelManuallyEdited ? item.label : (data.food_name ?? item.label),
-            calories: item.caloriesManuallyEdited
-              ? item.calories
-              : (data.calories ?? item.calories),
-            protein_g: item.proteinManuallyEdited
-              ? item.protein_g
-              : (data.protein_g ?? item.protein_g),
-            carbs_g: item.carbsManuallyEdited ? item.carbs_g : (data.carbs_g ?? item.carbs_g),
-            fat_g: item.fatManuallyEdited ? item.fat_g : (data.fat_g ?? item.fat_g),
-            fiber_g: item.fiberManuallyEdited ? item.fiber_g : (data.fiber_g ?? null),
-            sugar_g: item.sugarManuallyEdited ? item.sugar_g : (data.sugar_g ?? null),
+            ...it,
+            label: it.labelManuallyEdited ? it.label : (data.food_name ?? it.label),
+            calories: it.caloriesManuallyEdited ? it.calories : (data.calories ?? it.calories),
+            protein_g: it.proteinManuallyEdited ? it.protein_g : (data.protein_g ?? it.protein_g),
+            carbs_g: it.carbsManuallyEdited ? it.carbs_g : (data.carbs_g ?? it.carbs_g),
+            fat_g: it.fatManuallyEdited ? it.fat_g : (data.fat_g ?? it.fat_g),
+            fiber_g: it.fiberManuallyEdited ? it.fiber_g : (data.fiber_g ?? null),
+            sugar_g: it.sugarManuallyEdited ? it.sugar_g : (data.sugar_g ?? null),
+            // user_context is user-authored — always preserve it unchanged.
           };
         }),
       );
@@ -460,6 +468,7 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
   // ── Log as meal ───────────────────────────────────────────────────────────
   async function handleLogMeal() {
     const s = parseFloat(servings) || 1;
+    const logUserContext = items.find((i) => i.user_context)?.user_context;
     setLogging(true);
     try {
       const res = await fetch("/api/meals/log", {
@@ -468,6 +477,7 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
         body: JSON.stringify({
           meal_type: logMealType,
           notes: items.map((i) => i.label).join(", "),
+          user_context: logUserContext ?? undefined,
           calories: Math.round(combined.calories * s),
           protein_g: Math.round(combined.protein_g * s * 10) / 10,
           carbs_g: Math.round(combined.carbs_g * s * 10) / 10,
@@ -500,6 +510,7 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
       fiber_g: combinedFiber === null ? null : Math.round((combinedFiber / n) * 10) / 10,
       sugar_g: combinedSugar === null ? null : Math.round((combinedSugar / n) * 10) / 10,
     };
+    const prepUserContext = items.find((i) => i.user_context)?.user_context;
     setPrepping(true);
     try {
       const res = await fetch("/api/meals/log", {
@@ -508,6 +519,7 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
         body: JSON.stringify({
           meal_type: mealPrepType,
           notes: items.map((i) => i.label).join(", "),
+          user_context: prepUserContext ?? undefined,
           ...perContainer,
           source: "scanner",
           count: n,
@@ -801,7 +813,43 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
           >
             Scan a nutrition label or food photo to get started.
           </p>
-          <div className="flex flex-wrap justify-center" style={{ gap: "var(--space-2)" }}>
+          <div style={{ width: "100%", maxWidth: 360 }}>
+            <textarea
+              value={userContext}
+              onChange={(e) => setUserContext(e.target.value)}
+              maxLength={500}
+              rows={3}
+              placeholder="Tell Bridge what's in the dish (optional)"
+              autoComplete="off"
+              autoCorrect="off"
+              onFocus={() =>
+                scanCtaRef.current?.scrollIntoView({ block: "center", behavior: "smooth" })
+              }
+              style={{
+                ...inputStyle,
+                resize: "none",
+                lineHeight: 1.6,
+                fontSize: "var(--t-meta)",
+              }}
+            />
+            {userContext.length > 0 && (
+              <div
+                style={{
+                  fontSize: "var(--t-micro)",
+                  color: "var(--color-text-faint)",
+                  textAlign: "right",
+                  marginTop: "var(--space-1)",
+                }}
+              >
+                {userContext.length}/500
+              </div>
+            )}
+          </div>
+          <div
+            ref={scanCtaRef}
+            className="flex flex-wrap justify-center"
+            style={{ gap: "var(--space-2)" }}
+          >
             <button
               onClick={() => cameraInputRef.current?.click()}
               className="flex items-center justify-center transition-opacity active:opacity-70"

--- a/web/src/app/(protected)/meals/InlineMealChat.tsx
+++ b/web/src/app/(protected)/meals/InlineMealChat.tsx
@@ -27,6 +27,7 @@ interface LogMealProposal {
   items: ProposalItem[];
   meal_type: MealType;
   notes: string;
+  user_context: string | null;
   totals: {
     calories: number;
     protein_g: number;
@@ -120,6 +121,7 @@ export default function InlineMealChat({
             fat_g: i.fat_g,
             fiber_g: i.fiber_g,
             sugar_g: i.sugar_g,
+            user_context: i.user_context,
           })),
           mealType: defaultMealType,
         }),
@@ -218,6 +220,7 @@ export default function InlineMealChat({
         body: JSON.stringify({
           meal_type: p.meal_type,
           notes: p.notes,
+          user_context: p.user_context ?? undefined,
           calories: Math.round(p.totals.calories),
           protein_g: round(p.totals.protein_g, 1),
           carbs_g: round(p.totals.carbs_g, 1),

--- a/web/src/app/api/meals/analyze-photo/route.ts
+++ b/web/src/app/api/meals/analyze-photo/route.ts
@@ -81,6 +81,13 @@ export async function POST(req: Request) {
   const userPromptRaw = formData.get("prompt");
   const userPrompt = typeof userPromptRaw === "string" ? userPromptRaw.trim() : "";
 
+  const userContextRaw = formData.get("user_context");
+  const userContextStr =
+    typeof userContextRaw === "string" ? userContextRaw.trim().slice(0, 500) : "";
+  if (typeof userContextRaw === "string" && userContextRaw.length > 500) {
+    return Response.json({ error: "user_context must be ≤ 500 characters" }, { status: 400 });
+  }
+
   const modeRaw = formData.get("mode");
   const mode = modeRaw === "label" ? "label" : "food";
 
@@ -150,6 +157,14 @@ Instructions:
           role: "user",
           content: [
             { type: "image", image: base64, mediaType: mimeType },
+            ...(userContextStr
+              ? [
+                  {
+                    type: "text" as const,
+                    text: `User-provided description of the dish (for reference; may be inaccurate): ${userContextStr}`,
+                  },
+                ]
+              : []),
             ...(userPrompt ? [{ type: "text" as const, text: `User context: ${userPrompt}` }] : []),
           ],
         },

--- a/web/src/app/api/meals/estimate-macros/route.ts
+++ b/web/src/app/api/meals/estimate-macros/route.ts
@@ -41,6 +41,7 @@ export async function POST(req: Request) {
   let body: {
     ingredients: string;
     dish_name?: string;
+    user_context?: string;
     current_macros?: { calories?: number; protein_g?: number; carbs_g?: number; fat_g?: number };
   };
   try {
@@ -55,12 +56,21 @@ export async function POST(req: Request) {
     return Response.json({ error: "ingredients or dish_name is required" }, { status: 400 });
   }
 
+  const userContext = body.user_context?.trim() ?? "";
+  if (userContext.length > 500) {
+    return Response.json({ error: "user_context must be ≤ 500 characters" }, { status: 400 });
+  }
+
   const cm = body.current_macros;
   const hasCurrent =
     cm && (cm.calories != null || cm.protein_g != null || cm.carbs_g != null || cm.fat_g != null);
 
+  const userContextSuffix = userContext
+    ? `\n\nUser-provided description of the dish (for reference; may be inaccurate): ${userContext}`
+    : "";
+
   const prompt =
-    hasCurrent && dishName
+    (hasCurrent && dishName
       ? `A user already logged a meal and now wants to adjust its macros.
 
 Base dish: "${dishName}"
@@ -87,7 +97,7 @@ Instructions:
 - Use conservative estimates — do not inflate
 - Set confidence to "high" if ingredients and quantities are clearly specified
 - Set confidence to "low" if ingredients are vague or quantities are absent
-- Include any key assumptions in notes`;
+- Include any key assumptions in notes`) + userContextSuffix;
 
   try {
     const agent = new ToolLoopAgent({

--- a/web/src/app/api/meals/log/route.ts
+++ b/web/src/app/api/meals/log/route.ts
@@ -4,6 +4,7 @@ import { todayString } from "@/lib/timezone";
 interface MealLogBody {
   meal_type: "breakfast" | "lunch" | "dinner" | "snack";
   notes?: string;
+  user_context?: string;
   date?: string;
   calories?: number;
   protein_g?: number;
@@ -32,6 +33,10 @@ export async function POST(req: Request) {
     );
   }
 
+  if (typeof body.user_context === "string" && body.user_context.length > 500) {
+    return Response.json({ error: "user_context must be ≤ 500 characters" }, { status: 400 });
+  }
+
   const supabase = await createClient();
   const {
     data: { user },
@@ -44,6 +49,7 @@ export async function POST(req: Request) {
     user_id: user.id,
     meal_type: body.meal_type,
     notes: body.notes ?? null,
+    user_context: body.user_context?.trim() || null,
     date: body.date ?? todayString(),
     calories: body.calories ?? null,
     protein_g: body.protein_g ?? null,
@@ -80,6 +86,7 @@ export async function POST(req: Request) {
 interface MealLogPatchBody {
   id: string;
   notes?: string;
+  user_context?: string;
   meal_type?: "breakfast" | "lunch" | "dinner" | "snack";
   calories?: number | null;
   protein_g?: number | null;

--- a/web/src/app/api/meals/scan-chat/route.ts
+++ b/web/src/app/api/meals/scan-chat/route.ts
@@ -22,6 +22,7 @@ interface ScanItemInput {
   fat_g: number;
   fiber_g: number | null;
   sugar_g: number | null;
+  user_context?: string;
 }
 
 interface ScanChatBody {
@@ -60,7 +61,10 @@ ${scanItems
       .filter(Boolean)
       .join(", ");
     const base = `- ${i.label}: ${Math.round(i.calories)} cal, ${Math.round(i.protein_g)}g P, ${Math.round(i.carbs_g)}g C, ${Math.round(i.fat_g)}g fat`;
-    return extras ? `${base}, ${extras}` : base;
+    const withExtras = extras ? `${base}, ${extras}` : base;
+    return i.user_context
+      ? `${withExtras}\n  User-provided description of the dish (for reference; may be inaccurate): ${i.user_context}`
+      : withExtras;
   })
   .join("\n")}
 Default meal type: ${mealType}
@@ -152,11 +156,13 @@ Preserve fiber_g and sugar_g as null (not 0) when a food legitimately lacks that
             sugar_g: null as number | null,
           },
         );
+        const firstUserContext = scanItems.find((i) => i.user_context)?.user_context;
         return {
           kind: "log_meal_proposal",
           items,
           meal_type,
           notes: notes ?? items.map((i) => i.label).join(", "),
+          user_context: firstUserContext ?? null,
           totals,
         };
       },

--- a/web/src/components/meals/MealsClient.tsx
+++ b/web/src/components/meals/MealsClient.tsx
@@ -18,6 +18,7 @@ export interface MealRow {
   date: string;
   meal_type: string;
   notes: string | null;
+  user_context: string | null;
   recipes: { name: string } | null;
   calories: number | null;
   protein_g: number | null;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -126,6 +126,7 @@ export interface MealLog {
   meal_type: "breakfast" | "lunch" | "dinner" | "snack" | null;
   recipe_id: string | null;
   notes: string | null;
+  user_context: string | null;
   metadata: Record<string, unknown>;
 }
 


### PR DESCRIPTION
## Summary

- Adds an optional textarea ("Tell Bridge what's in the dish (optional)", max 500 chars) above the camera/library buttons on the Food Analyzer landing view. Users who skip it see no behavior change.
- User text is injected as an untrusted reference note in the **user-turn slot** of the vision model (`analyze-photo`) and text re-estimate model (`estimate-macros`) — never in the system prompt.
- `user_context` persists on each `ScanItem` through re-prompts and inline ingredient edits (#302 pattern).
- Stored in a new `meal_log.user_context` column (migration `20260421000003`). Kept separate from the existing `notes` column (which holds auto-generated item labels) to avoid clobbering.
- Flows through the Bridge chat log path: scan-chat system prompt includes user descriptions per item; `log_meal_proposal` carries `user_context` through to the confirm-card log POST.
- 500-char cap enforced client-side (`maxLength`) and server-side on all three entry points (`analyze-photo`, `estimate-macros`, `log`).
- Mobile: `fontSize: 16` on the textarea (prevents iOS auto-zoom); `onFocus` scrolls the CTA row into view so the virtual keyboard doesn't obscure the scan buttons.

## Files changed

| File | Change |
|------|--------|
| `supabase/migrations/20260421000003_add_user_context_to_meal_log.sql` | New column |
| `FoodPhotoAnalyzer.tsx` | `ScanItem.user_context`, textarea UI, state, threading through scan/re-estimate/log |
| `analyze-photo/route.ts` | Parse + inject `user_context` FormData field in user turn |
| `estimate-macros/route.ts` | Accept + append `user_context` to prompt |
| `log/route.ts` | Accept + persist `user_context` in insert |
| `scan-chat/route.ts` | `ScanItemInput.user_context`, include in system prompt + proposal payload |
| `InlineMealChat.tsx` | `LogMealProposal.user_context`, pass in scan-chat items + log POST |
| `types.ts`, `MealsClient.tsx` | `MealLog` / `MealRow` type updates |

## Test plan

- [ ] Meals → Food Analyzer: textarea appears above scan buttons on the landing view
- [ ] Type dish description → upload photo → scan returns macros; confirm description was considered (Network tab: `user_context` in FormData)
- [ ] Expand item → edit ingredients → re-estimate: `user_context` appears in the estimate-macros POST body
- [ ] Log the meal → SQL `select user_context from meal_log order by created_at desc limit 1` returns the typed value
- [ ] Ask Mr. Bridge → Bridge chat acknowledges the description
- [ ] Skip the textarea (leave blank) → scan and log work identically to before; `user_context` column is `null`
- [ ] Paste 501 chars → client truncates at 500 (maxLength); server returns 400 if bypassed
- [ ] Mobile: focus textarea → virtual keyboard appears → scan buttons remain scrolled into view

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)