### PR TITLE
fix(theme): kill /dashboard hydration mismatch (React #418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Fixed
 - **Clean up three sources of console noise during the CSP Report-Only soak.** (1) `interest-cohort=()` was the FLoC opt-out; Google killed FLoC in 2022 and Chrome now rejects the directive as "Unrecognized feature." (2) `upgrade-insecure-requests` is ignored by the CSP spec when delivered under `Content-Security-Policy-Report-Only`; it will be added back when the CSP flips to enforcing. (3) `'unsafe-eval'` added to `script-src` in dev only (`NODE_ENV !== "production"`) because Next 16 + Turbopack uses `eval()` to parse the RSC stream in dev mode, which tripped ~130 Report-Only violations per `/dashboard` load. Production builds don't use `eval`, so the prod CSP stays tight.
 
+- **ThemeToggle SSR/client hydration mismatch on /dashboard.** `next-themes` reads from `localStorage` on the client, which may disagree with the cookie-backed `defaultTheme` the server rendered with — the server rendered `Theme: System` + Monitor icon while the client hydrated as `Theme: Dark` + Moon icon, tripping React error #418 and the downstream `Cannot read properties of null (reading 'parentNode')` crash. `web/src/components/theme-toggle.tsx` now gates the theme-dependent label/icon behind a `mounted` flag so SSR and the first client render produce the same placeholder. New Playwright regression `web/smoke/specs/dashboard-hydration.spec.ts` asserts no React hydration errors in the dashboard console.
+
 - **Sleep efficiency chart blank after #453.** `RecoveryTrends` was reading `sleep_efficiency` from `metadata` JSONB; the cleanup migration in #453 removed that key. Now reads from the promoted real column `r.sleep_efficiency` directly.
 
 ### Added

--- a/web/smoke/specs/dashboard-hydration.spec.ts
+++ b/web/smoke/specs/dashboard-hydration.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "../fixtures/auth";
+
+// Regression for the ThemeToggle SSR/client mismatch: next-themes reads from
+// localStorage on the client, which may disagree with the cookie-backed
+// defaultTheme the server rendered with. Before the fix, /dashboard threw
+// React #418 ("server rendered HTML didn't match the client") on every load.
+test("dashboard hydrates without React hydration errors", async ({
+  signedInPage,
+  consoleErrors,
+}) => {
+  const page = signedInPage;
+  await page.goto("/dashboard", { waitUntil: "domcontentloaded" });
+  // Give React a beat to surface any hydration warnings after the initial paint.
+  await page.waitForLoadState("networkidle").catch(() => {});
+
+  const hydrationErrors = consoleErrors.filter(
+    (msg) => /hydrat|#418|Minified React error/i.test(msg) && !/favicon/i.test(msg),
+  );
+  expect(
+    hydrationErrors,
+    `dashboard threw hydration errors:\n${hydrationErrors.join("\n")}`,
+  ).toEqual([]);
+
+  // Preserve the existing pre-existing-errors convention from chat.spec.ts.
+  consoleErrors.length = 0;
+});

--- a/web/src/components/theme-toggle.tsx
+++ b/web/src/components/theme-toggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTransition } from "react";
+import { useSyncExternalStore, useTransition } from "react";
 import { useTheme } from "next-themes";
 import { Sun, Moon, Monitor } from "lucide-react";
 import { setThemePreference } from "@/lib/theme-actions";
@@ -14,9 +14,26 @@ const LABEL: Record<ThemePreference, string> = {
   dark: "Dark",
 };
 
+// Mount flag via external-store read — matches the pattern in
+// appearance-settings.tsx. Avoids the react-hooks@7 `set-state-in-effect`
+// lint rule that blocks the classic `useState(false) + useEffect(setTrue)`.
+const subscribeMounted = () => () => {};
+const getMountedSnapshot = () => true;
+const getMountedServerSnapshot = () => false;
+
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme();
   const [, startTransition] = useTransition();
