### PR TITLE
fix: add archive.org and googleapis to CSP img-src for book covers

### DIFF
--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -25,7 +25,7 @@ function buildCSP(nonce: string): string {
     // (Radix UI portals set inline positioning styles that cannot carry a nonce).
     styleSrcElem,
     "style-src-attr 'unsafe-inline'",
-    "img-src 'self' data: https://a.espncdn.com https://*.supabase.co https://image.tmdb.org https://images.igdb.com https://covers.openlibrary.org https://books.google.com",
+    "img-src 'self' data: https://a.espncdn.com https://*.supabase.co https://image.tmdb.org https://images.igdb.com https://covers.openlibrary.org https://*.archive.org https://books.google.com https://*.googleapis.com",
     "font-src 'self' data:",
     "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
     "frame-ancestors 'none'",


### PR DESCRIPTION
## Problem

Book cover images from OpenLibrary were not loading in the search modal. OpenLibrary cover URLs (`covers.openlibrary.org`) redirect through `ia*.archive.org` CDN subdomains, which were not in the `img-src` CSP directive. Google Books thumbnails can also come from `*.googleapis.com`.

## Fix

Added `https://*.archive.org` and `https://*.googleapis.com` to `img-src` in `proxy.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)