### PR TITLE
feat(meals): let the plan hear that things did not go to plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **A plan you can contradict.** `POST /api/meals/eat` requires a `cook_id` — it exists to log
+  macros that are already known. But most planned meals point at no cook: a recipe not yet
+  made, or freeform text. Those could be marked **nothing at all**, so `meal_plans` could
+  only ever describe intent, never outcome — and a day you ate something else looked
+  identical to a day that never happened.
+
+  Adds `PATCH /api/meal-plan` (`{id, status}` → `planned` | `eaten` | `skipped`) and
+  **Ate it / Skip** buttons on every planned meal in `KitchenPanel`. Cook-backed meals keep
+  the existing "Ate this", which also decrements the fridge; everything else records the
+  outcome without inventing macros for it.
+
+  A skip is data, not a failure — it's how the plan finds out it was wrong, and a plan nobody
+  can contradict is a plan nobody corrects. It gets a quiet button, not a red one.
+
 - **The coaching loop answers back.** 33 `workout_plans` were written between May and June
   2026 and never once opened; the user logged 7 sessions with real notes and the system
   responded with nothing. An unrewarded loop decays, and this one did — training stopped

--- a/web/src/app/api/meal-plan/route.ts
+++ b/web/src/app/api/meal-plan/route.ts
@@ -44,3 +44,61 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: msg }, { status: 500 });
   }
 }
+
+const STATUSES = ["planned", "eaten", "skipped"] as const;
+type PlanStatus = (typeof STATUSES)[number];
+
+/**
+ * Record what actually happened to a planned meal.
+ *
+ * `POST /api/meals/eat` requires a `cook_id` — it exists to log macros that are already known.
+ * But most planned meals point at no cook: they're a recipe not yet made, or freeform text.
+ * Those had no way to be marked anything at all, so the plan could only ever describe intent,
+ * never outcome, and every unlogged day looked identical to a day that never happened.
+ *
+ * This carries no macros and logs no meal. It records a decision. A skipped meal is data —
+ * it's how the plan learns it was wrong, and a plan nobody can contradict is a plan nobody
+ * corrects. For a cook-backed meal prefer /api/meals/eat, which also decrements the fridge.
+ */
+export async function PATCH(req: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  let body: { id?: string; status?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!body.id) return NextResponse.json({ error: "id is required" }, { status: 400 });
+  if (!STATUSES.includes(body.status as PlanStatus)) {
+    return NextResponse.json(
+      { error: `status must be one of: ${STATUSES.join(", ")}` },
+      { status: 400 },
+    );
+  }
+
+  try {
+    // Service client bypasses RLS, so user_id is the ownership check — not decoration.
+    const db = createServiceClient();
+    const { data, error } = await db
+      .from("meal_plans")
+      .update({ status: body.status })
+      .eq("id", body.id)
+      .eq("user_id", user.id)
+      .select("id, status")
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    if (!data) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+    return NextResponse.json({ meal: data });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Failed to update meal plan";
+    console.error("[PATCH /api/meal-plan]", err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/web/src/components/meals/KitchenPanel.tsx
+++ b/web/src/components/meals/KitchenPanel.tsx
@@ -99,6 +99,31 @@ export function KitchenPanel({ leftovers, plan }: KitchenPanelProps) {
     }
   }
 
+  // Outcome without macros. `eat()` above needs a cook, because it logs known numbers into
+  // meal_log. Most planned meals have no cook — a recipe not yet made, or freeform text — and
+  // those could previously be neither confirmed nor declined. Things don't go to plan; the plan
+  // has to be able to hear about it.
+  async function mark(planId: string, status: "eaten" | "skipped") {
+    setBusyId(planId);
+    setError(null);
+    try {
+      const res = await fetch("/api/meal-plan", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: planId, status }),
+      });
+      if (!res.ok) {
+        setError((await res.json()).error ?? "Couldn't update that");
+        return;
+      }
+      router.refresh();
+    } catch {
+      setError("Couldn't update that");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
   const todaysPlan = plan
     .filter((p) => p.status === "planned")
     .sort((a, b) => MEAL_ORDER.indexOf(a.meal_type) - MEAL_ORDER.indexOf(b.meal_type));
@@ -157,20 +182,44 @@ export function KitchenPanel({ leftovers, plan }: KitchenPanelProps) {
                     {!cook && !p.recipes ? " · off-plan" : ""}
                   </span>
                 </div>
-                {canEat ? (
+                <div style={{ display: "flex", gap: "var(--space-2)", flexShrink: 0 }}>
+                  {canEat ? (
+                    // Cook-backed: log the known macros AND decrement the fridge.
+                    <button
+                      type="button"
+                      disabled={busyId === p.id}
+                      onClick={() => eat(cook.id, { mealType: p.meal_type, mealPlanId: p.id })}
+                      style={eatButtonStyle(busyId === p.id)}
+                    >
+                      {busyId === p.id ? "Logging…" : "Ate this"}
+                    </button>
+                  ) : (
+                    // No cook — nothing to decrement and no macros to log, but the outcome is
+                    // still worth recording. Confirming intent beats leaving the row silent.
+                    <button
+                      type="button"
+                      disabled={busyId === p.id}
+                      onClick={() => mark(p.id, "eaten")}
+                      style={eatButtonStyle(busyId === p.id)}
+                      title={
+                        p.recipes
+                          ? "Marks it eaten. Not cooked, so no macros are logged."
+                          : "Marks it eaten. No macros are logged."
+                      }
+                    >
+                      {busyId === p.id ? "Saving…" : "Ate it"}
+                    </button>
+                  )}
                   <button
                     type="button"
                     disabled={busyId === p.id}
-                    onClick={() => eat(cook.id, { mealType: p.meal_type, mealPlanId: p.id })}
-                    style={eatButtonStyle(busyId === p.id)}
+                    onClick={() => mark(p.id, "skipped")}
+                    style={skipButtonStyle(busyId === p.id)}
+                    title="Didn't eat this. A skip is data — it's how the plan finds out it was wrong."
                   >
-                    {busyId === p.id ? "Logging…" : "Ate this"}
+                    Skip
                   </button>
-                ) : (
-                  // A planned recipe isn't eatable until it's been cooked — a cook is what
-                  // gives it portions and macros. Don't offer a button that can't work.
-                  <span style={subStyle}>{p.recipes ? "not cooked yet" : "—"}</span>
-                )}
+                </div>
               </div>
             );
           })}
