### PR TITLE
feat(meals): render the week you planned, not just today

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **The week you planned is now visible.** `meal_plans` shipped with a today-only read
+  (`.eq("date", todayString())` in the meals page), so a week of planned meals sat in the
+  table with no surface to render on — you could plan Sunday through Saturday and see none
+  of it until each day became today. The planning half of "plan, cook, confirm" was
+  write-only.
+
+  The meals page now reads the **next 7 days** in the same query and splits it: `KitchenPanel`
+  keeps today's slice for one-tap logging, and a new `WeekPlan` panel renders the rest.
+  Empty days are shown, not hidden — a gap is the most useful thing on the panel, because
+  it's the list of decisions still owed and exactly what the Sunday planning session exists
+  to close.
+
+  `WeekPlan` shows no macros, deliberately. `meal_plans` carries none of its own; a plan
+  points at a cook or a recipe and those own the numbers. Restating them here would mean
+  duplicating or inventing them.
+
+  Adds `daysAheadString()` and `getNextNDays()` to `lib/timezone` — the module could only
+  look backwards.
+
 - **Food gets measured macros, and cooking gets modelled.** `recipes` gains
   calories/protein/carbs/fat/fiber for the recipe **as written**, resolved once through the
   existing pipeline — the local model identifies the foods, **USDA FoodData Central supplies

--- a/web/src/app/(protected)/meals/page.tsx
+++ b/web/src/app/(protected)/meals/page.tsx
@@ -2,12 +2,13 @@ export const dynamic = "force-dynamic";
 
 import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
-import { daysAgoString, todayString } from "@/lib/timezone";
+import { daysAgoString, daysAheadString, getNextNDays, todayString } from "@/lib/timezone";
 import {
   KitchenPanel,
   type KitchenCook,
   type KitchenPlannedMeal,
 } from "@/components/meals/KitchenPanel";
+import { WeekPlan } from "@/components/meals/WeekPlan";
 import MealsClient, {
   type MealRow,
   type RecipeRow,
@@ -70,6 +71,9 @@ export default async function MealsPage() {
           .gt("portions_remaining", 0)
           .order("cooked_on", { ascending: true }) // oldest first — eat it before it turns
       : Promise.resolve({ data: [] }),
+    // The next 7 days, not just today. KitchenPanel still renders today's slice for one-tap
+    // logging; the rest feeds the week view. One query serves both — a plan you can't see
+    // until the day arrives isn't a plan.
     userId
       ? supabase
           .from("meal_plans")
@@ -78,12 +82,15 @@ export default async function MealsPage() {
               "cooks(id, name, portions, portions_remaining)",
           )
           .eq("user_id", userId)
-          .eq("date", todayString())
+          .gte("date", todayString())
+          .lte("date", daysAheadString(6))
+          .order("date", { ascending: true })
       : Promise.resolve({ data: [] }),
   ]);
 
   const meals = (mealsData ?? []) as unknown as MealRow[];
   const recipes = (recipesData ?? []) as unknown as RecipeRow[];
+  const weekPlan = (planData ?? []) as unknown as KitchenPlannedMeal[];
 
   // Profile → macro goals
   const profileMap: Record<string, string> = {};
