### PR TITLE
fix(google-health): live-verification fixes — civil time, int64 strings, proxy redirect

### DIFF
--- a/scripts/sync-google-health.py
+++ b/scripts/sync-google-health.py
@@ -220,9 +220,10 @@ def fetch_body(access_token: str, start_str: str, end_excl: str) -> list[dict]:
     # Height changes rarely and is only needed for BMI — take the latest on file.
     heights = list_data_points(access_token, "height", None, 1)
 
+    # heightMillimeters is int64 — proto-JSON serialises it as a STRING, not a number.
     height_mm = ((heights[0].get("height") or {}).get("heightMillimeters")
                  if heights else None)
-    height_m = height_mm / 1000 if height_mm else None
+    height_m = float(height_mm) / 1000 if height_mm else None
 
     by_date: dict[str, dict] = {}
     for p in weights:

--- a/scripts/sync-google-health.py
+++ b/scripts/sync-google-health.py
@@ -37,7 +37,7 @@ ROOT = Path(__file__).parent.parent
 load_dotenv(ROOT / ".env")
 sys.path.insert(0, str(Path(__file__).parent))
 from _supabase import get_client, get_owner_user_id, upsert
-from _sync_log import log_sync, urlopen_with_retry, HTTP_TIMEOUT
+from _sync_log import log_sync, urlopen_with_retry
 from _integrations import load_integration
 
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
@@ -93,8 +93,7 @@ def get_access_token(client, user_id: str) -> str:
         data=body,
         headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
-    with urlopen_with_retry(req, timeout=HTTP_TIMEOUT) as resp:
-        return json.loads(resp.read())["access_token"]
+    return urlopen_with_retry(req)["access_token"]
 
 
 # ---------------------------------------------------------------------------
