### PR TITLE
fix: guard update-references.sh against running on main

### DIFF
--- a/.claude/rules/features.md
+++ b/.claude/rules/features.md
@@ -2,13 +2,13 @@
 
 When planning new features or making non-trivial changes:
 
-1. **Pull latest best practices** before starting:
-   ```bash
-   bash scripts/update-references.sh
-   ```
-2. **Create a feature branch**:
+1. **Create a feature branch** first — the reference script commits to the current branch:
    ```bash
    git checkout -b feature/<short-description>
+   ```
+2. **Pull latest best practices** (must be on a feature branch, not main):
+   ```bash
+   bash scripts/update-references.sh
    ```
 3. Reference `.claude/references/best-practice/` for patterns and conventions
 4. Implement changes on the branch

--- a/scripts/update-references.sh
+++ b/scripts/update-references.sh
@@ -4,6 +4,13 @@
 
 set -e
 
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$current_branch" == "main" ]]; then
+  echo "ERROR: update-references.sh must not run on main — it commits to the current branch." >&2
+  echo "Create a feature branch first: git checkout -b feature/<name>" >&2
+  exit 1
+fi
+
 echo "[Mr. Bridge] Updating best-practice reference..."
 git subtree pull \
   --prefix .claude/references/best-practice \


### PR DESCRIPTION
## Summary
- `scripts/update-references.sh` now exits with an error if the current branch is `main` (Option B from issue)
- `.claude/rules/features.md` reordered so branch creation is step 1 and reference pull is step 2, with inline notes explaining why

## Test plan
- [ ] Run `bash scripts/update-references.sh` on main → should print error and exit 1
- [ ] Run `bash scripts/update-references.sh` on a feature branch → should proceed normally
- [ ] Verify features.md reads naturally with new step order

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)