### PR TITLE
fix: calibrate progression heuristics to lbs and add graduated plateau response (#278)

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
 # Graph Report - /Users/jason/Code Projects/mr-bridge-assistant  (2026-04-30)
 
 ## Corpus Check
-- 266 files · ~654,431 words
+- 266 files · ~654,497 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
@@ -968,11 +968,11 @@ Nodes (0):
 _Questions this graph is uniquely positioned to answer:_
 
 - **Why does `createClient()` connect `Community 0` to `Community 2`, `Community 36`, `Community 5`, `Community 11`, `Community 44`, `Community 25`?**
-  _High betweenness centrality (0.047) - this node is a cross-community bridge._
+  _High betweenness centrality (0.037) - this node is a cross-community bridge._
 - **Why does `getUser()` connect `Community 0` to `Community 2`, `Community 11`, `Community 5`?**
-  _High betweenness centrality (0.031) - this node is a cross-community bridge._
+  _High betweenness centrality (0.025) - this node is a cross-community bridge._
 - **Why does `POST@chat/route.ts` connect `Community 5` to `Community 0`, `Community 2`, `Community 7`?**
-  _High betweenness centrality (0.029) - this node is a cross-community bridge._
+  _High betweenness centrality (0.025) - this node is a cross-community bridge._
 - **Are the 101 inferred relationships involving `createClient()` (e.g. with `createSmokeAdminClient()` and `AdminLayout()`) actually correct?**
   _`createClient()` has 101 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 80 inferred relationships involving `getUser()` (e.g. with `proxy()` and `GET@callback/route.ts`) actually correct?**

--- a/web/src/app/api/cron/weekly-plan/route.ts
+++ b/web/src/app/api/cron/weekly-plan/route.ts
@@ -232,10 +232,10 @@ When an exercise has been performed at the user's equipment cap at avg RPE ≤ 8
 Always surface the rationale: "Held 25 lb Goblet Squat at RPE 6 for 3 sessions — converting to Bulgarian Split Squat (same DB, ~2× effective stimulus)."
 
 PROGRESSION RULES (use LAST WEEK'S EXERCISE PERFORMANCE data):
-- If last 2 sessions hit top-of-range reps at prescribed weight → suggest +2.5 kg upper-body / +5 kg lower-body, subject to equipment cap
+- If last 2 sessions hit top-of-range reps at prescribed weight → suggest +5 lb upper-body compound / +10 lb lower-body compound / +2.5–5 lb isolation (lateral raises, curls, flies), subject to equipment cap
 - If RPE ≥ 9 on working sets for 2+ sessions → hold weight
 - If target reps missed 2 sessions in a row → 10% deload
-- If no progression across 4+ sessions → variation swap
+- If no progression across 4+ sessions → first adjust rep scheme (e.g. 3×10 → 4×8) or add tempo/pause; only swap variation if still flat after that
 - Never count cancelled sessions in progression analysis
 - Surface the evidence in notes for every progression decision
 

--- a/web/src/lib/chat/system-prompt.ts
+++ b/web/src/lib/chat/system-prompt.ts
@@ -62,10 +62,10 @@ Equipment rules (apply whenever proposing workout weights):
 4. If the user asks for a weight beyond their current inventory, tell them and offer alternatives (lower weight + higher reps, substitute exercise) rather than writing an unachievable plan.
 
 Progression heuristics (apply when the user asks for planning/adjustment — always call get_workout_history first):
-1. If the last 2 sessions for an exercise hit top-of-range reps at the prescribed weight, suggest +2.5 kg upper-body / +5 kg lower-body for the next session.
+1. If the last 2 sessions for an exercise hit top-of-range reps at the prescribed weight, suggest +5 lb upper-body compound / +10 lb lower-body compound / +2.5–5 lb isolation (lateral raises, curls, flies — use the smaller jump), subject to equipment cap.
 2. If RPE ≥ 9 on working sets for 2+ consecutive sessions, hold the weight (do not add).
 3. If the user missed target reps 2 sessions in a row for the same exercise, suggest a 10% deload.
-4. If an exercise hasn't progressed (top weight × reps flat or lower) across 4+ sessions, suggest a variation swap.
+4. If an exercise hasn't progressed (top weight × reps flat or lower) across 4+ sessions: first try adjusting the rep scheme (e.g. 3×10 → 4×8 at the same weight) or adding tempo/pause; only suggest a variation swap if still flat after that adjustment.
 Always surface the evidence ("last 3 bench sessions: 135×8, 135×8, 135×9 — hit top of range twice, ready to go to 137.5") before making the recommendation. The user may override any suggestion.
 Only include sessions with status 'planned' or 'completed' in progression analysis — never count cancelled or skipped sessions.
 


### PR DESCRIPTION
## Summary

- Weight increment units fixed from kg to lbs — dumbbell sets go in 5 lb increments, so +2.5 kg was never a valid weight. Now: +5 lb upper compound / +10 lb lower compound / +2.5–5 lb isolation
- Isolation exercises (lateral raises, curls, flies) now get a smaller jump than compounds
- Rule 4 (flat for 4+ sessions) no longer jumps straight to a variation swap — tries rep scheme adjustment (e.g. 3×10 → 4×8) and tempo/pause first, only swaps variation if still flat after that
- Updated in both `web/src/lib/chat/system-prompt.ts` (real-time chat) and `web/src/app/api/cron/weekly-plan/route.ts` (Sunday weekly planner)
- Rules 2 and 3 unchanged — RPE ≥ 9 hold and 10% deload are correctly calibrated

Closes #278

## Test plan
- [ ] Chat: ask Bridge to review progression for an exercise — confirm it suggests lbs not kg
- [ ] Chat: verify isolation exercise gets +2.5–5 lb suggestion, not +5 lb
- [ ] Chat: confirm flat-exercise response tries rep scheme change before suggesting a swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)