### PR TITLE
fix: sleep efficiency chart blank after #453

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+- **Sleep efficiency chart blank after #453.** `RecoveryTrends` was reading `sleep_efficiency` from `metadata` JSONB; the cleanup migration in #453 removed that key. Now reads from the promoted real column `r.sleep_efficiency` directly.
+
 ### Added
 - **Multi-source recovery_metrics: Fitbit sleep/HRV/steps/calories + schema changes (#449).** Prerequisite for per-metric source preferences (#435). Three changes ship together: (1) `recovery_metrics` gains a `source` column in the unique constraint (`user_id, date, source`) so Fitbit and Oura rows coexist per date — existing rows backfilled to `source = 'oura'`. (2) Fitbit sync now calls the sleep, HRV, and daily-activity-summary endpoints and writes recovery rows with `source = 'fitbit'`. (3) Three Oura metadata JSONB fields (`sleep_efficiency`, `awake_hrs`, `vo2_max`) promoted to real columns with SQL backfill. All existing read paths updated with `source = 'oura'` filter to preserve current behaviour until the preference layer (#435) ships.
 

--- a/web/src/components/fitness/recovery-trends.tsx
+++ b/web/src/components/fitness/recovery-trends.tsx
@@ -21,17 +21,6 @@ function hoursToHm(h: number): string {
   return m > 0 ? `${hi}h ${m}m` : `${hi}h`;
 }
 
-function numberFromMeta(meta: Record<string, unknown> | null, key: string): number | null {
-  if (!meta) return null;
-  const v = meta[key];
-  if (typeof v === "number" && !Number.isNaN(v)) return v;
-  if (typeof v === "string") {
-    const parsed = parseFloat(v);
-    if (!Number.isNaN(parsed)) return parsed;
-  }
-  return null;
-}
-
 function sliceByDate<T extends { date: string }>(rows: T[], days: number): T[] {
   const today = todayString();
   const cutoff = addDays(today, -(days - 1));
@@ -84,11 +73,7 @@ export function RecoveryTrends({ trends }: Props) {
 
   // ── Sleep efficiency 14d (derived from metadata or fallback) ──────────
   const sleepEffLabels = t14.map((r) => formatDate(r.date));
-  const sleepEffValues = t14.map((r) => {
-    // Oura stores as metadata.sleep_efficiency; value is 0-100 percent.
-    const metaVal = numberFromMeta(r.metadata, "sleep_efficiency");
-    return metaVal;
-  });
+  const sleepEffValues = t14.map((r) => r.sleep_efficiency);
   const sleepEffHasAny = sleepEffValues.some((v) => v != null);
   const sleepEffTodayIdx = t14[t14.length - 1]?.date === today ? t14.length - 1 : -1;
   const sleepEffLatest = sleepEffValues[sleepEffValues.length - 1] ?? null;


### PR DESCRIPTION
## Summary
- `RecoveryTrends` was reading `sleep_efficiency` from `r.metadata` via a `numberFromMeta` helper
- The cleanup migration in #453 (`20260423000002`) removes that key from metadata JSONB
- Now reads directly from `r.sleep_efficiency` (the real column added in `20260423000001`)
- Removed the now-dead `numberFromMeta` helper

## Test plan
- [ ] Sleep Efficiency · 14D chart renders data on the fitness page
- [ ] `npx tsc --noEmit` passes

Fixes regression introduced by #453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)