### PR TITLE
fix(sports): allow ESPN CDN domain for team logo images

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -6,6 +6,14 @@ const withAnalyze = withBundleAnalyzer({
 });
 
 const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "a.espncdn.com",
+      },
+    ],
+  },
   experimental: {
     // Cache dynamic route RSC payloads in the client-side router cache.
     // Without this, force-dynamic pages re-fetch on every tab switch (stale=0).


### PR DESCRIPTION
## Summary
- Adds `a.espncdn.com` to `images.remotePatterns` in `next.config.ts`
- Next.js `Image` component blocks external hostnames by default; without this entry, all sports team logos silently failed to load

## Test plan
- [ ] Start dev server and open the Sports section of the dashboard
- [ ] Confirm team logos (Warriors, Giants, Ferrari) render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)