### PR TITLE
ci: run a11y smoke tests with multiple workers (#498)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Performance
+- **Parallelize a11y smoke tests (#498).** `web/smoke/specs/a11y.spec.ts` now calls `test.describe.configure({ mode: "parallel" })` so the 11 route tests run across workers instead of sequentially. `smoke:a11y` npm script passes `--workers=4` to override the global `workers:1` constraint (which exists solely for the chat suite). Wall-clock time drops from ~60s to ~ceil(11/4) × avg-test-time ≈ 20s. Chat tests are untouched.
 - **Reduce Anthropic API cost — 1-hour cache TTL and expanded Haiku routing.** Two changes to `web/src/app/api/chat/route.ts`. (1) Both cache breakpoints (system prompt and trailing tool) now use `ttl: "1h"` instead of the default 5-minute TTL. The 5-minute window was causing 10–30 cache re-writes per active hour at $3.75/MTok each; 1-hour TTL cuts that to 1 re-write/hr at $6/MTok — roughly 60–80% reduction in cache-write cost on active days. (2) `selectModel` Gate 4 (Haiku simple patterns) extended with 34 new read-only patterns across workouts, calendar, recovery/sleep, body stats, stocks, sports, and streaks. Mutations (`assign_workout`, `create_calendar_event`, `reschedule_workout`, etc.) are not affected — they have no simple-pattern match and fall through to Sonnet. All 19 routing test cases verified in-process before PR.
 
 ### Security

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,7 @@
     "prepare": "cd .. && husky web/.husky",
     "smoke": "playwright test",
     "smoke:chat": "playwright test smoke/specs/chat.spec.ts",
-    "smoke:a11y": "playwright test smoke/specs/a11y.spec.ts --workers=4",
+    "smoke:a11y": "playwright test smoke/specs/a11y.spec.ts --workers=2",
     "smoke:perf": "tsx smoke/perf/lighthouse.mts",
     "smoke:install": "playwright install --with-deps chromium"
   },

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,7 @@
     "prepare": "cd .. && husky web/.husky",
     "smoke": "playwright test",
     "smoke:chat": "playwright test smoke/specs/chat.spec.ts",
-    "smoke:a11y": "playwright test smoke/specs/a11y.spec.ts",
+    "smoke:a11y": "playwright test smoke/specs/a11y.spec.ts --workers=4",
     "smoke:perf": "tsx smoke/perf/lighthouse.mts",
     "smoke:install": "playwright install --with-deps chromium"
   },

--- a/web/smoke/specs/a11y.spec.ts
+++ b/web/smoke/specs/a11y.spec.ts
@@ -25,6 +25,7 @@ const ROUTES: Route[] = [
 ];
 
 test.describe("a11y — axe sweep (critical + serious)", () => {
+  test.describe.configure({ mode: "parallel" });
   for (const route of ROUTES) {
     test(`${route.path}`, async ({ signedInPage, page }, testInfo) => {
       const target = route.auth === "signed-in" ? signedInPage : page;


### PR DESCRIPTION
## Summary

- Adds `test.describe.configure({ mode: "parallel" })` to the top of the a11y describe block in `web/smoke/specs/a11y.spec.ts` so the 11 route tests are distributed across workers
- Updates `smoke:a11y` npm script with `--workers=4` to override the global `workers: 1` constraint (which is intentional for chat tests only)
- Expected wall-clock reduction: ~60s → ~20s (`ceil(11/4)` rounds × avg test time)
- Chat suite is untouched — `workers:1` remains the global default; the override only applies when `smoke:a11y` is invoked directly

## Test plan

- [ ] `npm run smoke:a11y` runs locally and all 11 route tests pass
- [ ] `npm run smoke:chat` is unaffected — still runs with `workers:1` from global config
- [ ] CI smoke-pr job passes on this branch (both `smoke:chat` and `smoke:a11y` steps)
- [ ] HTML report shows all 11 tests with distinct worker assignments

🤖 Generated with [Claude Code](https://claude.com/claude-code)