@@ -116,8 +115,7 @@ def list_data_points(access_token: str, data_type: str, filter_expr: str | None 
 
         url = f"{HEALTH_API_BASE}/users/me/dataTypes/{data_type}/dataPoints?{urllib.parse.urlencode(params)}"
         req = urllib.request.Request(url, headers={"Authorization": f"Bearer {access_token}"})
-        with urlopen_with_retry(req, timeout=HTTP_TIMEOUT) as resp:
-            data = json.loads(resp.read())
+        data = urlopen_with_retry(req)
 
         points.extend(data.get("dataPoints") or [])
         page_token = data.get("nextPageToken")
@@ -139,18 +137,31 @@ def civil_range_filter(field: str, start_str: str, end_str: str) -> str:
 # equivalent of Fitbit's local timestamps. No offset arithmetic needed.
 # ---------------------------------------------------------------------------
 
-def civil_date(civil: dict | None) -> str | None:
-    d = (civil or {}).get("date") or {}
-    if not all(d.get(k) for k in ("year", "month", "day")):
+def local_datetime(utc_time: str | None, utc_offset: str | None) -> datetime | None:
+    """The user's wall-clock time for an observation.
+
+    The API accepts `civil_*` fields in a FILTER but does not return them in the
+    response — an interval carries only `startTime` (UTC) and `startUtcOffset`
+    (a google-duration like "-25200s"). Verified against live data: startTime
+    2026-07-11T00:16:17Z with offset -25200s is a workout logged at 17:16 on 07-10.
+    Reading the documented `civilStartTime` instead yields None and silently drops
+    every row.
+    """
+    if not utc_time:
         return None
-    return f"{d['year']:04d}-{d['month']:02d}-{d['day']:02d}"
+    try:
+        dt = datetime.fromisoformat(utc_time.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return dt + timedelta(seconds=duration_secs(utc_offset))
 
 
-def civil_time(civil: dict | None) -> str | None:
-    t = (civil or {}).get("time")
-    if t is None:
-        return None
-    return f"{t.get('hours', 0):02d}:{t.get('minutes', 0):02d}:{t.get('seconds', 0):02d}"
+def local_date(dt: datetime | None) -> str | None:
+    return dt.strftime("%Y-%m-%d") if dt else None
+
+
+def local_time(dt: datetime | None) -> str | None:
+    return dt.strftime("%H:%M:%S") if dt else None
 
 
 def duration_secs(d: str | None) -> float:
@@ -216,13 +227,15 @@ def fetch_body(access_token: str, start_str: str, end_excl: str) -> list[dict]:
     by_date: dict[str, dict] = {}
     for p in weights:
         w = p.get("weight") or {}
-        date = civil_date((w.get("sampleTime") or {}).get("civilTime"))
+        st = w.get("sampleTime") or {}
+        date = local_date(local_datetime(st.get("physicalTime"), st.get("utcOffset")))
         grams = w.get("weightGrams")
         if date and grams is not None:
             by_date.setdefault(date, {})["weight_kg"] = grams / 1000
     for p in fats:
         f = p.get("bodyFat") or {}
-        date = civil_date((f.get("sampleTime") or {}).get("civilTime"))
+        st = f.get("sampleTime") or {}
+        date = local_date(local_datetime(st.get("physicalTime"), st.get("utcOffset")))
         pct = f.get("percentage")
         if date and pct is not None:
             by_date.setdefault(date, {})["fat_pct"] = pct
@@ -257,7 +270,8 @@ def fetch_workouts(access_token: str, start_str: str, end_excl: str) -> list[dic
         if not ex:
             continue
         interval = ex.get("interval") or {}
-        date = civil_date(interval.get("civilStartTime"))
+        start_local = local_datetime(interval.get("startTime"), interval.get("startUtcOffset"))
+        date = local_date(start_local)
         if not date:
             continue
 
@@ -266,7 +280,7 @@ def fetch_workouts(access_token: str, start_str: str, end_excl: str) -> list[dic
         if duration_min < 5:
             continue
 
-        start_time = civil_time(interval.get("civilStartTime"))
+        start_time = local_time(start_local)
         metrics = ex.get("metricsSummary") or {}
         avg_hr = metrics.get("averageHeartRateBeatsPerMinute")
         calories = metrics.get("caloriesKcal")

--- a/web/src/app/api/auth/google-health/callback/route.ts
+++ b/web/src/app/api/auth/google-health/callback/route.ts
@@ -7,6 +7,13 @@ import { storeIntegration } from "@/lib/integrations/tokens";
 
 const SETTINGS_URL = "/settings?connected=google_health";
 
+// Behind the Caddy reverse proxy, req.nextUrl.origin resolves to the container's bind
+// address (http://0.0.0.0:3000) rather than the public host, so redirecting to it lands
+// the browser on an unreachable URL. NEXT_PUBLIC_APP_URL is the app's own public origin.
+function appOrigin(req: NextRequest): string {
+  return process.env.NEXT_PUBLIC_APP_URL ?? req.nextUrl.origin;
+}
+
 export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl;
   const code = searchParams.get("code");
@@ -14,21 +21,17 @@ export async function GET(req: NextRequest) {
   const error = searchParams.get("error");
 
   if (error) {
-    return NextResponse.redirect(
-      new URL("/settings?error=google_health_denied", req.nextUrl.origin),
-    );
+    return NextResponse.redirect(new URL("/settings?error=google_health_denied", appOrigin(req)));
   }
   if (!code || !state) {
-    return NextResponse.redirect(
-      new URL("/settings?error=google_health_invalid", req.nextUrl.origin),
-    );
+    return NextResponse.redirect(new URL("/settings?error=google_health_invalid", appOrigin(req)));
   }
 
   // Validate CSRF state
   const cookieStore = await cookies();
   const csrf = cookieStore.get("google_health_oauth_csrf")?.value;
   if (!csrf || csrf !== state) {
-    return NextResponse.redirect(new URL("/settings?error=google_health_csrf", req.nextUrl.origin));
+    return NextResponse.redirect(new URL("/settings?error=google_health_csrf", appOrigin(req)));
   }
   cookieStore.delete("google_health_oauth_csrf");
 
@@ -38,7 +41,7 @@ export async function GET(req: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    return NextResponse.redirect(new URL("/login", req.nextUrl.origin));
+    return NextResponse.redirect(new URL("/login", appOrigin(req)));
   }
 
   const clientId = process.env.GOOGLE_CLIENT_ID!;
@@ -52,16 +55,14 @@ export async function GET(req: NextRequest) {
     const { tokens: exchanged } = await oauth2Client.getToken(code);
     tokens = exchanged;
   } catch {
-    return NextResponse.redirect(
-      new URL("/settings?error=google_health_exchange", req.nextUrl.origin),
-    );
+    return NextResponse.redirect(new URL("/settings?error=google_health_exchange", appOrigin(req)));
   }
 
   if (!tokens.refresh_token) {
     // Google only issues a refresh_token on first consent for a given scope set.
     // If it's missing, revoke the app's access and reconnect.
     return NextResponse.redirect(
-      new URL("/settings?error=google_health_no_refresh_token", req.nextUrl.origin),
+      new URL("/settings?error=google_health_no_refresh_token", appOrigin(req)),
     );
   }
 
@@ -75,10 +76,8 @@ export async function GET(req: NextRequest) {
       scopes: grantedScopes,
     });
   } catch {
-    return NextResponse.redirect(
-      new URL("/settings?error=google_health_store", req.nextUrl.origin),
-    );
+    return NextResponse.redirect(new URL("/settings?error=google_health_store", appOrigin(req)));
   }
 
-  return NextResponse.redirect(new URL(SETTINGS_URL, req.nextUrl.origin));
+  return NextResponse.redirect(new URL(SETTINGS_URL, appOrigin(req)));
 }

--- a/web/src/app/api/auth/google/callback/route.ts
+++ b/web/src/app/api/auth/google/callback/route.ts
@@ -7,6 +7,13 @@ import { storeIntegration } from "@/lib/integrations/tokens";
 
 const SETTINGS_URL = "/settings?connected=google";
 
+// Behind the Caddy reverse proxy, req.nextUrl.origin resolves to the container's bind
+// address (http://0.0.0.0:3000) rather than the public host, so redirecting to it lands
+// the browser on an unreachable URL. NEXT_PUBLIC_APP_URL is the app's own public origin.
+function appOrigin(req: NextRequest): string {
+  return process.env.NEXT_PUBLIC_APP_URL ?? req.nextUrl.origin;
+}
+
 export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl;
   const code = searchParams.get("code");
@@ -14,17 +21,17 @@ export async function GET(req: NextRequest) {
   const error = searchParams.get("error");
 
   if (error) {
-    return NextResponse.redirect(new URL("/settings?error=google_denied", req.nextUrl.origin));
+    return NextResponse.redirect(new URL("/settings?error=google_denied", appOrigin(req)));
   }
   if (!code || !state) {
-    return NextResponse.redirect(new URL("/settings?error=google_invalid", req.nextUrl.origin));
+    return NextResponse.redirect(new URL("/settings?error=google_invalid", appOrigin(req)));
   }
 
   // Validate CSRF state
   const cookieStore = await cookies();
   const csrf = cookieStore.get("google_oauth_csrf")?.value;
   if (!csrf || csrf !== state) {
-    return NextResponse.redirect(new URL("/settings?error=google_csrf", req.nextUrl.origin));
+    return NextResponse.redirect(new URL("/settings?error=google_csrf", appOrigin(req)));
   }
   cookieStore.delete("google_oauth_csrf");
 
@@ -34,7 +41,7 @@ export async function GET(req: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    return NextResponse.redirect(new URL("/login", req.nextUrl.origin));
+    return NextResponse.redirect(new URL("/login", appOrigin(req)));
   }
 
   const clientId = process.env.GOOGLE_CLIENT_ID!;
@@ -48,14 +55,14 @@ export async function GET(req: NextRequest) {
     const { tokens: exchanged } = await oauth2Client.getToken(code);
     tokens = exchanged;
   } catch {
-    return NextResponse.redirect(new URL("/settings?error=google_exchange", req.nextUrl.origin));
+    return NextResponse.redirect(new URL("/settings?error=google_exchange", appOrigin(req)));
   }
 
   if (!tokens.refresh_token) {
     // Google only issues a refresh_token on first consent. If it's missing,
     // the user likely connected before without revoking. Show a helpful error.
     return NextResponse.redirect(
-      new URL("/settings?error=google_no_refresh_token", req.nextUrl.origin),
+      new URL("/settings?error=google_no_refresh_token", appOrigin(req)),
     );
   }
 
@@ -69,8 +76,8 @@ export async function GET(req: NextRequest) {
       scopes: grantedScopes,
     });
   } catch {
-    return NextResponse.redirect(new URL("/settings?error=google_store", req.nextUrl.origin));
+    return NextResponse.redirect(new URL("/settings?error=google_store", appOrigin(req)));
   }
 
-  return NextResponse.redirect(new URL(SETTINGS_URL, req.nextUrl.origin));
+  return NextResponse.redirect(new URL(SETTINGS_URL, appOrigin(req)));
 }