+
+  // next-themes reads from localStorage on the client, which may disagree with
+  // the cookie-backed defaultTheme the server rendered with. Gate the
+  // theme-dependent label/icon behind mount so SSR and the first client render
+  // both produce the same placeholder.
+  const mounted = useSyncExternalStore(
+    subscribeMounted,
+    getMountedSnapshot,
+    getMountedServerSnapshot,
+  );
 
   const current: ThemePreference = (theme as ThemePreference | undefined) ?? "system";
   const Icon = current === "light" ? Sun : current === "dark" ? Moon : Monitor;
@@ -34,8 +51,8 @@ export function ThemeToggle() {
     <button
       type="button"
       onClick={handleClick}
-      aria-label={`Theme: ${LABEL[current]}. Click to change.`}
-      title={`Theme: ${LABEL[current]}`}
+      aria-label={mounted ? `Theme: ${LABEL[current]}. Click to change.` : "Theme"}
+      title={mounted ? `Theme: ${LABEL[current]}` : undefined}
       className="flex items-center justify-center rounded-md cursor-pointer hover-text-brighten"
       style={{
         width: 32,
@@ -47,7 +64,11 @@ export function ThemeToggle() {
           "color var(--motion-fast) var(--ease-out-quart), background-color var(--motion-fast) var(--ease-out-quart), border-color var(--motion-fast) var(--ease-out-quart)",
       }}
     >
-      <Icon size={15} />
+      {mounted ? (
+        <Icon size={15} />
+      ) : (
+        <span aria-hidden style={{ width: 15, height: 15, display: "inline-block" }} />
+      )}
     </button>
   );
 }


### PR DESCRIPTION
## Summary
Fixes the React error #418 hydration mismatch that fires on every `/dashboard` load in production (confirmed reproducing in incognito, so not extension noise).

## Root cause
`next-themes` reads from `localStorage` on the client, which may disagree with the cookie-backed `defaultTheme` the server rendered with. Dev mode surfaced the exact diff:

```
aria-label="Theme: System. Click to change."  (server)
aria-label="Theme: Dark. Click to change."    (client)
<Monitor>  (server)   vs   <Moon>  (client)
```

Tripped React error #418 (\"server rendered HTML didn't match the client\"), followed by the downstream `Cannot read properties of null (reading 'parentNode')` crash.

## Fix
[web/src/components/theme-toggle.tsx](web/src/components/theme-toggle.tsx) now gates the theme-dependent label and icon behind a mount flag. SSR and the first client render both emit the same placeholder (empty button, generic `aria-label=\"Theme\"`, 15px square span). After the external-store snapshot flips to mounted, the button swaps in the correct icon and label synchronously — no visible flicker.

Uses the existing `useSyncExternalStore` mount-flag pattern from [appearance-settings.tsx:22-28](web/src/components/settings/appearance-settings.tsx#L22) — the codebase's `react-hooks@7`-compatible replacement for `useState(false) + useEffect(setTrue)`.

## Regression test
New spec [web/smoke/specs/dashboard-hydration.spec.ts](web/smoke/specs/dashboard-hydration.spec.ts) loads `/dashboard` and asserts zero console errors matching `/hydrat|#418|Minified React error/`. Will fail if this regresses.

## Test plan
- [ ] CI green (typecheck, lint, token-lint)
- [ ] `npm run smoke:a11y` + new `dashboard-hydration` spec pass
- [ ] Local dev: reload `/dashboard`, confirm React #418 gone from console
- [ ] Theme toggle still cycles `System → Light → Dark → System` correctly
- [ ] No visible icon flicker on load

## Related
- #455 / #483 — security-headers PR that surfaced this via active console monitoring (not a regression from it)
- #485 — separate PR removing two console-noisy CSP/Permissions-Policy directives during the soak

🤖 Generated with [Claude Code](https://claude.com/claude-code)