@@ -243,6 +292,25 @@ const subStyle: React.CSSProperties = {
   color: "var(--color-text-muted)",
   marginTop: 2,
 };
+
+// Skipping is a legitimate outcome, not a failure — it gets a quiet button, not a red one.
+function skipButtonStyle(pending: boolean): React.CSSProperties {
+  return {
+    fontFamily: "var(--font-body), system-ui, sans-serif",
+    fontSize: "var(--t-micro)",
+    fontWeight: 500,
+    color: "var(--color-text-muted)",
+    background: "transparent",
+    border: "1px solid var(--rule-soft)",
+    borderRadius: "var(--r-1)",
+    padding: "0 var(--space-3)",
+    minHeight: 36,
+    flexShrink: 0,
+    cursor: pending ? "wait" : "pointer",
+    opacity: pending ? 0.5 : 1,
+    transition: "opacity var(--motion-fast) var(--ease-out-quart)",
+  };
+}
 
 function eatButtonStyle(pending: boolean): React.CSSProperties {
   return {


### PR DESCRIPTION
## Problem

`POST /api/meals/eat` requires a `cook_id` — it exists to log macros that are already known. But most planned meals point at **no cook**: a recipe not yet made, or freeform text like "3 eggs + spinach". Those could be marked **nothing at all**.

`KitchenPanel` rendered them with a dead `—` and no button:

```tsx
// A planned recipe isn't eatable until it's been cooked — a cook is what
// gives it portions and macros. Don't offer a button that can't work.
<span style={subStyle}>{p.recipes ? "not cooked yet" : "—"}</span>
```

That reasoning is right about macros and wrong about outcomes. `meal_plans` could only ever describe **intent, never outcome** — so a day you ate something else looked identical to a day that never happened, and `status` had `eaten`/`skipped` values nothing could ever set from the UI.

## Change

- `PATCH /api/meal-plan` — `{id, status}` → `planned` | `eaten` | `skipped`. Carries no macros, logs no meal. Records a decision. Service client, so `user_id` is the real ownership check.
- **Ate it / Skip** buttons on every planned meal in `KitchenPanel`.
- Cook-backed meals keep **"Ate this"** (`/api/meals/eat`) — that path also decrements the fridge and logs real macros, so it stays preferred where it applies.

## Decisions

- **A skip is data, not a failure.** It's how the plan finds out it was wrong; a plan nobody can contradict is a plan nobody corrects. Quiet bordered button, not a red one.
- **No macros invented for freeform meals.** Marking "3 eggs" eaten records the outcome and nothing else. Guessing what went in is the one thing this codebase refuses to do.
- Buttons live in `KitchenPanel` (today) rather than `WeekPlan` (server component, and marking Thursday's dinner eaten on Monday isn't a real workflow). `WeekPlan` already renders the resulting status.

## Verification

- `npx tsc --noEmit` clean
- `npx eslint` clean
- `npx prettier --check .` clean (the CI job named `eslint` also runs `format:check` — worth knowing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhJiUBmQB8WWvVWMgRZygc