--- a/web/src/lib/sync/google-health.ts
+++ b/web/src/lib/sync/google-health.ts
@@ -18,17 +18,19 @@ const BODY_SOURCES = ["google_health", "fitbit_body", "google_fit"];
 // Verified against the v4 discovery doc, rev 20260713.
 // ---------------------------------------------------------------------------
 
-interface CivilDateTime {
-  date?: { year?: number; month?: number; day?: number };
-  time?: { hours?: number; minutes?: number; seconds?: number };
+interface SampleTime {
+  physicalTime?: string;
+  utcOffset?: string;
 }
 
 interface DataPoint {
-  weight?: { sampleTime?: { civilTime?: CivilDateTime }; weightGrams?: number };
-  bodyFat?: { sampleTime?: { civilTime?: CivilDateTime }; percentage?: number };
-  height?: { heightMillimeters?: number };
+  // heightMillimeters and averageHeartRateBeatsPerMinute are int64 — proto-JSON
+  // serialises them as STRINGS, not numbers.
+  weight?: { sampleTime?: SampleTime; weightGrams?: number };
+  bodyFat?: { sampleTime?: SampleTime; percentage?: number };
+  height?: { heightMillimeters?: string };
   exercise?: {
-    interval?: { civilStartTime?: CivilDateTime };
+    interval?: { startTime?: string; startUtcOffset?: string };
     exerciseType?: string;
     displayName?: string;
     activeDuration?: string;
@@ -118,21 +120,29 @@ async function listDataPoints(
 }
 
 // ---------------------------------------------------------------------------
-// Civil time = the user's local wall-clock time, supplied by the API directly.
-// This is the equivalent of Fitbit's local timestamps; no offset math needed.
+// Local wall-clock time.
+//
+// The API accepts `civil_*` fields in a FILTER but does not return them in the
+// response — a data point carries only a UTC instant plus a google-duration offset
+// ("-25200s"). Verified against live data: startTime 2026-07-11T00:16:17Z with
+// startUtcOffset -25200s is a workout the user logged at 17:16 on 07-10. Reading the
+// documented civilStartTime instead yields undefined and silently drops every row.
 // ---------------------------------------------------------------------------
 
-function civilDate(c: CivilDateTime | undefined): string | null {
-  const d = c?.date;
-  if (!d?.year || !d.month || !d.day) return null;
-  return `${d.year}-${String(d.month).padStart(2, "0")}-${String(d.day).padStart(2, "0")}`;
+function localDate(utcTime?: string, utcOffset?: string): Date | null {
+  if (!utcTime) return null;
+  const ms = Date.parse(utcTime);
+  if (Number.isNaN(ms)) return null;
+  return new Date(ms + durationSecs(utcOffset) * 1000);
 }
 
-function civilTime(c: CivilDateTime | undefined): string | null {
-  const t = c?.time;
-  if (!t) return null;
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${pad(t.hours ?? 0)}:${pad(t.minutes ?? 0)}:${pad(t.seconds ?? 0)}`;
+// Read back the shifted instant in UTC — it now holds the user's local wall clock.
+function dateStr(d: Date | null): string | null {
+  return d ? d.toISOString().slice(0, 10) : null;
+}
+
+function timeStr(d: Date | null): string | null {
+  return d ? d.toISOString().slice(11, 19) : null;
 }
 
 // Filters take civil time as an unzoned RFC-3339-style literal, and use the
@@ -251,17 +261,20 @@ export async function syncGoogleHealth(
   // derived from weight + height. Height is a separate sample, not part of the weight
   // reading; if the user has never recorded one, BMI stays null rather than guessed.
 
-  const heightM = (heightPoints[0]?.height?.heightMillimeters ?? 0) / 1000 || null;
+  const heightMm = Number(heightPoints[0]?.height?.heightMillimeters ?? 0);
+  const heightM = Number.isFinite(heightMm) && heightMm > 0 ? heightMm / 1000 : null;
 
   const byDate = new Map<string, { weightKg?: number; fatPct?: number }>();
   for (const p of weightPoints) {
-    const date = civilDate(p.weight?.sampleTime?.civilTime);
+    const st = p.weight?.sampleTime;
+    const date = dateStr(localDate(st?.physicalTime, st?.utcOffset));
     const grams = p.weight?.weightGrams;
     if (!date || grams == null) continue;
     byDate.set(date, { ...byDate.get(date), weightKg: grams / 1000 });
   }
   for (const p of fatPoints) {
-    const date = civilDate(p.bodyFat?.sampleTime?.civilTime);
+    const st = p.bodyFat?.sampleTime;
+    const date = dateStr(localDate(st?.physicalTime, st?.utcOffset));
     const pct = p.bodyFat?.percentage;
     if (!date || pct == null) continue;
     byDate.set(date, { ...byDate.get(date), fatPct: pct });
@@ -320,7 +333,8 @@ export async function syncGoogleHealth(
     const ex = p.exercise;
     if (!ex) continue;
 
-    const date = civilDate(ex.interval?.civilStartTime);
+    const startLocal = localDate(ex.interval?.startTime, ex.interval?.startUtcOffset);
+    const date = dateStr(startLocal);
     if (!date) continue;
 
     // activeDuration excludes pauses; Fitbit's `duration` did not. Slightly stricter,
@@ -328,7 +342,7 @@ export async function syncGoogleHealth(
     const durationMin = Math.round(durationSecs(ex.activeDuration) / 60);
     if (durationMin < 5) continue;
 
-    const timeStr = civilTime(ex.interval?.civilStartTime);
+    const startTime = timeStr(startLocal);
     const metrics = ex.metricsSummary;
     const avgHrRaw = metrics?.averageHeartRateBeatsPerMinute;
     const avgHr = avgHrRaw != null ? Number(avgHrRaw) : null;
@@ -337,14 +351,14 @@ export async function syncGoogleHealth(
 
     workoutRows.push({
       date,
-      start_time: timeStr,
+      start_time: startTime,
       activity,
       duration_mins: durationMin,
       calories: calories != null ? Math.round(calories) : null,
       avg_hr: avgHr != null && Number.isFinite(avgHr) ? Math.round(avgHr) : null,
       source: "google_health",
       metadata: { hr_zones: fmtHrZones(metrics?.heartRateZoneDurations) },
-      _key: `${date}|${timeStr}|${activity}`,
+      _key: `${date}|${startTime}|${activity}`,
     });
   }
 


### PR DESCRIPTION
Follow-up to #614. The first live run against the Google Health API surfaced three wire-format defects plus one proxy bug. All four are fixed, and the sync is now **verified end-to-end against real data**.

## The one that mattered

**The API never returns `civilStartTime` / `civilTime`.** A data point carries only a UTC instant plus a google-duration offset:

```json
"interval": {
  "startTime": "2026-07-11T00:16:17Z",
  "startUtcOffset": "-25200s"
}
```

The schema documents `civilStartTime` as an output field, and #614 read it. It comes back `undefined`, so `civilDate()` returned null and **every exercise was silently dropped** — body composition worked fine while 90 days of workouts returned zero rows. A failure indistinguishable from "no workouts this week".

The `civil_*` **filter** is accepted and correct (it returns 13 points over a 7-day window); only the *response* shape differs. Local wall-clock time is now derived from `startTime + startUtcOffset`.

Verified against a known session: `2026-07-11T00:16:17Z` with offset `-25200s` resolves to **17:16 on 07-10**, matching the pre-existing Fitbit row for that workout, and `activeDuration: 945s` → 16 min matches its duration.

## Also fixed

- **`heightMillimeters` is int64**, which proto-JSON serialises as a **string**. Dividing it crashed BMI derivation. (`averageHeartRateBeatsPerMinute` has the same shape and was already coerced.)
- **`urlopen_with_retry()`** returns a parsed dict and takes no `timeout` kwarg.
- **OAuth callbacks redirected to `http://0.0.0.0:3000`.** Behind Caddy, `req.nextUrl.origin` is the container's bind address rather than the public host, so completing a consent dropped the browser on an unreachable URL. The token was stored correctly — `storeIntegration` runs before the redirect — so the integration *worked* despite appearing to fail. `/api/auth/google/callback` carried the same latent bug and is fixed too.

## #607's central claim, confirmed against live data

`heartRateZoneDurations` comes back **populated**, alongside average HR:

```json
"metricsSummary": {
  "caloriesKcal": <n>,
  "averageHeartRateBeatsPerMinute": "<bpm>",
  "heartRateZoneDurations": {
    "lightTime": "<n>s", "moderateTime": "<n>s",
    "vigorousTime": "<n>s", "peakTime": "<n>s"
  }
}
```

Per-workout heart-rate zones survive the Fitbit migration. (`dataSource.platform: FITBIT`, device a Pixel Watch — the data is reaching Google Health as intended.)

## Cutover dedup — verified, not assumed

The failure mode I flagged in #614: Google Health returns the same workouts already stored as `source='fitbit'`, so a naive dedup would re-insert all of them. A real run fetched **13** workouts in the window, correctly recognised **12** as already present, and inserted only the one genuinely new session. No double-insert.

Live result: **1 new body-composition row, 1 new workout row.** `fitness_log` now holds 49 `google_health` rows (48 relabelled by the #614 migration + 1 new).

## Still outstanding after this merges

The **day-8 token check**. If the OAuth app is not in "In production", refresh tokens expire after 7 days — this will look healthy for a week and then silently stop. It was In production at consent time; the only real proof is a sync still working 8+ days out with no re-auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gkXP7WF4yaHcRWCFBEqAX
