### PR TITLE
fix: condense month view to fit viewport without scrolling

### DIFF
--- a/web/src/components/calendar/month-view.tsx
+++ b/web/src/components/calendar/month-view.tsx
@@ -30,7 +30,7 @@ const TYPE_COLORS: Record<string, { bg: string; text: string }> = {
   other: { bg: "oklch(30% 0.04 var(--hue) / 0.3)", text: "var(--color-text-muted)" },
 };
 
-const MAX_VISIBLE = 3;
+const MAX_VISIBLE = 2;
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
@@ -69,7 +69,7 @@ export default function MonthView({
           gridAutoRows: "1fr",
           flex: 1,
           minHeight: 0,
-          overflow: "auto",
+          overflow: "hidden",
         }}
       >
         {days.map((day, idx) => {
@@ -97,7 +97,7 @@ export default function MonthView({
                 display: "flex",
                 flexDirection: "column",
                 gap: 2,
-                minHeight: 80,
+                overflow: "hidden",
                 background: isWeekend ? "var(--color-surface)" : "transparent",
               }}
             >
@@ -140,6 +140,7 @@ export default function MonthView({
                 return (
                   <button
                     key={e.eventId}
+                    title={e.title}
                     onClick={(ev) => {
                       ev.stopPropagation();
                       onEventClick(e);


### PR DESCRIPTION
## Summary
- Removes `minHeight: 80` from cells so `gridAutoRows: 1fr` controls row height uniformly — the full month grid now fits the viewport without any scrolling
- Sets grid `overflow: hidden` to prevent the container from growing beyond available space
- Adds `overflow: hidden` to each cell so content clips instead of pushing cell height
- Reduces `MAX_VISIBLE` from 3 → 2 events per cell; busy days show `+N more`
- Adds `title` attribute on event buttons for native browser tooltip showing full event name on hover

## Test plan
- [ ] Month view shows the full month grid without vertical scrolling
- [ ] All 5–6 week rows are equal height and fit within the viewport
- [ ] Event pills truncate with ellipsis; hovering shows full name in tooltip
- [ ] Days with >2 events show `+N more` indicator
- [ ] Clicking `+N more` day slot (or any event) opens the event detail as before
- [ ] Today's date circle, weekend shading, and off-month opacity all intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)