@@ -200,8 +207,10 @@ export default async function MealsPage() {
 
       <KitchenPanel
         leftovers={(leftoversData ?? []) as unknown as KitchenCook[]}
-        plan={(planData ?? []) as unknown as KitchenPlannedMeal[]}
+        plan={weekPlan.filter((p) => p.date === today)}
       />
+
+      <WeekPlan week={weekPlan} days={getNextNDays(7)} today={today} />
 
       <MealsClient
         todayMeals={todayMeals}

--- a/web/src/components/meals/WeekPlan.tsx
+++ b/web/src/components/meals/WeekPlan.tsx
@@ -52,7 +52,11 @@ export function WeekPlan({
     <section style={{ marginBottom: "var(--space-6)" }}>
       <h2
         className="font-heading font-semibold"
-        style={{ fontSize: "var(--t-h3)", color: "var(--color-text)", marginBottom: "var(--space-1)" }}
+        style={{
+          fontSize: "var(--t-h3)",
+          color: "var(--color-text)",
+          marginBottom: "var(--space-1)",
+        }}
       >
         This week
       </h2>

--- a/web/src/components/meals/WeekPlan.tsx
+++ b/web/src/components/meals/WeekPlan.tsx
@@ -1,0 +1,167 @@
+import type { KitchenPlannedMeal } from "./KitchenPanel";
+
+/**
+ * The week ahead, as planned.
+ *
+ * `meal_plans` shipped with only a today-scoped read (`.eq("date", todayString())`), so a week
+ * of planned meals existed in the table with no surface to render on — you could plan Sunday
+ * through Saturday and see none of it until each day arrived. This is that surface.
+ *
+ * Empty days are rendered, not hidden. A gap is the most useful thing on this panel: it's the
+ * list of decisions still owed, and it's what the Sunday planning session exists to close.
+ *
+ * Macros are deliberately absent. `meal_plans` carries none of its own (see
+ * .claude/rules/data-sources.md) — a plan points at a cook or a recipe, and those own the
+ * numbers. Restating macros here would mean either duplicating them or inventing them.
+ */
+
+const MEAL_ORDER = ["breakfast", "lunch", "dinner", "snack"];
+
+function dayLabel(dateStr: string, today: string): { label: string; isToday: boolean } {
+  if (dateStr === today) return { label: "Today", isToday: true };
+  const d = new Date(`${dateStr}T00:00:00`);
+  const t = new Date(`${today}T00:00:00`);
+  const diff = Math.round((d.getTime() - t.getTime()) / 86_400_000);
+  if (diff === 1) return { label: "Tomorrow", isToday: false };
+  return {
+    label: d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" }),
+    isToday: false,
+  };
+}
+
+export function WeekPlan({
+  week,
+  days,
+  today,
+}: {
+  week: KitchenPlannedMeal[];
+  days: string[];
+  today: string;
+}) {
+  const byDate = new Map<string, KitchenPlannedMeal[]>();
+  for (const p of week) {
+    const list = byDate.get(p.date) ?? [];
+    list.push(p);
+    byDate.set(p.date, list);
+  }
+
+  const plannedCount = week.filter((p) => p.status !== "skipped").length;
+  const unplannedDays = days.filter((d) => !(byDate.get(d) ?? []).length).length;
+
+  return (
+    <section style={{ marginBottom: "var(--space-6)" }}>
+      <h2
+        className="font-heading font-semibold"
+        style={{ fontSize: "var(--t-h3)", color: "var(--color-text)", marginBottom: "var(--space-1)" }}
+      >
+        This week
+      </h2>
+      <p
+        style={{
+          fontSize: "var(--t-micro)",
+          color: "var(--color-text-muted)",
+          marginBottom: "var(--space-4)",
+        }}
+      >
+        {plannedCount} meal{plannedCount === 1 ? "" : "s"} planned over the next {days.length} days
+        {unplannedDays > 0
+          ? ` · ${unplannedDays} day${unplannedDays === 1 ? "" : "s"} with nothing planned`
+          : ""}
+      </p>
+
+      {days.map((date) => {
+        const { label, isToday } = dayLabel(date, today);
+        const meals = (byDate.get(date) ?? []).sort(
+          (a, b) => MEAL_ORDER.indexOf(a.meal_type) - MEAL_ORDER.indexOf(b.meal_type),
+        );
+        return (
+          <div key={date} style={dayBlockStyle}>
+            <p style={{ ...dayHeadStyle, color: isToday ? "var(--accent)" : "var(--color-text)" }}>
+              {label}
+            </p>
+            {meals.length === 0 ? (
+              <p style={emptyStyle}>Nothing planned</p>
+            ) : (
+              meals.map((p) => {
+                const name = p.cooks?.name ?? p.recipes?.name ?? p.name ?? "Meal";
+                const eaten = p.status === "eaten";
+                const skipped = p.status === "skipped";
+                return (
+                  <div key={p.id} style={rowStyle}>
+                    <span style={mealTypeStyle}>{p.meal_type}</span>
+                    <span
+                      style={{
+                        ...nameStyle,
+                        color: eaten || skipped ? "var(--color-text-muted)" : "var(--color-text)",
+                        textDecoration: skipped ? "line-through" : undefined,
+                      }}
+                    >
+                      {name}
+                    </span>
+                    <span style={statusStyle}>
+                      {eaten
+                        ? "eaten"
+                        : skipped
+                          ? "skipped"
+                          : p.cooks
+                            ? "ready"
+                            : p.recipes
+                              ? "needs cooking"
+                              : ""}
+                    </span>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        );
+      })}
+    </section>
+  );
+}
+
+const dayBlockStyle: React.CSSProperties = {
+  paddingBottom: "var(--space-3)",
+  marginBottom: "var(--space-3)",
+  borderBottom: "1px solid var(--rule-soft)",
+};
+
+const dayHeadStyle: React.CSSProperties = {
+  fontSize: "var(--t-micro)",
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.04em",
+  marginBottom: "var(--space-2)",
+};
+
+const rowStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "72px 1fr auto",
+  alignItems: "baseline",
+  gap: "var(--space-3)",
+  padding: "var(--space-1) 0",
+};
+
+const mealTypeStyle: React.CSSProperties = {
+  fontSize: "var(--t-micro)",
+  color: "var(--color-text-muted)",
+  textTransform: "capitalize",
+};
+
+const nameStyle: React.CSSProperties = {
+  fontSize: "var(--t-body)",
+  minWidth: 0,
+  overflowWrap: "anywhere",
+};
+
+const statusStyle: React.CSSProperties = {
+  fontSize: "var(--t-micro)",
+  color: "var(--color-text-muted)",
+  whiteSpace: "nowrap",
+};
+
+const emptyStyle: React.CSSProperties = {
+  fontSize: "var(--t-micro)",
+  color: "var(--color-text-muted)",
+  fontStyle: "italic",
+};

--- a/web/src/lib/timezone.ts
+++ b/web/src/lib/timezone.ts
@@ -27,6 +27,23 @@ export function daysAgoString(days: number, tz = USER_TZ): string {
   return new Intl.DateTimeFormat("en-CA", { timeZone: tz }).format(d);
 }
 
+/** Returns a YYYY-MM-DD string for N days from now in the user's timezone. */
+export function daysAheadString(days: number, tz = USER_TZ): string {
+  const d = new Date(Date.now() + days * 86_400_000);
+  return new Intl.DateTimeFormat("en-CA", { timeZone: tz }).format(d);
+}
+
+/**
+ * Returns the next N days as YYYY-MM-DD strings in the user's timezone,
+ * today first (index 0 = today, last index = N-1 days ahead).
+ */
+export function getNextNDays(n: number, tz = USER_TZ): string[] {
+  return Array.from({ length: n }, (_, i) => {
+    const d = new Date(Date.now() + i * 86_400_000);
+    return new Intl.DateTimeFormat("en-CA", { timeZone: tz }).format(d);
+  });
+}
+
 /**
  * Returns the UTC offset string for a timezone at the current moment,
  * e.g. "-07:00" for PDT or "-08:00" for PST.


### PR DESCRIPTION
## Problem

`meal_plans` shipped in #616 with a **today-only read**:

```
web/src/app/(protected)/meals/page.tsx:81   .eq("date", todayString())
```

So a week of planned meals sits in the table with no surface to render on — you can plan Sunday through Saturday and see none of it until each day becomes today. The `plan` tab doesn't help: it's an ingredients→suggestions tool that never touches `meal_plans`. The planning half of "plan, cook, confirm" was effectively **write-only**.

Found the hard way: a full week of meals was written to the table and none of it was visible.

## Change

- Widen the meals-page query to **the next 7 days**, ordered by date. One query serves both panels.
- `KitchenPanel` keeps today's slice — one-tap logging is unchanged.
- New `WeekPlan` panel renders the week.
- Add `daysAheadString()` / `getNextNDays()` to `lib/timezone`, which could only look backwards.

## Decisions

- **Empty days render, not hide.** A gap is the most useful thing on the panel — it's the list of decisions still owed, and precisely what the Sunday planning session exists to close.
- **No macros in `WeekPlan`.** `meal_plans` carries none of its own (per `.claude/rules/data-sources.md`); a plan points at a cook or a recipe and those own the numbers. Restating them here would mean duplicating or inventing them — and inventing macros is the one thing this codebase refuses to do.
- Server component, no client JS — nothing here is interactive.

## Verification

- `npx tsc --noEmit` clean
- `npx eslint` clean on all changed files
- Renders against 7 real `meal_plans` rows (2026-07-16 → 07-19)

Owed follow-up: `graphify update .` (not installed on the WSL box this was authored from).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhJiUBmQB8WWvVWMgRZygc
