### PR TITLE
fix(onboarding): use generateObject for reliable nutrition target generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Fixed
+- **Onboarding generate button now reliably fills in targets.** Replaced `generateText` + manual `JSON.parse` with `generateObject` (Zod schema). The old approach silently returned null whenever the model included any preamble text or markdown fences in its response, causing the "fill in your body stats" error even when stats were present.
 - **Onboarding generate button shows error when no data to work with.** "Generate with Mr. Bridge →" now shows an inline hint if it returns null (no body stats or fitness goals entered yet) instead of silently doing nothing. Also catches unexpected errors and shows a fallback message.
 - **Workout preferences and equipment now editable in Settings → Fitness tab.** Previously, `workout_preferences` and `equipment_preference` set during onboarding had no Settings UI — they were invisible and uneditable after setup. Settings → Fitness tab now has "Workout preferences" (chip toggles) and "Equipment" (preset chips + free-text tag input) sections that save immediately on change, matching the onboarding experience.
 

--- a/web/src/app/(protected)/onboarding/page.tsx
+++ b/web/src/app/(protected)/onboarding/page.tsx
@@ -2,8 +2,9 @@ export const dynamic = "force-dynamic";
 
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
-import { generateText } from "ai";
+import { generateObject } from "ai";
 import { anthropic } from "@ai-sdk/anthropic";
+import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import { OnboardingWizard } from "@/components/onboarding/onboarding-wizard";
 import type { SportsFavorite } from "@/lib/sync/sports";
@@ -161,21 +162,17 @@ async function suggestNutritionTargets(
   if (parts.length === 0) return null;
 
   try {
-    const { text } = await generateText({
+    const { object } = await generateObject({
       model: anthropic("claude-haiku-4-5-20251001"),
-      maxOutputTokens: 80,
-      prompt: `You are a sports nutritionist. Return ONLY a JSON object — no markdown, no explanation — with daily macro targets for this person:\n\n${parts.join("\n")}\n\nFormat: {"calories":2400,"protein_g":180,"carbs_g":260,"fat_g":70}`,
+      schema: z.object({
+        calories: z.number(),
+        protein_g: z.number(),
+        carbs_g: z.number(),
+        fat_g: z.number(),
+      }),
+      prompt: `You are a sports nutritionist. Suggest daily macro targets for this person:\n\n${parts.join("\n")}`,
     });
-    const parsed = JSON.parse(text.trim()) as NutritionTargets;
-    if (
-      typeof parsed.calories === "number" &&
-      typeof parsed.protein_g === "number" &&
-      typeof parsed.carbs_g === "number" &&
-      typeof parsed.fat_g === "number"
-    ) {
-      return parsed;
-    }
-    return null;
+    return object;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

- Replaces `generateText` + manual `JSON.parse` with `generateObject` (Zod schema) in `suggestNutritionTargets`
- **Root cause of #506 regression**: the old code did `JSON.parse(text.trim())` on the raw model response. Haiku would sometimes include preamble text (\"Here are your targets:\") or wrap the JSON in markdown fences (\`\`\`json ... \`\`\`). Either caused `JSON.parse` to throw; the inner `catch` silently returned `null`; the wizard showed \"Fill in your body stats\" even when all stats were present
- `generateObject` uses Anthropic's structured output (tool-use mode under the hood), guaranteeing the response matches the Zod schema — no parsing needed
- Also removes the `maxOutputTokens: 80` cap and the manual field-type validation (Zod handles both)

## Test plan

- [ ] Onboarding step 5 (Nutrition): fill in body stats + fitness goal on earlier steps, click \"Generate with Mr. Bridge →\" → calories/protein/carbs/fat fields populate
- [ ] Onboarding step 5: click Generate without completing earlier steps → \"Fill in your body stats\" error still appears
- [ ] No TypeScript errors: `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)