### PR TITLE
fix: RSS-based dev server watchdog catches Turbopack memory leaks

### DIFF
--- a/scripts/dev-watchdog.mjs
+++ b/scripts/dev-watchdog.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// Spawns `next dev` and monitors its RSS. When resident memory crosses
+// MAX_RSS_MB it sends SIGTERM (escalating to SIGKILL after 5s grace).
+// Bundler is selected by passing --turbopack or --webpack through to next.
+
+import { spawn, execFileSync } from "node:child_process";
+
+const MAX_RSS_MB = Number(process.env.DEV_MAX_RSS_MB ?? 6144);
+const POLL_MS = Number(process.env.DEV_POLL_MS ?? 5000);
+const WARN_RSS_MB = Math.floor(MAX_RSS_MB * 0.75);
+
+const passthrough = process.argv.slice(2);
+const bundlerFlag = passthrough.includes("--webpack")
+  ? "--webpack"
+  : "--turbopack";
+const nextArgs = ["dev", bundlerFlag, ...passthrough.filter((a) => a !== "--webpack" && a !== "--turbopack")];
+
+const child = spawn("next", nextArgs, {
+  stdio: "inherit",
+  env: process.env,
+});
+
+console.error(
+  `[watchdog] next dev (${bundlerFlag}) pid=${child.pid} cap=${MAX_RSS_MB}MB poll=${POLL_MS}ms`,
+);
+
+let warned = false;
+let killing = false;
+
+function rssMb(pid) {
+  try {
+    const out = execFileSync("ps", ["-o", "rss=", "-p", String(pid)], {
+      encoding: "utf8",
+    }).trim();
+    if (!out) return 0;
+    return Math.round(Number(out) / 1024);
+  } catch {
+    return 0;
+  }
+}
+
+function killTree(signal) {
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {}
+  }
+}
+
+const timer = setInterval(() => {
+  if (killing || child.exitCode !== null) return;
+  const rss = rssMb(child.pid);
+  if (!rss) return;
+
+  if (rss >= MAX_RSS_MB) {
+    killing = true;
+    console.error(
+      `\n[watchdog] RSS ${rss}MB ≥ cap ${MAX_RSS_MB}MB — terminating dev server`,
+    );
+    killTree("SIGTERM");
+    setTimeout(() => {
+      if (child.exitCode === null) {
+        console.error("[watchdog] grace expired — SIGKILL");
+        killTree("SIGKILL");
+      }
+    }, 5000);
+  } else if (!warned && rss >= WARN_RSS_MB) {
+    warned = true;
+    console.error(
+      `[watchdog] RSS ${rss}MB ≥ ${WARN_RSS_MB}MB (75% of cap) — restart soon`,
+    );
+  }
+}, POLL_MS);
+
+child.on("exit", (code, signal) => {
+  clearInterval(timer);
+  if (signal) console.error(`[watchdog] dev server exited via ${signal}`);
+  process.exit(code ?? (signal ? 1 : 0));
+});
+
+for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+  process.on(sig, () => {
+    if (!killing) {
+      killing = true;
+      killTree(sig);
+    }
+  });
+}

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "NODE_OPTIONS='--max-old-space-size=3072' next dev --turbopack",
+    "dev": "NODE_OPTIONS='--max-old-space-size=4096' node ../scripts/dev-watchdog.mjs --turbopack",
+    "dev:webpack": "NODE_OPTIONS='--max-old-space-size=4096' node ../scripts/dev-watchdog.mjs --webpack",
+    "dev:raw": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary

- New [scripts/dev-watchdog.mjs](scripts/dev-watchdog.mjs) spawns `next dev`, polls process RSS via `ps -o rss=` every 5 s, warns at 75% of cap, sends SIGTERM at 100% (escalates to SIGKILL after 5 s grace).
- [web/package.json](web/package.json) wires `dev` (Turbopack, default) and `dev:webpack` through the watchdog with a 6 GB cap (`DEV_MAX_RSS_MB=6144`); `dev:raw` stays as an unmonitored escape hatch.
- Heap cap raised 3072 → 4096 MB to give Turbopack headroom inside the new RSS ceiling.

## Why this is needed

Turbopack allocates outside the V8 heap (Rust), so `NODE_OPTIONS=--max-old-space-size` does **not** bound it. The dev process can balloon to many GB and swap macOS to a hard hang — requiring a hard reboot. PR #563 only kills lingering processes at session Stop, which doesn't help while you're actively coding.

The watchdog measures *process RSS* (V8 + Rust + native), so it catches the actual leak.

## Test plan

- [x] `npm run dev` starts Next 16 on `:3000`, watchdog logs config line: `[watchdog] next dev (--turbopack) pid=N cap=6144MB poll=5000ms`
- [x] With artificial low cap (`DEV_MAX_RSS_MB=50`): watchdog logs `RSS XMB ≥ cap 50MB — terminating dev server`, child exits cleanly, npm process exits
- [x] SIGINT (`Ctrl+C`) on the parent propagates and shuts both processes down without orphans
- [ ] `npm run dev:webpack` works as A/B comparison
- [ ] `npm run dev:raw` still works for emergency unmonitored runs
- [x] `cd web && npx tsc --noEmit` clean

## Tuning

```bash
npm run dev                          # Turbopack, 6 GB cap (default)
npm run dev:webpack                  # webpack, 6 GB cap
DEV_MAX_RSS_MB=4096 npm run dev      # tighter cap if 6 GB still hangs the Mac
DEV_POLL_MS=2000 npm run dev         # faster polling
npm run dev:raw                      # no watchdog, no cap
```

## Workflow change

Updated `~/.claude/projects/.../memory/feedback_github_issue_workflow.md` Step 3 of the close sequence to mandate `npm run dev` (which wraps the watchdog) for issue smoke tests, and forbid `dev:raw` / direct `next dev`. Future sessions doing issue work that requires a dev server will use the watchdog by default.

## Post-deploy steps

None — local dev only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)