### PR TITLE
fix: add archive.org root domain to CSP for book covers

### DIFF
--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -25,7 +25,7 @@ function buildCSP(nonce: string): string {
     // (Radix UI portals set inline positioning styles that cannot carry a nonce).
     styleSrcElem,
     "style-src-attr 'unsafe-inline'",
-    "img-src 'self' data: https://a.espncdn.com https://*.supabase.co https://image.tmdb.org https://images.igdb.com https://covers.openlibrary.org https://*.archive.org https://books.google.com https://*.googleapis.com",
+    "img-src 'self' data: https://a.espncdn.com https://*.supabase.co https://image.tmdb.org https://images.igdb.com https://covers.openlibrary.org https://archive.org https://*.archive.org https://books.google.com https://*.googleapis.com https://books.googleusercontent.com",
     "font-src 'self' data:",
     "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
     "frame-ancestors 'none'",


### PR DESCRIPTION
## Summary

- Adds `https://archive.org` to `img-src` CSP directive in `proxy.ts`
- OpenLibrary cover URLs (`covers.openlibrary.org/b/id/...`) redirect to `https://archive.org/download/...` — the root domain, not a subdomain
- `https://*.archive.org` only matches one subdomain level (e.g. `foo.archive.org`), so the root domain must be listed explicitly
- Also adds `https://books.googleusercontent.com` for Google Books fallback covers

## Test plan

- [ ] Open Library → Books tab → search "Hunger Games" → all cover images load
- [ ] Verify no CSP errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)