### PR TITLE
fix: new library items visible immediately on return without refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+- **Library: new items now appear immediately when navigating back from the detail page.** Added `router.refresh()` after import so the Next.js router cache for `/library` is invalidated before the push, preventing the stale cached page from being served on return.
+
 ### Changed
 - **Library: Add button shows a type picker (Game / Show / Movie / Book) when on the All tab**, preventing ambiguous imports where a title matches across multiple media types. Tabs other than All bypass the picker and go directly to search for that type.
 - **Library: Queued items now appear in the Completion progress bar and legend** as a distinct segment (muted slate), giving a full-picture breakdown of total items by lifecycle state.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
 # Graph Report - /Users/jason/Code Projects/mr-bridge-assistant  (2026-04-30)
 
 ## Corpus Check
-- 285 files · ~671,841 words
+- 285 files · ~672,784 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
@@ -992,11 +992,11 @@ Nodes (0):
 _Questions this graph is uniquely positioned to answer:_
 
 - **Why does `createClient()` connect `Community 0` to `Community 3`, `Community 4`, `Community 38`, `Community 7`, `Community 46`, `Community 18`, `Community 26`?**
-  _High betweenness centrality (0.035) - this node is a cross-community bridge._
-- **Why does `getUser()` connect `Community 0` to `Community 18`, `Community 3`, `Community 4`, `Community 7`?**
-  _High betweenness centrality (0.025) - this node is a cross-community bridge._
+  _High betweenness centrality (0.047) - this node is a cross-community bridge._
 - **Why does `POST@chat/route.ts` connect `Community 4` to `Community 0`, `Community 10`, `Community 3`?**
-  _High betweenness centrality (0.023) - this node is a cross-community bridge._
+  _High betweenness centrality (0.039) - this node is a cross-community bridge._
+- **Why does `getUser()` connect `Community 0` to `Community 18`, `Community 3`, `Community 4`, `Community 7`?**
+  _High betweenness centrality (0.038) - this node is a cross-community bridge._
 - **Are the 113 inferred relationships involving `createClient()` (e.g. with `createSmokeAdminClient()` and `AdminLayout()`) actually correct?**
   _`createClient()` has 113 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 92 inferred relationships involving `getUser()` (e.g. with `proxy()` and `GET@callback/route.ts`) actually correct?**

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -13087,8 +13087,8 @@
       "source_file": "/Users/jason/Code Projects/mr-bridge-assistant/web/src/app/api/google/calendar/events/[eventId]/route.ts",
       "source_location": "L80",
       "weight": 1.0,
-      "_src": "users_jason_code_projects_mr_bridge_assistant_web_src_app_api_google_calendar_events_eventid_route_ts_patch",
-      "_tgt": "librarydetailclient_patch",
+      "_src": "librarydetailclient_patch",
+      "_tgt": "users_jason_code_projects_mr_bridge_assistant_web_src_app_api_google_calendar_events_eventid_route_ts_patch",
       "source": "librarydetailclient_patch",
       "target": "users_jason_code_projects_mr_bridge_assistant_web_src_app_api_google_calendar_events_eventid_route_ts_patch"
     },
@@ -13099,8 +13099,8 @@
       "source_file": "/Users/jason/Code Projects/mr-bridge-assistant/web/src/lib/fitness/reschedule-workout.ts",
       "source_location": "L135",
       "weight": 1.0,
-      "_src": "reschedule_workout_rescheduleworkout",
-      "_tgt": "librarydetailclient_patch",
+      "_src": "librarydetailclient_patch",
+      "_tgt": "reschedule_workout_rescheduleworkout",
       "source": "librarydetailclient_patch",
       "target": "reschedule_workout_rescheduleworkout"
     },

--- a/web/src/app/(protected)/library/LibraryClient.tsx
+++ b/web/src/app/(protected)/library/LibraryClient.tsx
@@ -923,6 +923,7 @@ export default function LibraryClient({ initialItems }: { initialItems: BacklogI
     if (res.ok) {
       const newItem = await res.json();
       setItems((prev) => [...prev, newItem as BacklogItem]);
+      router.refresh();
       router.push(`/library/${(newItem as BacklogItem).id}`);
     }
   };


### PR DESCRIPTION
## Summary
- After adding an item, `router.refresh()` is called before `router.push()` to the detail page
- This invalidates the Next.js client-side router cache for `/library`, so navigating back serves a fresh SSR response that includes the new item
- Without this, Next.js served the cached (pre-add) page segment and the item only appeared after a manual reload

## Test plan
- [ ] Add a new item from the Library page — you are redirected to the detail page
- [ ] Navigate back to Library (back button or nav link) — new item appears in the list without a manual refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)