### PR TITLE
fix(nutrition): take quantities, prep-state and food selection away from the model

### DIFF
--- a/web/src/__tests__/quantity.test.ts
+++ b/web/src/__tests__/quantity.test.ts
@@ -122,6 +122,22 @@ test("a shared CATEGORY word is not a match either", () => {
   assert.equal(isPlausibleMatch("cheese", "Cheese, cheddar"), true);
 });
 
+test("branded and restaurant records are not ingredients", () => {
+  // USDA has no plain marinara, so the best "marinara" hit was an Olive Garden entrée.
+  // A ravioli dinner is not a spoon of sauce.
+  assert.equal(
+    isPlausibleMatch("sauce, marinara", "OLIVE GARDEN, cheese ravioli with marinara sauce"),
+    false,
+  );
+  assert.equal(isPlausibleMatch("cheese, cheddar", "KRAFT, cheddar cheese"), false);
+  assert.equal(
+    isPlausibleMatch("chicken, breast", "Restaurant, family style, chicken breast"),
+    false,
+  );
+  // Real foods are sentence case and must still pass.
+  assert.equal(isPlausibleMatch("beef, ribeye", "Beef, ribeye, steak, boneless, raw"), true);
+});
+
 test("a shared PREPARATION word is not a match", () => {
   // Otherwise "rice, brown, raw" would happily match "Beef, raw" on the strength of "raw"
   // alone — which is how you end up with beef where the rice should be.

--- a/web/src/__tests__/quantity.test.ts
+++ b/web/src/__tests__/quantity.test.ts
@@ -1,0 +1,72 @@
+// Unit tests for the quantity lexer (nutrition/quantity.ts).
+// Run with: node --experimental-strip-types --test src/__tests__/quantity.test.ts
+// (from the web/ directory)
+//
+// WHY THIS EXISTS
+//
+// The pipeline's guarantee was "the model never produces a macro number — USDA does". That
+// was never enough: the model still produced the two inputs that DETERMINE the macros, and
+// it altered them. Measured on qwen2.5vl:7b against a real recipe:
+//
+//   "3 lb chicken breast, 2 cups dry brown rice, Green beans, olive oil"
+//     -> "rice, brown, COOKED"      (the text said DRY — cooked grains are mostly water,
+//                                    so this resolved ~90g of carbs instead of ~280g)
+//     -> "green bean, 1 SERVING"    (no quantity was stated; it invented one)
+//     -> olive oil                  (dropped entirely)
+//
+// The result was 3x wrong and was reported as HIGH confidence.
+//
+// "3 lb" and "2 cups" are literally written down. Reading them is a lexer's job. These tests
+// pin that the number reaching USDA is the number the user wrote — and, just as importantly,
+// that an ingredient with NO stated amount is reported as unquantified rather than guessed.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { lexQuantity, splitIngredients } from "../lib/nutrition/quantity.ts";
+
+test("reads a stated mass or volume exactly", () => {
+  assert.deepEqual(lexQuantity("3 lb chicken breast"), {
+    qty: 3,
+    unit: "lb",
+    source: "3 lb",
+  });
+  assert.deepEqual(lexQuantity("370 g dry brown rice"), { qty: 370, unit: "g", source: "370 g" });
+  assert.equal(lexQuantity("2 cups dry brown rice")?.qty, 2);
+  assert.equal(lexQuantity("2 cups dry brown rice")?.unit, "cup");
+  assert.equal(lexQuantity("1.5 lb ground turkey")?.qty, 1.5);
+});
+
+test("handles the fractions people actually write", () => {
+  assert.equal(lexQuantity("1/2 cup oats")?.qty, 0.5);
+  assert.equal(lexQuantity("1 1/2 cups pasta")?.qty, 1.5);
+  assert.equal(lexQuantity("½ cup rice")?.qty, 0.5);
+  assert.equal(lexQuantity("1½ cups flour")?.qty, 1.5);
+});
+
+test("a bare count keeps the count and admits it doesn't know the weight", () => {
+  // "each" is the honest unit: we know HOW MANY, and we are not pretending to know how much
+  // one weighs. USDA's portion table answers that ("1 large egg = 50g").
+  assert.deepEqual(lexQuantity("2 eggs"), { qty: 2, unit: "each", source: "2" });
+  assert.equal(lexQuantity("12 drumsticks")?.qty, 12);
+  assert.equal(lexQuantity("12 drumsticks")?.unit, "drumstick");
+});
+
+test("REFUSES to invent a quantity that was never stated", () => {
+  // This is the important one. Returning null here is what makes the estimate flag the
+  // ingredient and cap its confidence, instead of quietly folding a made-up serving into a
+  // confident-looking total.
+  assert.equal(lexQuantity("Green beans"), null);
+  assert.equal(lexQuantity("olive oil"), null);
+  assert.equal(lexQuantity("marinara"), null);
+  assert.equal(lexQuantity("Onion, bell pepper"), null);
+  // Not a measurement we can resolve — do not coerce it into one.
+  assert.equal(lexQuantity("a handful of spinach"), null);
+  assert.equal(lexQuantity(""), null);
+});
+
+test("splits a real recipe's ingredient text into ingredients", () => {
+  assert.deepEqual(
+    splitIngredients("3 lb chicken breast, 2 cups dry brown rice\nGreen beans, olive oil + lemon"),
+    ["3 lb chicken breast", "2 cups dry brown rice", "Green beans", "olive oil", "lemon"],
+  );
+});

--- a/web/src/__tests__/quantity.test.ts
+++ b/web/src/__tests__/quantity.test.ts
@@ -106,6 +106,22 @@ test("accepts the real match, including USDA's verbose phrasing", () => {
   assert.equal(isPlausibleMatch("pasta, dry, enriched", "Pasta, dry, enriched"), true);
 });
 
+test("a shared CATEGORY word is not a match either", () => {
+  // The one that slipped through in production: the model queries "sauce, marinara", and
+  // "Cheese sauce, prepared from recipe" shares "sauce" — so marinara resolved as cheese
+  // sauce. A category noun is not evidence; a distinctive one is.
+  assert.equal(isPlausibleMatch("sauce, marinara", "Cheese sauce, prepared from recipe"), false);
+  assert.equal(isPlausibleMatch("cheese, cream", "Cheese, goat, soft type"), false);
+  assert.equal(isPlausibleMatch("oil, olive", "Oil, corn, peanut, and olive"), true); // olive IS distinctive
+  assert.equal(
+    isPlausibleMatch("sauce, marinara", "Sauce, pasta, spaghetti/marinara, ready-to-serve"),
+    true,
+  );
+  // A query with no distinctive word at all must not be blocked — anything in the family
+  // is a fair answer to a vague question.
+  assert.equal(isPlausibleMatch("cheese", "Cheese, cheddar"), true);
+});
+
 test("a shared PREPARATION word is not a match", () => {
   // Otherwise "rice, brown, raw" would happily match "Beef, raw" on the strength of "raw"
   // alone — which is how you end up with beef where the rice should be.

--- a/web/src/__tests__/quantity.test.ts
+++ b/web/src/__tests__/quantity.test.ts
@@ -23,6 +23,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { lexQuantity, splitIngredients } from "../lib/nutrition/quantity.ts";
+import { isPlausibleMatch } from "../lib/nutrition/fdc.ts";
 
 test("reads a stated mass or volume exactly", () => {
   assert.deepEqual(lexQuantity("3 lb chicken breast"), {
@@ -69,4 +70,45 @@ test("splits a real recipe's ingredient text into ingredients", () => {
     splitIngredients("3 lb chicken breast, 2 cups dry brown rice\nGreen beans, olive oil + lemon"),
     ["3 lb chicken breast", "2 cups dry brown rice", "Green beans", "olive oil", "lemon"],
   );
+});
+
+// ---------------------------------------------------------------------------
+// Food-selection guard.
+//
+// The model picks from a USDA candidate list. When USDA's search returns nothing relevant it
+// picks the least-bad of a bad set, silently. Observed on real recipes:
+//
+//   "salt"       -> "Syrups, table blends, pancake"   (20g of SYRUP in a zero-calorie
+//                                                      ingredient — it INVENTS calories)
+//   "broccolini" -> "Abiyuch, raw"                    (a tropical fruit)
+//   "marinara"   -> "Cheese sauce, prepared from recipe"
+//
+// No prompt fixes this — the right answer was never in the list. The guard is arithmetic.
+// ---------------------------------------------------------------------------
+
+test("rejects a candidate that is not plausibly the food asked for", () => {
+  assert.equal(isPlausibleMatch("salt", "Syrups, table blends, pancake"), false);
+  assert.equal(isPlausibleMatch("broccolini", "Abiyuch, raw"), false);
+  assert.equal(isPlausibleMatch("marinara", "Cheese sauce, prepared from recipe"), false);
+});
+
+test("accepts the real match, including USDA's verbose phrasing", () => {
+  assert.equal(
+    isPlausibleMatch("chicken, breast, raw", "Chicken, broilers or fryers, meat only, raw"),
+    true,
+  );
+  assert.equal(
+    isPlausibleMatch("rice, brown, long-grain, raw", "Rice, brown, long grain, unenriched, raw"),
+    true,
+  );
+  assert.equal(isPlausibleMatch("green beans, raw", "Beans, snap, green, raw"), true);
+  assert.equal(isPlausibleMatch("turkey, ground, raw", "Turkey, Ground, raw"), true);
+  assert.equal(isPlausibleMatch("pasta, dry, enriched", "Pasta, dry, enriched"), true);
+});
+
+test("a shared PREPARATION word is not a match", () => {
+  // Otherwise "rice, brown, raw" would happily match "Beef, raw" on the strength of "raw"
+  // alone — which is how you end up with beef where the rice should be.
+  assert.equal(isPlausibleMatch("rice, brown, raw", "Beef, ribeye, raw"), false);
+  assert.equal(isPlausibleMatch("oats, dry", "Sugars, granulated, dry"), false);
 });

--- a/web/src/app/api/internal/resolve-recipe-macros/route.ts
+++ b/web/src/app/api/internal/resolve-recipe-macros/route.ts
@@ -56,7 +56,14 @@ export async function POST(request: NextRequest) {
 
     try {
       const macros = await resolveRecipeMacros(db, userId, r.id as string);
-      resolved.push({ name, ...macros?.total });
+      resolved.push({
+        name,
+        ...macros?.total,
+        // The working, not just the answer — which USDA record each ingredient matched and
+        // how its grams were derived. This is what makes a wrong total findable.
+        unquantified: macros?.unquantified ?? [],
+        items: macros?.items ?? [],
+      });
     } catch (e) {
       failed.push({ name, error: (e as Error).message });
     }

--- a/web/src/lib/nutrition/estimate.ts
+++ b/web/src/lib/nutrition/estimate.ts
@@ -15,6 +15,7 @@ import {
   EMPTY_MACROS,
   getFood,
   gramsFor,
+  isPlausibleMatch,
   macrosForGrams,
   roundMacros,
   searchFoods,
@@ -49,6 +50,8 @@ export type MealEstimate = {
   items: EstimatedItem[];
   totals: Macros;
   confidence: "high" | "medium" | "low";
+  /** Foods that matched no plausible USDA record and are ABSENT from `totals`. */
+  unmatched: string[];
   notes: string;
 };
 
@@ -67,7 +70,16 @@ function isNutritionallyEmpty(m: {
 }
 
 async function estimateOne(food: ParsedFood, context?: string): Promise<EstimatedItem | null> {
-  const candidates = await searchFoods(food.query, 5);
+  const searched = await searchFoods(food.query, 5);
+
+  // Drop candidates that are not plausibly the food we asked for. USDA's search sometimes
+  // returns nothing relevant, and the model then picks the least-bad of a bad set — "salt"
+  // became "Syrups, table blends, pancake", which puts 20g of SYRUP into a zero-calorie
+  // ingredient. No prompt fixes that: the right answer was never in the list.
+  //
+  // Matching NOTHING is a better outcome than matching syrup. Salt genuinely has no macros;
+  // a bogus match invents some. The caller reports what went unmatched.
+  const candidates = searched.filter((c) => isPlausibleMatch(food.query, c.description));
   if (candidates.length === 0) return null;
 
   // THE QUANTITY COMES FROM THE TEXT, NOT THE MODEL.
@@ -122,7 +134,7 @@ async function estimateOne(food: ParsedFood, context?: string): Promise<Estimate
   return null; // every candidate was empty — better to report nothing than zeros
 }
 
-function assemble(items: EstimatedItem[], label: string): MealEstimate {
+function assemble(items: EstimatedItem[], label: string, unmatched: string[] = []): MealEstimate {
   const totals = items.reduce<Macros>((acc, i) => addMacros(acc, i.macros), { ...EMPTY_MACROS });
 
   // CONFIDENCE MUST MEASURE THE RIGHT THING.
@@ -154,6 +166,14 @@ function assemble(items: EstimatedItem[], label: string): MealEstimate {
         `${unquantified.map((i) => i.input).join(", ")}. Add an amount to fix the total.`,
     );
   }
+  if (unmatched.length) {
+    // Name them. Some (salt, pepper) contribute nothing and their absence is harmless —
+    // correct, even. Others are a real hole in the total. Only the user can tell which.
+    parts.push(
+      `No USDA match for: ${unmatched.join(", ")} — these contribute NOTHING to the total. ` +
+        `Harmless for salt/pepper; a real gap for anything else.`,
+    );
+  }
   if (assumedPortion) {
     parts.push(`${assumedPortion} portion(s) used an assumed serving weight.`);
   }
@@ -164,6 +184,7 @@ function assemble(items: EstimatedItem[], label: string): MealEstimate {
     items,
     totals: roundMacros(totals),
     confidence,
+    unmatched,
     notes: parts.join(" "),
   };
 }
@@ -177,7 +198,12 @@ export async function estimateFromText(
   const foods = await parseFoodText(text, mode);
   const settled = await Promise.all(foods.map((f) => estimateOne(f, text).catch(() => null)));
   const items = settled.filter((i): i is EstimatedItem => i !== null);
-  return assemble(items, label?.trim() || text.trim());
+  // An ingredient that matched nothing used to vanish silently. Carry it through so the
+  // estimate can say what is missing from its own total.
+  const unmatched = foods
+    .filter((_, i) => settled[i] === null)
+    .map((f) => f.source?.trim() || f.query);
+  return assemble(items, label?.trim() || text.trim(), unmatched);
 }
 
 /**

--- a/web/src/lib/nutrition/estimate.ts
+++ b/web/src/lib/nutrition/estimate.ts
@@ -21,6 +21,7 @@ import {
   type Macros,
 } from "./fdc";
 import { parseFoodPhoto, parseFoodText, pickBestFood, type ParsedFood } from "./parse";
+import { lexQuantity } from "./quantity";
 
 export type EstimatedItem = {
   /** What the user said / the model saw. */
@@ -33,6 +34,12 @@ export type EstimatedItem = {
   grams: number;
   /** false when we fell back to an assumed portion weight. */
   exactPortion: boolean;
+  /**
+   * false when the source text stated no quantity at all ("Green beans", "olive oil").
+   * The amount used is then an invention, and the estimate must say so rather than let a
+   * made-up serving hide inside a confident-looking total.
+   */
+  quantified: boolean;
   basis: string;
   macros: Macros;
 };
@@ -63,6 +70,22 @@ async function estimateOne(food: ParsedFood, context?: string): Promise<Estimate
   const candidates = await searchFoods(food.query, 5);
   if (candidates.length === 0) return null;
 
+  // THE QUANTITY COMES FROM THE TEXT, NOT THE MODEL.
+  //
+  // The model is asked to echo the fragment it read (`source`) and we lex the number out of
+  // that ourselves. It is not trusted to repeat a number, because it demonstrably alters
+  // them: "2 cups dry brown rice" came back as a cooked-rice match, and "about 6oz of
+  // chicken" used to come back as qty=1 unit='medium'. A stated measurement is the user's
+  // own data and no model should be able to round it.
+  //
+  // When the source states nothing ("Green beans"), the model's qty/unit is an invention.
+  // We still estimate — a rough total beats no total — but the item is flagged unquantified
+  // and the confidence below is capped accordingly.
+  const lexed = food.source ? lexQuantity(food.source) : null;
+  const qty = lexed ? lexed.qty : food.qty;
+  const unit = lexed ? lexed.unit : food.unit;
+  const quantified = lexed !== null;
+
   // Never blind-trust candidates[0] — USDA's top hit for "chicken breast, cooked"
   // is breaded microwaved tenders (252 kcal vs ~165 for plain).
   let idx: number | null = null;
@@ -80,17 +103,18 @@ async function estimateOne(food: ParsedFood, context?: string): Promise<Estimate
     const detail = await getFood(candidates[i].fdcId);
     if (isNutritionallyEmpty(detail.per100g)) continue;
 
-    const { grams, exact, basis } = gramsFor(food.qty, food.unit, detail.portions);
+    const { grams, exact, basis } = gramsFor(qty, unit, detail.portions);
     return {
-      input: `${food.qty} ${food.unit} ${food.query}`.trim(),
+      input: (food.source ?? `${qty} ${unit} ${food.query}`).trim(),
       matched: detail.description,
       fdcId: detail.fdcId,
-      qty: food.qty,
-      unit: food.unit,
+      qty,
+      unit,
       grams: Math.round(grams),
       // Only "exact" if we both picked deliberately AND resolved a real portion.
       exactPortion: exact && idx !== null && i === idx,
-      basis,
+      quantified,
+      basis: quantified ? basis : `${basis} — NO QUANTITY STATED, amount is a guess`,
       macros: macrosForGrams(detail.per100g, grams),
     };
   }
@@ -101,31 +125,56 @@ async function estimateOne(food: ParsedFood, context?: string): Promise<Estimate
 function assemble(items: EstimatedItem[], label: string): MealEstimate {
   const totals = items.reduce<Macros>((acc, i) => addMacros(acc, i.macros), { ...EMPTY_MACROS });
 
-  // Confidence reflects what actually happened, not a vibe:
-  //  high   — every portion resolved against real USDA portion data
-  //  medium — some portions fell back to an assumed weight
-  //  low    — nothing matched
-  const assumed = items.filter((i) => !i.exactPortion).length;
-  const confidence: MealEstimate["confidence"] =
-    items.length === 0 ? "low" : assumed === 0 ? "high" : assumed < items.length ? "medium" : "low";
+  // CONFIDENCE MUST MEASURE THE RIGHT THING.
+  //
+  // It used to reflect only whether gramsFor() found a USDA portion table. That is a fact
+  // about USDA's data, not about whether the answer is right — so a recipe whose rice was
+  // silently resolved as COOKED (a 3x carb error) came back "high", because USDA does
+  // happen to publish a cup-portion for cooked rice. A wrong number wearing a confident
+  // badge is worse than an honest "I guessed".
+  //
+  // So: any ingredient we had to invent an amount for makes "high" unreachable. You cannot
+  // be highly confident in a total that contains a number nobody wrote down.
+  const unquantified = items.filter((i) => !i.quantified);
+  const assumedPortion = items.filter((i) => i.quantified && !i.exactPortion).length;
 
-  const notes =
-    assumed === 0
-      ? "All portions resolved from USDA measured portion data."
-      : `${assumed} of ${items.length} portion(s) used an assumed serving weight — adjust below if that's off.`;
+  let confidence: MealEstimate["confidence"];
+  if (items.length === 0) confidence = "low";
+  else if (unquantified.length)
+    confidence = unquantified.length === items.length ? "low" : "medium";
+  else if (assumedPortion === 0) confidence = "high";
+  else confidence = assumedPortion < items.length ? "medium" : "low";
+
+  const parts: string[] = [];
+  if (unquantified.length) {
+    // Name them. "Some portions were assumed" is unactionable; "green beans, olive oil had
+    // no quantity" tells the user exactly which line to go and fix.
+    parts.push(
+      `${unquantified.length} ingredient(s) had NO stated quantity and were guessed: ` +
+        `${unquantified.map((i) => i.input).join(", ")}. Add an amount to fix the total.`,
+    );
+  }
+  if (assumedPortion) {
+    parts.push(`${assumedPortion} portion(s) used an assumed serving weight.`);
+  }
+  if (!parts.length) parts.push("Every amount was taken from your text; USDA supplied the grams.");
 
   return {
     food_name: label,
     items,
     totals: roundMacros(totals),
     confidence,
-    notes,
+    notes: parts.join(" "),
   };
 }
 
 /** Free-text: "2 eggs and toast" */
-export async function estimateFromText(text: string, label?: string): Promise<MealEstimate> {
-  const foods = await parseFoodText(text);
+export async function estimateFromText(
+  text: string,
+  label?: string,
+  mode: "meal" | "recipe" = "meal",
+): Promise<MealEstimate> {
+  const foods = await parseFoodText(text, mode);
   const settled = await Promise.all(foods.map((f) => estimateOne(f, text).catch(() => null)));
   const items = settled.filter((i): i is EstimatedItem => i !== null);
   return assemble(items, label?.trim() || text.trim());

--- a/web/src/lib/nutrition/fdc.ts
+++ b/web/src/lib/nutrition/fdc.ts
@@ -99,6 +99,99 @@ const ZERO: Macros = {
 };
 
 /**
+ * Reject a USDA record that isn't plausibly the food we asked for.
+ *
+ * The model picks from a candidate list, and when USDA's search returns nothing relevant it
+ * picks the least-bad of a bad set — silently. Observed on real recipes:
+ *
+ *   "salt"        -> "Syrups, table blends, pancake"       (20g of SYRUP for a zero-cal
+ *                                                            ingredient — invents calories)
+ *   "broccolini"  -> "Abiyuch, raw"                        (a tropical fruit)
+ *   "marinara"    -> "Cheese sauce, prepared from recipe"
+ *
+ * A model cannot be prompted out of this: the right answer was never in the list. The guard
+ * is arithmetic — a candidate must share at least one MEANINGFUL word with the query.
+ *
+ * "Meaningful" excludes preparation and packaging words, because otherwise "rice, brown, raw"
+ * would happily match "Beef, raw" on the strength of "raw" alone. Matching on those is how
+ * you get a plate of beef where the rice should be.
+ *
+ * This deliberately only catches the egregious cases (ZERO overlap). It will still let
+ * "cream cheese" through as "Cheese, goat" — a wrong-ish match, but one in the right food
+ * family and the right calorie order. Better a narrow guard that never rejects a good match
+ * than a clever one that does.
+ */
+const PREP_WORDS = new Set([
+  "raw",
+  "cooked",
+  "boiled",
+  "roasted",
+  "baked",
+  "fried",
+  "grilled",
+  "broiled",
+  "steamed",
+  "dry",
+  "dried",
+  "fresh",
+  "frozen",
+  "canned",
+  "prepared",
+  "enriched",
+  "unenriched",
+  "whole",
+  "boneless",
+  "skinless",
+  "sliced",
+  "chopped",
+  "ground",
+  "powder",
+  "powdered",
+  "type",
+  "soft",
+  "hard",
+  "light",
+  "regular",
+  "plain",
+  "unsalted",
+  "salted",
+  "low",
+  "reduced",
+  "and",
+  "or",
+  "with",
+  "without",
+  "in",
+  "of",
+  "the",
+  "a",
+  "from",
+  "table",
+  "blends",
+  "blend",
+]);
+
+function significantTokens(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .split(/[^a-z]+/)
+      .filter((w) => w.length > 2 && !PREP_WORDS.has(w))
+      // Crude singularisation so "broilers" matches "broiler", "beans" matches "bean".
+      .map((w) => (w.endsWith("s") && !w.endsWith("ss") ? w.slice(0, -1) : w)),
+  );
+}
+
+/** True when the candidate plausibly IS the queried food. */
+export function isPlausibleMatch(query: string, description: string): boolean {
+  const wanted = significantTokens(query);
+  if (wanted.size === 0) return true; // nothing to check against — don't block on a vague query
+  const got = significantTokens(description);
+  for (const w of wanted) if (got.has(w)) return true;
+  return false;
+}
+
+/**
  * Search for candidate foods.
  *
  * Restricted to Foundation + SR Legacy: these are USDA's *measured* datasets.

--- a/web/src/lib/nutrition/fdc.ts
+++ b/web/src/lib/nutrition/fdc.ts
@@ -121,6 +121,39 @@ const ZERO: Macros = {
  * family and the right calorie order. Better a narrow guard that never rejects a good match
  * than a clever one that does.
  */
+// Broad category nouns. These are too weak to PROVE a match on their own: "sauce, marinara"
+// and "Cheese sauce, prepared from recipe" share "sauce" and are not the same food — that
+// exact match got marinara resolved as cheese sauce in production. Likewise "cheese, cream"
+// vs "Cheese, goat".
+//
+// They are only stripped from the QUERY's required tokens; a query consisting of NOTHING but
+// category words (a bare "cheese") still matches anything in that family, which is the right
+// behaviour for a vague query.
+const WEAK_TOKENS = new Set([
+  "sauce",
+  "soup",
+  "oil",
+  "cheese",
+  "juice",
+  "spice",
+  "spices",
+  "seasoning",
+  "beverage",
+  "beverages",
+  "drink",
+  "snack",
+  "snacks",
+  "food",
+  "foods",
+  "mix",
+  "mixture",
+  "product",
+  "products",
+  "dish",
+  "meal",
+  "recipe",
+]);
+
 const PREP_WORDS = new Set([
   "raw",
   "cooked",
@@ -171,12 +204,12 @@ const PREP_WORDS = new Set([
   "blend",
 ]);
 
-function significantTokens(text: string): Set<string> {
+function tokens(text: string, dropWeak: boolean): Set<string> {
   return new Set(
     text
       .toLowerCase()
       .split(/[^a-z]+/)
-      .filter((w) => w.length > 2 && !PREP_WORDS.has(w))
+      .filter((w) => w.length > 2 && !PREP_WORDS.has(w) && !(dropWeak && WEAK_TOKENS.has(w)))
       // Crude singularisation so "broilers" matches "broiler", "beans" matches "bean".
       .map((w) => (w.endsWith("s") && !w.endsWith("ss") ? w.slice(0, -1) : w)),
   );
@@ -184,9 +217,16 @@ function significantTokens(text: string): Set<string> {
 
 /** True when the candidate plausibly IS the queried food. */
 export function isPlausibleMatch(query: string, description: string): boolean {
-  const wanted = significantTokens(query);
-  if (wanted.size === 0) return true; // nothing to check against — don't block on a vague query
-  const got = significantTokens(description);
+  // The query must be matched on a DISTINCTIVE word ("marinara"), not a category one
+  // ("sauce"). The description keeps its category words — "Sauce, marinara" should still
+  // match on "marinara".
+  const wanted = tokens(query, true);
+  if (wanted.size === 0) {
+    // The query is nothing but category/prep words (a bare "cheese", "oil"). There is no
+    // distinctive word to check, so don't block — anything in the family is a fair answer.
+    return true;
+  }
+  const got = tokens(description, false);
   for (const w of wanted) if (got.has(w)) return true;
   return false;
 }

--- a/web/src/lib/nutrition/fdc.ts
+++ b/web/src/lib/nutrition/fdc.ts
@@ -215,8 +215,28 @@ function tokens(text: string, dropWeak: boolean): Set<string> {
   );
 }
 
+/**
+ * Branded and restaurant records are not INGREDIENTS.
+ *
+ * The dataType filter already excludes USDA's "Branded" set, but SR Legacy still carries
+ * restaurant entrées — so a search for marinara, which USDA has no plain entry for, resolved
+ * to "OLIVE GARDEN, cheese ravioli with marinara sauce". A ravioli dinner is not a spoon of
+ * sauce, and seeing a restaurant menu item inside your own recipe is the fastest way to stop
+ * believing any of the numbers.
+ *
+ * USDA writes brands in caps ("OLIVE GARDEN,", "KRAFT,") while real foods are sentence case
+ * ("Beef, ribeye..."), which makes this cheap to detect.
+ */
+function isBrandedOrRestaurant(description: string): boolean {
+  if (/^restaurant\b/i.test(description)) return true;
+  const head = description.split(",")[0].trim();
+  // Two or more consecutive capitals in the leading segment = a brand, not a food.
+  return head.length > 2 && /[A-Z]{2,}/.test(head) && head === head.toUpperCase();
+}
+
 /** True when the candidate plausibly IS the queried food. */
 export function isPlausibleMatch(query: string, description: string): boolean {
+  if (isBrandedOrRestaurant(description)) return false;
   // The query must be matched on a DISTINCTIVE word ("marinara"), not a category one
   // ("sauce"). The description keeps its category words — "Sauce, marinara" should still
   // match on "marinara".

--- a/web/src/lib/nutrition/parse.ts
+++ b/web/src/lib/nutrition/parse.ts
@@ -20,8 +20,19 @@
 export type ParsedFood = {
   /** Plain USDA-style food name, e.g. "egg, whole, raw". */
   query: string;
+  /**
+   * The model's OWN reading of the quantity. Treated as a fallback only — `source` is
+   * lexed in code and wins whenever it states a quantity, because the model demonstrably
+   * alters numbers it is asked to repeat (see quantity.ts).
+   */
   qty: number;
   unit: string;
+  /**
+   * The exact fragment of the user's text this food came from, verbatim. This is what the
+   * quantity lexer reads, so the number that reaches USDA is the number the user wrote —
+   * not the model's recollection of it.
+   */
+  source?: string;
 };
 
 function ollamaUrl(): string {
@@ -82,8 +93,9 @@ const PARSE_SCHEMA = {
           query: { type: "string" },
           qty: { type: "number" },
           unit: { type: "string" },
+          source: { type: "string" },
         },
-        required: ["query", "qty", "unit"],
+        required: ["query", "qty", "unit", "source"],
       },
     },
   },
@@ -103,6 +115,9 @@ const PARSE_SYSTEM = [
   "  itself (raw/cooked/roasted/toasted); drop the rest.",
   "- qty: the NUMBER of units. Never null.",
   "- unit: the unit AS STATED by the user.",
+  "- source: the exact fragment of the input this food came from, COPIED VERBATIM.",
+  "  Copy the characters; do not normalise, round, or re-word them. This is the only",
+  "  field that is trusted for the quantity — qty/unit are a fallback.",
   "",
   "RULES",
   "1. If the user states a weight or volume, keep it EXACTLY. Never replace a stated",
@@ -117,26 +132,82 @@ const PARSE_SYSTEM = [
   "",
   "EXAMPLES",
   'Input: "2 eggs and toast"',
-  'Output: [{"query":"egg, whole, raw","qty":2,"unit":"large"},',
-  '         {"query":"bread, white, toasted","qty":1,"unit":"slice"}]',
+  'Output: [{"query":"egg, whole, raw","qty":2,"unit":"large","source":"2 eggs"},',
+  '         {"query":"bread, white, toasted","qty":1,"unit":"slice","source":"toast"}]',
   "",
   'Input: "grilled chicken breast, about 6oz, with a cup of white rice"',
-  'Output: [{"query":"chicken breast, roasted","qty":6,"unit":"oz"},',
-  '         {"query":"rice, white, cooked","qty":1,"unit":"cup"}]',
+  'Output: [{"query":"chicken breast, roasted","qty":6,"unit":"oz","source":"about 6oz"},',
+  '         {"query":"rice, white, cooked","qty":1,"unit":"cup","source":"a cup of white rice"}]',
   "",
   'Input: "a bowl of oatmeal with a banana"',
-  'Output: [{"query":"oats, cooked","qty":1,"unit":"cup"},',
-  '         {"query":"banana, raw","qty":1,"unit":"medium"}]',
+  'Output: [{"query":"oats, cooked","qty":1,"unit":"cup","source":"a bowl of oatmeal"},',
+  '         {"query":"banana, raw","qty":1,"unit":"medium","source":"a banana"}]',
   "",
   'Input: "added some chicken"',
-  'Output: [{"query":"chicken breast, roasted","qty":1,"unit":"serving"}]',
+  'Output: [{"query":"chicken breast, roasted","qty":1,"unit":"serving","source":"some chicken"}]',
 ].join("\n");
 
-/** "2 eggs and toast" -> [{query:'egg, whole, raw', qty:2, unit:'each'}, ...] */
-export async function parseFoodText(text: string): Promise<ParsedFood[]> {
+/**
+ * Recipes are a different domain and the meal prompt is actively wrong for them.
+ *
+ * A meal is a plate of COOKED food — "rice, white, cooked" is the right USDA entry, and
+ * every example above teaches that. A recipe's ingredient list is a tray of RAW, DRY
+ * ingredients. Fed the meal prompt, qwen2.5vl rewrote "2 cups dry brown rice" to
+ * "rice, brown, cooked": ~90g of carbs instead of ~280g, a 3x error, reported as HIGH
+ * confidence. It did the same to raw chicken breast (-> "roasted").
+ *
+ * So: the preparation state comes from the user's words, never the model's default.
+ */
+const PARSE_SYSTEM_RECIPE = [
+  "Convert a RECIPE INGREDIENT LIST into a structured food list.",
+  "",
+  "These are RAW, UNCOOKED ingredients as bought and measured — not a plate of food.",
+  "",
+  "For each ingredient emit exactly:",
+  "- query: a plain USDA-style ingredient name (e.g. 'rice, brown, long-grain, raw',",
+  "  'chicken, breast, raw', 'pasta, dry, enriched').",
+  "- qty: the NUMBER of units. Never null.",
+  "- unit: the unit AS STATED.",
+  "- source: the exact fragment of the input this ingredient came from, COPIED VERBATIM.",
+  "",
+  "RULES",
+  "1. NEVER add 'cooked', 'roasted', 'boiled' or 'prepared' unless the input says so.",
+  "   An ingredient list is raw/dry by default. Adding 'cooked' to rice or pasta changes",
+  "   the answer by ~3x, because cooked grains are mostly water.",
+  "2. Keep a stated weight or volume EXACTLY. It is the user's own measurement.",
+  "3. Never estimate grams. Never output calories or macros — a database supplies those.",
+  "4. If an ingredient has no stated quantity, still emit it with qty 1 and unit 'serving'.",
+  "   Do not invent a plausible amount; the caller detects this and reports it.",
+  "",
+  "EXAMPLES",
+  'Input: "3 lb chicken breast, 2 cups dry brown rice"',
+  'Output: [{"query":"chicken, broiler, breast, raw","qty":3,"unit":"lb","source":"3 lb chicken breast"},',
+  '         {"query":"rice, brown, long-grain, raw","qty":2,"unit":"cup","source":"2 cups dry brown rice"}]',
+  "",
+  'Input: "1.5 lb ground turkey, 2.5 cups pasta"',
+  'Output: [{"query":"turkey, ground, raw","qty":1.5,"unit":"lb","source":"1.5 lb ground turkey"},',
+  '         {"query":"pasta, dry, enriched","qty":2.5,"unit":"cup","source":"2.5 cups pasta"}]',
+  "",
+  'Input: "Green beans, olive oil + lemon"',
+  'Output: [{"query":"green beans, raw","qty":1,"unit":"serving","source":"Green beans"},',
+  '         {"query":"oil, olive","qty":1,"unit":"serving","source":"olive oil"},',
+  '         {"query":"lemon, raw","qty":1,"unit":"serving","source":"lemon"}]',
+].join("\n");
+
+/**
+ * "2 eggs and toast" -> [{query:'egg, whole, raw', qty:2, unit:'large', source:'2 eggs'}, ...]
+ *
+ * `mode` picks the domain. A recipe's ingredient list is raw and dry; a meal is cooked.
+ * Using the meal prompt on a recipe silently triples the carbs of every grain — see
+ * PARSE_SYSTEM_RECIPE.
+ */
+export async function parseFoodText(
+  text: string,
+  mode: "meal" | "recipe" = "meal",
+): Promise<ParsedFood[]> {
   const out = await chatJSON<{ items: ParsedFood[] }>(
     [
-      { role: "system", content: PARSE_SYSTEM },
+      { role: "system", content: mode === "recipe" ? PARSE_SYSTEM_RECIPE : PARSE_SYSTEM },
       { role: "user", content: text },
     ],
     PARSE_SCHEMA,

--- a/web/src/lib/nutrition/quantity.ts
+++ b/web/src/lib/nutrition/quantity.ts
@@ -1,0 +1,180 @@
+/**
+ * Quantities are TEXT, not inference.
+ *
+ * The pipeline's stated invariant is "the model never produces a macro number — USDA does".
+ * That was never enough, because the model still produced the two inputs that DETERMINE the
+ * macros: the food's identity and its quantity. Measured on qwen2.5vl:7b against a real
+ * recipe:
+ *
+ *   input:  "3 lb chicken breast, 2 cups dry brown rice, green beans, olive oil"
+ *   emits:  chicken breast, ROASTED      (the text said raw)
+ *           rice, brown, COOKED          (the text said DRY — a 3x carb error)
+ *           green bean, 1 SERVING        (no quantity was stated; it invented one)
+ *           olive oil                    (dropped entirely)
+ *
+ * The rice resolved to 90g of carbs instead of ~280g and was reported as HIGH confidence.
+ *
+ * "3 lb" and "2 cups" are literally written down. Reading them is a lexer's job, not a
+ * language model's. This module extracts a quantity from the user's own words so the model
+ * never has to repeat a number — because when it repeats one, it sometimes changes it.
+ *
+ * When no quantity is stated, that is reported as UNQUANTIFIED rather than papered over with
+ * an invented serving. An unquantified ingredient is a question for the user, not a guess.
+ */
+
+export interface LexedQuantity {
+  qty: number;
+  unit: string;
+  /** The literal text this came from, for the audit trail. */
+  source: string;
+}
+
+// Unicode fractions people actually type, plus the ascii ones.
+const VULGAR: Record<string, number> = {
+  "¼": 0.25,
+  "½": 0.5,
+  "¾": 0.75,
+  "⅓": 1 / 3,
+  "⅔": 2 / 3,
+  "⅛": 0.125,
+};
+
+// Units we can act on. Anything else (a "handful", a "bunch") is not a measurement we can
+// resolve, and is treated as unquantified rather than coerced into one.
+//
+// Mass/volume units pass straight through to fdc.ts's DIRECT_GRAMS or USDA portion tables.
+// Countable units ("large", "slice") are resolved against USDA's own portion data.
+const UNIT_ALIASES: Record<string, string> = {
+  g: "g",
+  gram: "g",
+  grams: "g",
+  gr: "g",
+  kg: "kg",
+  kilogram: "kg",
+  kilograms: "kg",
+  oz: "oz",
+  ounce: "oz",
+  ounces: "oz",
+  lb: "lb",
+  lbs: "lb",
+  pound: "lb",
+  pounds: "lb",
+  cup: "cup",
+  cups: "cup",
+  tbsp: "tbsp",
+  tablespoon: "tbsp",
+  tablespoons: "tbsp",
+  tsp: "tsp",
+  teaspoon: "tsp",
+  teaspoons: "tsp",
+  ml: "ml",
+  milliliter: "ml",
+  milliliters: "ml",
+  l: "l",
+  liter: "l",
+  liters: "l",
+  clove: "clove",
+  cloves: "clove",
+  slice: "slice",
+  slices: "slice",
+  large: "large",
+  medium: "medium",
+  small: "small",
+  each: "each",
+  can: "can",
+  cans: "can",
+  fillet: "fillet",
+  fillets: "fillet",
+  breast: "breast",
+  breasts: "breast",
+  thigh: "thigh",
+  thighs: "thigh",
+  drumstick: "drumstick",
+  drumsticks: "drumstick",
+  wing: "wing",
+  wings: "wing",
+};
+
+// number: "2", "2.5", "1/2", "1 1/2", "½", "1½"
+const NUMBER = String.raw`(\d+\s+\d+\/\d+|\d+\/\d+|\d*[¼½¾⅓⅔⅛]|\d+(?:\.\d+)?)`;
+const UNIT = String.raw`([a-zA-Z]+)`;
+
+const QTY_WITH_UNIT = new RegExp(String.raw`^\s*${NUMBER}\s*${UNIT}\b`, "u");
+const QTY_BARE = new RegExp(String.raw`^\s*${NUMBER}\s+`, "u");
+
+function parseNumber(raw: string): number | null {
+  const t = raw.trim();
+
+  // "1 1/2"
+  const mixed = /^(\d+)\s+(\d+)\/(\d+)$/.exec(t);
+  if (mixed) return Number(mixed[1]) + Number(mixed[2]) / Number(mixed[3]);
+
+  // "1/2"
+  const frac = /^(\d+)\/(\d+)$/.exec(t);
+  if (frac) return Number(frac[1]) / Number(frac[2]);
+
+  // "1½" / "½"
+  const vulgar = /^(\d*)([¼½¾⅓⅔⅛])$/u.exec(t);
+  if (vulgar) return (vulgar[1] ? Number(vulgar[1]) : 0) + VULGAR[vulgar[2]];
+
+  const n = Number(t);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/**
+ * Read a quantity off the front of an ingredient line.
+ *
+ * Returns null when the text states no quantity ("Green beans, olive oil + lemon") — that is
+ * a real answer, not a failure. The caller must NOT substitute a serving; it must say so.
+ *
+ *   "3 lb chicken breast"      -> { qty: 3,   unit: "lb"  }
+ *   "2 cups dry brown rice"    -> { qty: 2,   unit: "cup" }
+ *   "1/2 cup oats"             -> { qty: 0.5, unit: "cup" }
+ *   "12 drumsticks"            -> { qty: 12,  unit: "drumstick" }
+ *   "Green beans"              -> null
+ *   "a handful of spinach"     -> null   (not a measurement we can resolve)
+ */
+export function lexQuantity(text: string): LexedQuantity | null {
+  const t = text.trim();
+  if (!t) return null;
+
+  const withUnit = QTY_WITH_UNIT.exec(t);
+  if (withUnit) {
+    const qty = parseNumber(withUnit[1]);
+    const unit = UNIT_ALIASES[withUnit[2].toLowerCase()];
+    // A recognised number followed by a word we don't know as a unit is usually the food
+    // itself ("2 eggs", "3 bananas") — a bare count. Fall through to the bare-count branch.
+    if (qty !== null && unit) {
+      return { qty, unit, source: withUnit[0].trim() };
+    }
+  }
+
+  // A bare leading count: "2 eggs", "12 drumsticks". The unit is the food's own natural one,
+  // which USDA's portion table resolves ("1 large egg = 50g"). "each" is the honest label:
+  // we know HOW MANY, and we are not pretending to know how much each weighs.
+  const bare = QTY_BARE.exec(t);
+  if (bare) {
+    const qty = parseNumber(bare[1]);
+    if (qty !== null) return { qty, unit: "each", source: bare[1].trim() };
+  }
+
+  return null;
+}
+
+/**
+ * Split a recipe's ingredient text into individual ingredient fragments.
+ *
+ * Recipes are written as lines and comma-separated lists, and both matter:
+ *
+ *   "3 lb chicken breast, 2 cups dry brown rice
+ *    Green beans, olive oil + lemon"
+ *
+ * Splitting on "+" too would break "olive oil + lemon" into two, which is correct — they
+ * are two ingredients.
+ */
+export function splitIngredients(text: string): string[] {
+  return text
+    .split(/[\n,+]/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}

--- a/web/src/lib/nutrition/recipe-macros.ts
+++ b/web/src/lib/nutrition/recipe-macros.ts
@@ -44,6 +44,8 @@ export interface RecipeMacros {
   items: ResolvedIngredient[];
   /** Ingredients with no stated amount. Non-empty means the total is soft — go fix the text. */
   unquantified: string[];
+  /** Ingredients that matched no plausible USDA record and are ABSENT from the total. */
+  unmatched: string[];
   /** Hint only — what a portion would look like IF split this many ways. Not a claim. */
   typicalPortions: number | null;
   perPortion: Omit<RecipeMacroTotals, "confidence" | "notes"> | null;
@@ -135,7 +137,11 @@ export async function resolveRecipeMacros(
       macros_computed_at: new Date().toISOString(),
       // Persist the working, not just the answer. Without this the only way to find out that
       // the rice had been resolved as COOKED was to reverse-engineer it from the carb count.
-      metadata: { macro_items: items, macro_notes: total.notes },
+      metadata: {
+        macro_items: items,
+        macro_notes: total.notes,
+        macro_unmatched: estimate.unmatched,
+      },
     })
     .eq("id", recipeId)
     .eq("user_id", userId);
@@ -147,6 +153,7 @@ export async function resolveRecipeMacros(
     total,
     items,
     unquantified,
+    unmatched: estimate.unmatched,
     typicalPortions,
     perPortion: typicalPortions ? perPortion(total, typicalPortions) : null,
   };

--- a/web/src/lib/nutrition/recipe-macros.ts
+++ b/web/src/lib/nutrition/recipe-macros.ts
@@ -25,8 +25,25 @@ export interface RecipeMacroTotals {
   notes: string;
 }
 
+/** One resolved ingredient — the audit trail. A number you cannot audit is a number you
+ *  cannot trust, and this is what makes the total checkable instead of hopeful. */
+export interface ResolvedIngredient {
+  input: string;
+  matched: string;
+  fdcId: number;
+  grams: number;
+  /** false when the text stated no amount and one was guessed. */
+  quantified: boolean;
+  /** How the grams were derived, e.g. "USDA portion: 1 cup = 195g". */
+  basis: string;
+}
+
 export interface RecipeMacros {
   total: RecipeMacroTotals;
+  /** Every ingredient, what USDA record it matched, and how its grams were arrived at. */
+  items: ResolvedIngredient[];
+  /** Ingredients with no stated amount. Non-empty means the total is soft — go fix the text. */
+  unquantified: string[];
   /** Hint only — what a portion would look like IF split this many ways. Not a claim. */
   typicalPortions: number | null;
   perPortion: Omit<RecipeMacroTotals, "confidence" | "notes"> | null;
@@ -73,7 +90,10 @@ export async function resolveRecipeMacros(
   // The recipe NAME is passed as the label, not as food to parse — naming the dish helps
   // the identifier disambiguate ("Greek Salmon" -> salmon, not a generic fish), while the
   // ingredient list remains the only thing quantities are read from.
-  const estimate = await estimateFromText(ingredients, recipe.name as string);
+  // "recipe" mode, NOT the meal prompt. A recipe's ingredients are raw and dry; the meal
+  // prompt's examples all say "cooked", and fed a recipe it rewrote "2 cups dry brown rice"
+  // to cooked rice — ~90g of carbs instead of ~280g, reported as HIGH confidence.
+  const estimate = await estimateFromText(ingredients, recipe.name as string, "recipe");
 
   const total: RecipeMacroTotals = {
     calories: Math.round(estimate.totals.calories),
@@ -93,6 +113,16 @@ export async function resolveRecipeMacros(
     );
   }
 
+  const items: ResolvedIngredient[] = estimate.items.map((i) => ({
+    input: i.input,
+    matched: i.matched,
+    fdcId: i.fdcId,
+    grams: i.grams,
+    quantified: i.quantified,
+    basis: i.basis,
+  }));
+  const unquantified = items.filter((i) => !i.quantified).map((i) => i.input);
+
   const { error: writeErr } = await db
     .from("recipes")
     .update({
@@ -103,6 +133,9 @@ export async function resolveRecipeMacros(
       fiber_g: total.fiber_g,
       macros_confidence: total.confidence,
       macros_computed_at: new Date().toISOString(),
+      // Persist the working, not just the answer. Without this the only way to find out that
+      // the rice had been resolved as COOKED was to reverse-engineer it from the carb count.
+      metadata: { macro_items: items, macro_notes: total.notes },
     })
     .eq("id", recipeId)
     .eq("user_id", userId);
@@ -112,6 +145,8 @@ export async function resolveRecipeMacros(
   const typicalPortions = (recipe.typical_portions as number | null) ?? null;
   return {
     total,
+    items,
+    unquantified,
     typicalPortions,
     perPortion: typicalPortions ? perPortion(total, typicalPortions) : null,
   };

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -6,6 +6,9 @@
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
+    // The unit tests run under `node --experimental-strip-types`, which requires the .ts
+    // extension on relative imports. Safe here because noEmit is true.
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
The pipeline's guarantee was *"the model never produces a macro number — USDA does."* That was true, and it was never enough. **The model still produced the two inputs that determine the macros, and it altered both.**

Measured on `qwen2.5vl:7b` against a real recipe:

```
in:   "3 lb chicken breast, 2 cups dry brown rice, Green beans, olive oil"

out:   chicken breast, ROASTED     <- the text said raw
       rice, brown, COOKED         <- the text said DRY
       green bean, 1 SERVING       <- no quantity was stated; it invented one
       (olive oil: dropped entirely)
```

Cooked grains are mostly water, so the rice resolved to **~90 g of carbs instead of ~280 g**. A 3× error — and it was reported as **`high` confidence**, because confidence measured whether USDA happened to publish a portion table. That is a fact about USDA's data, not about whether the answer is right. A wrong number wearing a confident badge is worse than an honest "I guessed".

## Four structural fixes

**1. Quantities are text, not inference.** New `quantity.ts` lexes `3 lb` / `2 cups` / `1 1/2` / `½` out of the user's own words. The model echoes the fragment it read (`source`) and we read the number ourselves. It is never trusted to repeat a number, because when it repeats one it sometimes changes it.

This just extends the rule the codebase already had — *"it was measured 2× off on portion weight, so it is never asked to weigh"* — to its logical end: it shouldn't be **repeating** weights either. (The old code even admitted this: *"told only in prose to keep stated weights, the model still turned 'about 6oz of chicken' into qty=1 unit='medium'"*. Worked examples were a patch; a lexer is the fix.)

**2. Unquantified ingredients are reported, not invented.** "Green beans" with no amount is a question for the user, not a guess. Named explicitly, so you know which line to go and fix.

**3. Recipes get their own prompt.** A meal is a plate of COOKED food and every example in the meal prompt says so. A recipe's ingredient list is a tray of RAW, DRY ingredients. Reusing the meal prompt for recipes was the root cause of the rice. The model is now forbidden from adding cooked/roasted unless the text says it.

**4. Confidence stops lying.** Any ingredient whose amount we had to invent makes `high` unreachable.

Plus: **the working is persisted.** Every ingredient records its USDA match, its grams, and how they were derived (`"USDA portion: 1 cup = 195g"`). *A number you cannot audit is a number you cannot trust* — and without it, the only way to discover the rice was resolved as cooked was to reverse-engineer it from the carb count.

## The audit trail immediately exposed a second bug

Which is the point of it. The model picks from a USDA candidate list, and when the search returns nothing relevant it picks the least-bad of a bad set — **silently**:

```
"salt"         -> "Syrups, table blends, pancake"    20g of SYRUP in a zero-calorie
                                                     ingredient. It INVENTS calories.
"broccolini"   -> "Abiyuch, raw"                     a tropical fruit
"marinara"     -> "Cheese sauce, prepared from recipe"
```

No prompt fixes this — the right answer was never in the list. So the guard is arithmetic, and it took three iterations, each one found by the audit trail showing the next failure:

1. **Reject zero-overlap matches** → killed salt→syrup, broccolini→abiyuch.
2. **A category word is not evidence** → marinara was still matching *cheese sauce* on the shared word "sauce". The query must match on a **distinctive** word.
3. **Branded/restaurant records are not ingredients** → marinara then matched *"OLIVE GARDEN, cheese ravioli with marinara sauce"*. USDA has no plain marinara, so the best hit was a restaurant entrée.

Where nothing plausible remains, the ingredient is **reported as unmatched and absent from the total**. Matching nothing beats matching syrup: salt genuinely has no macros; a bogus match invents some.

## Verified on the real recipe library

| Recipe | kcal | P | C | F | conf | absent |
|---|---:|---:|---:|---:|---|---|
| Chicken, Rice, Green Beans | 2810 | 315 | **242** | 57 | medium | — |
| Lemon Garlic Chicken + Pasta | 4646 | 463 | 124 | 250 | medium | — |
| Ribeye Roast Meal Prep | 3884 | 257 | **3.9** | 310 | medium | salt, broccolini |
| Turkey Pasta | 1623 | 155 | 125 | 55 | medium | marinara |

- Rice: **103 g carbs at `high`** → **242 g at `medium`**. Right, and honest about why.
- Ribeye: **109.6 g carbs → 3.9 g** once the pancake syrup was evicted.
- Nothing reports `high` any more, correctly: every one of these recipes has an ingredient with no written amount.

**(1) and (4) fix the meal logger too**, not just recipes — the same quantity-invention and the same meaningless confidence flag were in the photo/text path used every day.

10 unit tests (`src/__tests__/quantity.test.ts`) pin the lexer, the refusal to invent, and all three selection guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gkXP7WF4yaHcRWCFBEqAX
