### PR TITLE
fix: resolve ESLint errors and opt CI into Node.js 24 action runtime

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   lint-tokens:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - uses: actions/checkout@v4
       - name: Run token guards
@@ -17,6 +19,8 @@ jobs:
 
   eslint:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     defaults:
       run:
         working-directory: web

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -24,6 +24,7 @@ jobs:
       run:
         working-directory: web
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
       # Smoke-only vars (fixture + supabase-verify admin client)
       SMOKE_TEST_EMAIL: ${{ secrets.SMOKE_TEST_EMAIL }}
       SMOKE_TEST_PASSWORD: ${{ secrets.SMOKE_TEST_PASSWORD }}
@@ -80,6 +81,7 @@ jobs:
       run:
         working-directory: web
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
       SMOKE_TEST_EMAIL: ${{ secrets.SMOKE_TEST_EMAIL }}
       SMOKE_TEST_PASSWORD: ${{ secrets.SMOKE_TEST_PASSWORD }}
       SMOKE_SUPABASE_SERVICE_KEY: ${{ secrets.SMOKE_SUPABASE_SERVICE_KEY }}

--- a/web/smoke/specs/gate-b.spec.ts
+++ b/web/smoke/specs/gate-b.spec.ts
@@ -94,7 +94,7 @@ test.describe("theme-switch — SSR match after reload", () => {
     { label: "Auto", next: "Light" },
   ];
 
-  for (const { label, next } of THEMES) {
+  for (const { label, next: _next } of THEMES) {
     test(`set ${label} → reload → SSR matches client`, async ({ signedInPage: page }) => {
       await page.goto("/settings");
       await page.locator("h1").first().waitFor({ timeout: 20_000 });

--- a/web/src/app/(protected)/fitness/page.tsx
+++ b/web/src/app/(protected)/fitness/page.tsx
@@ -112,7 +112,6 @@ export default async function FitnessPage() {
     .filter((w) => w.date >= mondayStr && w.date <= sundayStr)
     .map((w) => w.date);
 
-  const workouts = allWorkouts.filter((w) => !/walk/i.test(w.activity));
   const walkSessions = allWorkouts.filter((w) => /walk/i.test(w.activity));
   const weekStart = daysAgoString(6);
   const walksThisWeek = walkSessions.filter((w) => w.date >= weekStart);

--- a/web/src/app/(protected)/settings/page.tsx
+++ b/web/src/app/(protected)/settings/page.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/components/settings/equipment-settings";
 import { createServiceClient } from "@/lib/supabase/service";
 import { loadIntegration, storeIntegration, deleteIntegration } from "@/lib/integrations/tokens";
-import { lastSyncStatus, type SyncStatus } from "@/lib/sync/log";
+import { lastSyncStatus } from "@/lib/sync/log";
 import type { SportsFavorite } from "@/lib/sync/sports";
 
 async function updateProfile(key: string, value: string) {

--- a/web/src/components/dashboard/sports-card.tsx
+++ b/web/src/components/dashboard/sports-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, useTransition } from "react";
+import Image from "next/image";
 import { ChevronDown, ChevronRight, Trophy } from "lucide-react";
 import EmptyState from "./empty-state";
 import type { SportsCache } from "@/lib/types";
@@ -111,7 +112,7 @@ function TeamLogo({
 }) {
   if (src) {
     return (
-      <img
+      <Image
         src={src}
         alt={name}
         width={24}

--- a/web/src/components/fitness/FitnessClient.tsx
+++ b/web/src/components/fitness/FitnessClient.tsx
@@ -90,7 +90,7 @@ export function FitnessClient({
   bodyFatGoal,
   windowKey,
   days,
-  weekCount,
+  weekCount: _weekCount,
   exercisePRs,
   prCount,
   restTimerEnabled,

--- a/web/src/components/fitness/weekly-workout-plan.tsx
+++ b/web/src/components/fitness/weekly-workout-plan.tsx
@@ -97,7 +97,13 @@ interface ExerciseRowProps {
   };
 }
 
-function ExerciseRow({ ex, unit, exercisePR, restTimerEnabled, loggerContext }: ExerciseRowProps) {
+function ExerciseRow({
+  ex,
+  unit: _unit,
+  exercisePR,
+  restTimerEnabled,
+  loggerContext,
+}: ExerciseRowProps) {
   const [detailsOpen, setDetailsOpen] = useState(false);
   const setsStr = ex.sets ? `${ex.sets} sets` : null;
   const repsStr = ex.reps ? `× ${ex.reps}` : null;


### PR DESCRIPTION
## Summary
- Prefix unused destructured params with `_` (`unit`, `weekCount`, `next` in gate-b spec)
- Remove unused `SyncStatus` type import in settings page and unused `workouts` assignment in fitness page
- Replace `<img>` with `<Image>` from `next/image` in `sports-card` TeamLogo component
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` to all CI jobs ahead of the June 2026 forced cutover

## Test plan
- [ ] Lint CI passes (no ESLint errors)
- [ ] Smoke CI passes
- [ ] Sports card team logos still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)