### PR TITLE
fix: week_start override for weekly planning cron catch-up runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Added
+- **Weekly planning cron: `week_start` override param.** Both `/api/cron/weekly-plan` and `/api/internal/plan` now accept a `week_start=YYYY-MM-DD` parameter, enabling catch-up runs when the Sunday cron is missed. The cron route forwards it to the internal plan endpoint for both context fetch and write.
 - **Library/Backlog: console/platform and price paid fields in pre-add form.** When adding a game, the step-2 modal now includes "Console / Platform" (maps to `metadata.played_on`) and "Price Paid" fields. Books show "Price Paid" only. Both fields are optional and merged into the item's metadata on save.
 
 ### Changed

--- a/web/src/app/api/cron/weekly-plan/route.ts
+++ b/web/src/app/api/cron/weekly-plan/route.ts
@@ -437,10 +437,11 @@ export async function GET(req: Request) {
 
   // 6. Push notification
   const workoutCount = (plan.workout_days ?? []).filter((d) => d.date).length;
-  const weekStart = plan.meal_prep_task?.metadata?.week_start ?? plan.workout_days?.[0]?.date ?? "";
+  const notifyWeekStart =
+    weekStart ?? plan.meal_prep_task?.metadata?.week_start ?? plan.workout_days?.[0]?.date ?? "";
   await sendNtfy(
     "Weekly Plan Ready",
-    `${workoutCount} workout${workoutCount !== 1 ? "s" : ""} + meal prep scheduled for week of ${weekStart}.`,
+    `${workoutCount} workout${workoutCount !== 1 ? "s" : ""} + meal prep scheduled for week of ${notifyWeekStart}.`,
   );
 
   return NextResponse.json({

--- a/web/src/app/api/cron/weekly-plan/route.ts
+++ b/web/src/app/api/cron/weekly-plan/route.ts
@@ -267,6 +267,8 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const weekStart = new URL(req.url).searchParams.get("week_start") ?? undefined;
+
   const uid = process.env.OWNER_USER_ID;
   if (!uid) return NextResponse.json({ error: "OWNER_USER_ID not configured" }, { status: 500 });
 
@@ -306,7 +308,9 @@ export async function GET(req: Request) {
   ].filter((s): s is string => s !== null);
 
   // 1. Fetch prior-week planning context from internal endpoint
-  const contextRes = await fetch(`${APP_URL}/api/internal/plan`, {
+  const internalUrl = new URL(`${APP_URL}/api/internal/plan`);
+  if (weekStart) internalUrl.searchParams.set("week_start", weekStart);
+  const contextRes = await fetch(internalUrl.toString(), {
     headers: { Authorization: `Bearer ${CRON_SECRET}` },
   });
   if (!contextRes.ok) {
@@ -357,7 +361,7 @@ export async function GET(req: Request) {
       "Content-Type": "application/json",
       Authorization: `Bearer ${CRON_SECRET}`,
     },
-    body: JSON.stringify(plan),
+    body: JSON.stringify(weekStart ? { ...plan, week_start: weekStart } : plan),
   });
   const writeBody = (await writeRes.json()) as {
     ok?: boolean;

--- a/web/src/app/api/internal/plan/route.ts
+++ b/web/src/app/api/internal/plan/route.ts
@@ -33,7 +33,11 @@ function checkAuth(request: NextRequest): boolean {
   return !!(process.env.CRON_SECRET && auth === `Bearer ${process.env.CRON_SECRET}`);
 }
 
-function getComingMonday(): Date {
+function getComingMonday(weekStart?: string): Date {
+  if (weekStart) {
+    const [y, m, d] = weekStart.split("-").map(Number);
+    return new Date(y, m - 1, d);
+  }
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const pyDow = (today.getDay() + 6) % 7; // 0=Mon … 6=Sun
@@ -70,7 +74,8 @@ export async function GET(request: NextRequest) {
   if (!uid) return NextResponse.json({ error: "OWNER_USER_ID not configured" }, { status: 500 });
 
   const db = createServiceClient();
-  const nextMonday = getComingMonday();
+  const weekStartParam = request.nextUrl.searchParams.get("week_start") ?? undefined;
+  const nextMonday = getComingMonday(weekStartParam);
   const priorMonday = addDays(nextMonday, -7);
   const priorSunday = addDays(nextMonday, -1);
   const nextSunday = addDays(nextMonday, 6);
@@ -423,14 +428,14 @@ export async function POST(request: NextRequest) {
   const uid = process.env.OWNER_USER_ID;
   if (!uid) return NextResponse.json({ error: "OWNER_USER_ID not configured" }, { status: 500 });
 
-  let body: { workout_days?: WorkoutDay[]; meal_prep_task?: MealPrepTask };
+  let body: { workout_days?: WorkoutDay[]; meal_prep_task?: MealPrepTask; week_start?: string };
   try {
     body = await request.json();
   } catch {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  const { workout_days = [], meal_prep_task } = body;
+  const { workout_days = [], meal_prep_task, week_start } = body;
   if (!workout_days.length && !meal_prep_task) {
     return NextResponse.json(
       { error: "payload has neither workout_days nor meal_prep_task" },
@@ -439,7 +444,7 @@ export async function POST(request: NextRequest) {
   }
 
   const db = createServiceClient();
-  const nextMonday = getComingMonday();
+  const nextMonday = getComingMonday(week_start);
   const nextMondayStr = toDateStr(nextMonday);
   const nextSundayStr = toDateStr(addDays(nextMonday, 6));
 


### PR DESCRIPTION
## Summary
- Adds `?week_start=YYYY-MM-DD` to `/api/cron/weekly-plan` (GET) so missed Sunday cron runs can be retriggered for the correct week
- Passes `week_start` through to `/api/internal/plan` GET (context fetch) and POST (write) so the date window is correct end-to-end
- Without this, running the cron on any day other than Sunday computes the wrong target Monday

## Why this was needed
The Sunday May 3 cron missed. Running it today (Monday May 4) would have planned for May 11 instead of May 4 due to `getComingMonday()` always advancing to the next Monday from `new Date()`.

## Usage after merge
```
curl -H "Authorization: Bearer $CRON_SECRET" \
  "https://mr-bridge-assistant.vercel.app/api/cron/weekly-plan?week_start=2026-05-04"
```

## Test plan
- [ ] Trigger endpoint with `?week_start=2026-05-04` after deploy — confirm `workout_plans` rows for May 4–10 are written
- [ ] Confirm normal Sunday run (no param) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)