### PR TITLE
fix: read files before clearing input in handleFilesChange

### DIFF
--- a/web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx
+++ b/web/src/app/(protected)/meals/FoodPhotoAnalyzer.tsx
@@ -501,9 +501,9 @@ export default function FoodPhotoAnalyzer({ onUnsavedItems }: FoodPhotoAnalyzerP
 
   // ── Library multi-select — up to 6 photos at once (#545) ─────────────────
   async function handleFilesChange(e: React.ChangeEvent<HTMLInputElement>) {
-    if (libraryInputRef.current) libraryInputRef.current.value = "";
     const remaining = 6 - items.length - pendingPhotos.length;
     const files = Array.from(e.target.files ?? []).slice(0, remaining);
+    if (libraryInputRef.current) libraryInputRef.current.value = "";
     if (files.length === 0) return;
 
     const heic = files.find(


### PR DESCRIPTION
## Summary

- `handleFilesChange` was calling `libraryInputRef.current.value = ""` before `Array.from(e.target.files)` — setting `input.value` clears the `FileList`, so selecting photos and pressing Done produced an empty array and nothing happened
- Fix: swap the two lines so files are captured first, input is cleared after

## Test plan

- [ ] Select 2–3 photos from library → photos appear as loading rows and analyze
- [ ] Single photo select still works
- [ ] Camera path unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)