### PR TITLE
fix: flatten library list view — remove collapsible sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+- **Library: list view is now flat — no collapsible sections.** Items render in status order (Active → Queued → Paused → Finished → Dropped) as a continuous list; the status badge on each row already identifies the group. Section headers and expand/collapse toggles removed entirely.
+
 ### Added
 - **Library: cover grid view.** A list/grid toggle (List · LayoutGrid icons) in the header switches between the existing list view and a cover art grid. Grid renders all filtered items as 2:3 aspect-ratio cards with a hover lift, gradient title overlay, status dot, and optional media-type badge on the All tab. Drag-to-reorder and status grouping remain list-only; the grid shows all filtered items flat.
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
-# Graph Report - /Users/jason/Code Projects/mr-bridge-assistant  (2026-04-30)
+# Graph Report - /Users/jason/Code Projects/mr-bridge-assistant  (2026-05-01)
 
 ## Corpus Check
-- 285 files · ~673,312 words
+- 285 files · ~673,167 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
@@ -992,11 +992,11 @@ Nodes (0):
 _Questions this graph is uniquely positioned to answer:_
 
 - **Why does `createClient()` connect `Community 0` to `Community 3`, `Community 4`, `Community 38`, `Community 7`, `Community 46`, `Community 18`, `Community 26`?**
-  _High betweenness centrality (0.049) - this node is a cross-community bridge._
+  _High betweenness centrality (0.043) - this node is a cross-community bridge._
 - **Why does `getUser()` connect `Community 0` to `Community 18`, `Community 3`, `Community 4`, `Community 7`?**
-  _High betweenness centrality (0.039) - this node is a cross-community bridge._
-- **Why does `POST@chat/route.ts` connect `Community 4` to `Community 0`, `Community 10`, `Community 3`?**
   _High betweenness centrality (0.028) - this node is a cross-community bridge._
+- **Why does `POST@chat/route.ts` connect `Community 4` to `Community 0`, `Community 10`, `Community 3`?**
+  _High betweenness centrality (0.027) - this node is a cross-community bridge._
 - **Are the 113 inferred relationships involving `createClient()` (e.g. with `createSmokeAdminClient()` and `AdminLayout()`) actually correct?**
   _`createClient()` has 113 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 92 inferred relationships involving `getUser()` (e.g. with `proxy()` and `GET@callback/route.ts`) actually correct?**

