### PR TITLE
fix: bypass middleware auth for /api/internal/ routes

### DIFF
--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -75,7 +75,8 @@ export async function proxy(request: NextRequest) {
     request.nextUrl.pathname.startsWith("/reset-password") ||
     request.nextUrl.pathname.startsWith("/auth") ||
     request.nextUrl.pathname.startsWith("/api/auth/") ||
-    request.nextUrl.pathname.startsWith("/api/cron/");
+    request.nextUrl.pathname.startsWith("/api/cron/") ||
+    request.nextUrl.pathname.startsWith("/api/internal/");
 
   if (!user && !isAuthRoute) {
     const url = request.nextUrl.clone();


### PR DESCRIPTION
## Summary

- Adds `/api/internal/` to the `isAuthRoute` bypass list in `proxy.ts`
- Without this, unauthenticated callers (e.g. the weekly planning agent's `curl` requests) hit the `!user` redirect before the route's own Bearer token check runs, returning 403

## Root cause

`/api/cron/` was already bypassed but `/api/internal/` was not. The route handler itself validates `CRON_SECRET` — the middleware just needs to let it through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)