--- a/web/src/app/(protected)/library/LibraryClient.tsx
+++ b/web/src/app/(protected)/library/LibraryClient.tsx
@@ -3,16 +3,7 @@
 import { useState, useRef, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import {
-  Search,
-  Plus,
-  X,
-  GripVertical,
-  ChevronDown,
-  ChevronRight,
-  LayoutGrid,
-  List,
-} from "lucide-react";
+import { Search, Plus, X, GripVertical, LayoutGrid, List } from "lucide-react";
 import type { BacklogItem, MediaType, MetadataSearchResult } from "@/lib/types";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -774,60 +765,6 @@ function ItemRow({
   );
 }
 
-// ── Collapsible section ───────────────────────────────────────────────────────
-
-function CollapsibleSection({
-  title,
-  count,
-  defaultOpen,
-  children,
-}: {
-  title: string;
-  count: number;
-  defaultOpen: boolean;
-  children: React.ReactNode;
-}) {
-  const [open, setOpen] = useState(defaultOpen);
-  if (count === 0) return null;
-  return (
-    <div>
-      <button
-        onClick={() => setOpen((o) => !o)}
-        style={{
-          background: "none",
-          border: "none",
-          cursor: "pointer",
-          display: "flex",
-          alignItems: "center",
-          gap: 6,
-          padding: "8px 0",
-          width: "100%",
-          color: "var(--color-text-muted)",
-          fontSize: 12,
-          fontWeight: 600,
-          textTransform: "uppercase",
-          letterSpacing: "0.06em",
-        }}
-      >
-        {open ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
-        {title}
-        <span
-          style={{
-            marginLeft: "auto",
-            fontWeight: 400,
-            textTransform: "none",
-            letterSpacing: 0,
-            fontSize: 12,
-          }}
-        >
-          {count}
-        </span>
-      </button>
-      {open && <div>{children}</div>}
-    </div>
-  );
-}
-
 // ── Cover grid ────────────────────────────────────────────────────────────────
 
 function CoverCard({ item, showType }: { item: BacklogItem; showType?: boolean }) {
@@ -1524,93 +1461,29 @@ export default function LibraryClient({ initialItems }: { initialItems: BacklogI
             <CoverGrid items={filteredItems} showType={showType} />
           ) : (
             <>
-              {activeItems.length > 0 && (
-                <div style={{ marginBottom: 8 }}>
-                  <p
-                    style={{
-                      fontSize: 11,
-                      fontWeight: 600,
-                      textTransform: "uppercase",
-                      letterSpacing: "0.06em",
-                      color: "var(--color-text-muted)",
-                      margin: "0 0 4px",
-                    }}
-                  >
-                    Active — {activeItems.length}
-                  </p>
-                  {activeItems.map((item) => (
-                    <ItemRow
-                      key={item.id}
-                      item={item}
-                      showType={showType}
-                      draggable={canDrag}
-                      onDragStart={handleDragStart}
-                      onDragOver={handleDragOver}
-                      onDrop={handleDrop}
-                    />
-                  ))}
-                </div>
-              )}
+              {activeItems.map((item) => (
+                <ItemRow
+                  key={item.id}
+                  item={item}
+                  showType={showType}
+                  draggable={canDrag}
+                  onDragStart={handleDragStart}
+                  onDragOver={handleDragOver}
+                  onDrop={handleDrop}
+                />
+              ))}
 
-              <CollapsibleSection
-                title="Queued"
-                count={queuedItems.length}
-                defaultOpen={activeItems.length === 0}
-              >
-                {queuedItems.map((item) => (
-                  <ItemRow
-                    key={item.id}
-                    item={item}
-                    showType={showType}
-                    draggable={canDrag}
-                    onDragStart={handleDragStart}
-                    onDragOver={handleDragOver}
-                    onDrop={handleDrop}
-                  />
-                ))}
-              </CollapsibleSection>
-
-              <CollapsibleSection title="Paused" count={pausedItems.length} defaultOpen={false}>
-                {pausedItems.map((item) => (
-                  <ItemRow
-                    key={item.id}
-                    item={item}
-                    showType={showType}
-                    draggable={canDrag}
-                    onDragStart={handleDragStart}
-                    onDragOver={handleDragOver}
-                    onDrop={handleDrop}
-                  />
-                ))}
-              </CollapsibleSection>
-
-              <CollapsibleSection title="Finished" count={finishedItems.length} defaultOpen={false}>
-                {finishedItems.map((item) => (
-                  <ItemRow
-                    key={item.id}
-                    item={item}
-                    showType={showType}
-                    draggable={false}
-                    onDragStart={handleDragStart}
-                    onDragOver={handleDragOver}
-                    onDrop={handleDrop}
-                  />
-                ))}
-              </CollapsibleSection>
-
-              <CollapsibleSection title="Dropped" count={droppedItems.length} defaultOpen={false}>
-                {droppedItems.map((item) => (
-                  <ItemRow
-                    key={item.id}
-                    item={item}
-                    showType={showType}
-                    draggable={false}
-                    onDragStart={handleDragStart}
-                    onDragOver={handleDragOver}
-                    onDrop={handleDrop}
-                  />
-                ))}
-              </CollapsibleSection>
+              {[...queuedItems, ...pausedItems, ...finishedItems, ...droppedItems].map((item) => (
+                <ItemRow
+                  key={item.id}
+                  item={item}
+                  showType={showType}
+                  draggable={canDrag && (item.status === "backlog" || item.status === "paused")}
+                  onDragStart={handleDragStart}
+                  onDragOver={handleDragOver}
+                  onDrop={handleDrop}
+                />
+              ))}
             </>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Removed all collapsible section toggles (Queued ›, Finished ›, etc.) from the list view
- Items now render as a continuous flat list in status order: Active → Queued → Paused → Finished → Dropped
- The status badge on each row already communicates the group — no section headers needed
- Grid view unaffected

## Test plan
- [ ] All items visible immediately in list view — no expand/collapse needed
- [ ] Status order is correct: active items first, then queued, paused, finished, dropped
- [ ] Status badge on each row correctly identifies its state
- [ ] Grid view unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)