### PR TITLE
feat(meals): recipe-backed plans log their macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **A recipe-backed plan now logs its macros.** `PATCH /api/meal-plan` (above) records that a
+  planned meal happened, but logs no macros — right for freeform text, wrong for a meal you
+  actually cooked from a recipe whose macros are already known. So marking "3 eggs + spinach"
+  eaten flipped a status and left the day's totals at zero: you did what the plan said and got
+  nothing back, which is the same unrewarded loop that killed meal logging in May.
+
+  `POST /api/meals/eat` now accepts `recipe_id` as an alternative to `cook_id`, backed by a new
+  `eatFromRecipe` (`web/src/lib/nutrition/cooks.ts`): it creates a `cook` from the recipe and
+  eats a portion in one call, so the macros land in `meal_log` and any surplus becomes
+  leftovers. A recipe is "one time you made food" the moment you eat it. In `KitchenPanel`, a
+  recipe-backed plan with resolved macros now shows **"Ate this"** (logs macros) instead of the
+  macro-less "Ate it"; a name-only recipe stub still falls back to the status-only path, since
+  there is nothing to log. `meal_plans` and the plan API now surface `recipes.macros_computed_at`
+  so the panel can tell a real recipe from a stub.
+
+### Fixed
+
+- **`bunch` / `package` no longer resolve to the wrong weight.** `lexQuantity` documented
+  "bunch" as unresolvable but didn't treat it that way: a number before any unrecognized unit
+  fell through to the bare-count branch, so `1/2 bunch spinach` became `qty 0.5, unit "each"`
+  and silently resolved against whatever spinach portion USDA returned first — a wrong number
+  wearing a confident badge, exactly the failure mode the quantity lexer exists to prevent.
+  These are real USDA portion descriptors (`1 bunch spinach = 340g`, `1 package (10 oz) = 284g`),
+  so they now pass through to `gramsFor` like `large` does for eggs. Added: `bunch`, `package`,
+  `bag`, `head`, `stalk`, `sprig`. A bare `handful` (no USDA portion) is still unquantified.
+
 - **A plan you can contradict.** `POST /api/meals/eat` requires a `cook_id` — it exists to log
   macros that are already known. But most planned meals point at no cook: a recipe not yet
   made, or freeform text. Those could be marked **nothing at all**, so `meal_plans` could

--- a/web/src/app/(protected)/meals/page.tsx
+++ b/web/src/app/(protected)/meals/page.tsx
@@ -78,7 +78,8 @@ export default async function MealsPage() {
       ? supabase
           .from("meal_plans")
           .select(
-            "id, date, meal_type, portions, status, name, recipes(id, name), " +
+            "id, date, meal_type, portions, status, name, " +
+              "recipes(id, name, calories, macros_computed_at), " +
               "cooks(id, name, portions, portions_remaining)",
           )
           .eq("user_id", userId)

--- a/web/src/app/api/meal-plan/route.ts
+++ b/web/src/app/api/meal-plan/route.ts
@@ -28,7 +28,7 @@ export async function GET(req: NextRequest) {
       .from("meal_plans")
       .select(
         "id, date, meal_type, portions, status, name, notes, " +
-          "recipes(id, name), " +
+          "recipes(id, name, calories, macros_computed_at), " +
           "cooks(id, name, portions, portions_remaining)",
       )
       .eq("user_id", user.id)

--- a/web/src/app/api/meals/eat/route.ts
+++ b/web/src/app/api/meals/eat/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { createServiceClient } from "@/lib/supabase/service";
-import { eatFromCook } from "@/lib/nutrition/cooks";
+import { eatFromCook, eatFromRecipe } from "@/lib/nutrition/cooks";
 
 /**
  * "I ate this." One tap: the macros are already known, so there is no photo, no local model
@@ -10,6 +10,13 @@ import { eatFromCook } from "@/lib/nutrition/cooks";
  *
  * This route is the entire reason the cooks model exists. Every prepped meal previously cost
  * a photo -> parse -> USDA cycle; three of those a day is what made meal logging stop.
+ *
+ * Two ways in, both landing in meal_log with USDA-derived macros:
+ *   cook_id    — eat a portion of food that already exists (leftovers). No cooking.
+ *   recipe_id  — eat a recipe-backed planned meal: cook it (one tap), then eat a portion,
+ *                the surplus becoming leftovers. This is what lets a recipe-backed plan log
+ *                macros at all; before it, "Ate it" on such a plan recorded a status and no
+ *                numbers, so eating to plan and eating nothing looked the same in the totals.
  */
 export async function POST(req: NextRequest) {
   const supabase = await createClient();
@@ -20,6 +27,7 @@ export async function POST(req: NextRequest) {
 
   let body: {
     cook_id?: string;
+    recipe_id?: string;
     portions?: number;
     meal_type?: string;
     date?: string;
@@ -32,25 +40,35 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  if (!body.cook_id) {
-    return NextResponse.json({ error: "cook_id is required" }, { status: 400 });
+  if (!body.cook_id && !body.recipe_id) {
+    return NextResponse.json({ error: "cook_id or recipe_id is required" }, { status: 400 });
   }
 
   try {
     const db = createServiceClient();
-    const result = await eatFromCook(db, user.id, {
-      cookId: body.cook_id,
-      portions: body.portions,
-      mealType: body.meal_type,
-      date: body.date,
-      mealPlanId: body.meal_plan_id ?? null,
-      notes: body.notes,
-    });
+    const result = body.cook_id
+      ? await eatFromCook(db, user.id, {
+          cookId: body.cook_id,
+          portions: body.portions,
+          mealType: body.meal_type,
+          date: body.date,
+          mealPlanId: body.meal_plan_id ?? null,
+          notes: body.notes,
+        })
+      : await eatFromRecipe(db, user.id, {
+          recipeId: body.recipe_id!,
+          portionsEaten: body.portions,
+          mealType: body.meal_type,
+          date: body.date,
+          mealPlanId: body.meal_plan_id ?? null,
+          notes: body.notes,
+        });
     return NextResponse.json({ success: true, ...result });
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Failed to log meal";
-    // "Only 1 portion left" is a normal thing for a user to hit, not a server fault.
-    const client = /not found|portion|greater than zero/i.test(msg);
+    // "Only 1 portion left" and "resolve macros first" are normal user-facing conditions,
+    // not server faults.
+    const client = /not found|portion|greater than zero|no macros yet/i.test(msg);
     if (!client) console.error("[POST /api/meals/eat]", err);
     return NextResponse.json({ error: msg }, { status: client ? 400 : 500 });
   }

--- a/web/src/components/meals/KitchenPanel.tsx
+++ b/web/src/components/meals/KitchenPanel.tsx
@@ -33,7 +33,15 @@ export interface KitchenPlannedMeal {
   portions: number;
   status: string;
   name: string | null;
-  recipes: { id: string; name: string } | null;
+  // macros_computed_at distinguishes a real recipe from a name-only stub: only a resolved
+  // recipe can be cooked-and-logged in one tap. calories is shown as a preview of what the tap
+  // will log.
+  recipes: {
+    id: string;
+    name: string;
+    calories: number | null;
+    macros_computed_at: string | null;
+  } | null;
   cooks: { id: string; name: string; portions: number; portions_remaining: number } | null;
 }
 
@@ -99,10 +107,39 @@ export function KitchenPanel({ leftovers, plan }: KitchenPanelProps) {
     }
   }
 
-  // Outcome without macros. `eat()` above needs a cook, because it logs known numbers into
-  // meal_log. Most planned meals have no cook — a recipe not yet made, or freeform text — and
-  // those could previously be neither confirmed nor declined. Things don't go to plan; the plan
-  // has to be able to hear about it.
+  // Eat a recipe-backed plan: cook the recipe and eat a portion in one tap. Unlike `mark`
+  // below, this DOES log macros — the recipe's are known — so a planned meal you actually made
+  // stops being invisible in the day's totals. Same endpoint as `eat`, keyed on recipe_id.
+  async function eatRecipe(recipeId: string, opts: { mealType?: string; mealPlanId: string }) {
+    setBusyId(opts.mealPlanId);
+    setError(null);
+    try {
+      const res = await fetch("/api/meals/eat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          recipe_id: recipeId,
+          portions: 1,
+          meal_type: opts.mealType,
+          meal_plan_id: opts.mealPlanId,
+        }),
+      });
+      if (!res.ok) {
+        setError((await res.json()).error ?? "Couldn't log that");
+        return;
+      }
+      router.refresh();
+    } catch {
+      setError("Couldn't log that");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  // Outcome without macros. The two `eat*` handlers above log known numbers into meal_log; this
+  // is the fallback for a plan that has none to log — freeform text ("dinner out"), or a recipe
+  // that is still a name-only stub. Those could previously be neither confirmed nor declined.
+  // Things don't go to plan; the plan has to be able to hear about it.
   async function mark(planId: string, status: "eaten" | "skipped") {
     setBusyId(planId);
     setError(null);
@@ -172,14 +209,19 @@ export function KitchenPanel({ leftovers, plan }: KitchenPanelProps) {
             const cook = p.cooks;
             const label = cook?.name ?? p.recipes?.name ?? p.name ?? "Meal";
             const canEat = !!cook && cook.portions_remaining > 0;
+            // A recipe with resolved macros can be cooked-and-logged in one tap. A name-only
+            // stub (macros_computed_at null) can't — it falls through to the status-only path.
+            const recipe = p.recipes;
+            const canEatRecipe = !cook && !!recipe && !!recipe.macros_computed_at;
             return (
               <div key={p.id} style={rowStyle}>
                 <div>
                   <span style={nameStyle}>{label}</span>
                   <span style={subStyle}>
                     {p.meal_type}
-                    {!cook && p.recipes ? " · needs cooking" : ""}
-                    {!cook && !p.recipes ? " · off-plan" : ""}
+                    {canEatRecipe ? " · from recipe" : ""}
+                    {!cook && recipe && !recipe.macros_computed_at ? " · needs cooking" : ""}
+                    {!cook && !recipe ? " · off-plan" : ""}
                   </span>
                 </div>
                 <div style={{ display: "flex", gap: "var(--space-2)", flexShrink: 0 }}>
@@ -193,17 +235,34 @@ export function KitchenPanel({ leftovers, plan }: KitchenPanelProps) {
                     >
                       {busyId === p.id ? "Logging…" : "Ate this"}
                     </button>
+                  ) : canEatRecipe ? (
+                    // Recipe-backed with known macros: cook it and log a portion in one tap.
+                    <button
+                      type="button"
+                      disabled={busyId === p.id}
+                      onClick={() =>
+                        eatRecipe(recipe.id, { mealType: p.meal_type, mealPlanId: p.id })
+                      }
+                      style={eatButtonStyle(busyId === p.id)}
+                      title={
+                        recipe.calories != null
+                          ? `Logs this recipe's macros (~${recipe.calories} kcal for the batch) and adds any surplus to the fridge.`
+                          : "Cooks this recipe and logs a portion's macros."
+                      }
+                    >
+                      {busyId === p.id ? "Logging…" : "Ate this"}
+                    </button>
                   ) : (
-                    // No cook — nothing to decrement and no macros to log, but the outcome is
-                    // still worth recording. Confirming intent beats leaving the row silent.
+                    // No cook and no resolved recipe — nothing to log macros from, but the
+                    // outcome is still worth recording. Confirming intent beats a silent row.
                     <button
                       type="button"
                       disabled={busyId === p.id}
                       onClick={() => mark(p.id, "eaten")}
                       style={eatButtonStyle(busyId === p.id)}
                       title={
-                        p.recipes
-                          ? "Marks it eaten. Not cooked, so no macros are logged."
+                        recipe
+                          ? "Marks it eaten. This recipe has no macros yet, so none are logged."
                           : "Marks it eaten. No macros are logged."
                       }
                     >

--- a/web/src/lib/nutrition/cooks.ts
+++ b/web/src/lib/nutrition/cooks.ts
@@ -238,3 +238,60 @@ export async function eatFromCook(
 
   return { mealLogId: logged.id as string, portionsRemaining: remaining, macros };
 }
+
+/**
+ * Eat a recipe-backed planned meal: make the recipe, then eat a portion of it.
+ *
+ * A recipe-backed plan means "cook this", so the honest record is a cook (the tray you made)
+ * plus a meal_log (the serving you ate), with any surplus becoming leftovers the planner can
+ * spend later. That is exactly createCook followed by eatFromCook — this only ties the two
+ * together so one tap does both, which is what makes a recipe-backed plan loggable at all.
+ * Before this, "Ate it" on such a plan flipped its status and logged NO macros, so a day of
+ * eating to plan looked identical in the totals to a day of eating nothing.
+ *
+ * portionsCooked defaults to the recipe's typical_portions hint, or 1 when it has none — a
+ * single-serving dish, or "no idea yet", where 1 is the honest floor (a real batch is still
+ * best logged as a cook directly, with its true portion count). createCook enforces that the
+ * recipe has resolved macros and throws a message pointing at the resolve endpoint otherwise.
+ */
+export async function eatFromRecipe(
+  db: SupabaseClient,
+  userId: string,
+  input: {
+    recipeId: string;
+    portionsCooked?: number;
+    portionsEaten?: number;
+    mealType?: string;
+    date?: string;
+    mealPlanId?: string | null;
+    notes?: string;
+  },
+): Promise<{ mealLogId: string; portionsRemaining: number; macros: Totals; cookId: string }> {
+  const { data: recipe, error } = await db
+    .from("recipes")
+    .select("typical_portions")
+    .eq("id", input.recipeId)
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error) throw new Error(`recipe load failed: ${error.message}`);
+  if (!recipe) throw new Error("Recipe not found");
+
+  const portionsCooked = input.portionsCooked ?? (recipe.typical_portions as number | null) ?? 1;
+
+  const cook = await createCook(db, userId, {
+    recipeId: input.recipeId,
+    portions: portionsCooked,
+    cookedOn: input.date,
+  });
+
+  const eaten = await eatFromCook(db, userId, {
+    cookId: cook.id,
+    portions: input.portionsEaten ?? 1,
+    mealType: input.mealType,
+    date: input.date,
+    mealPlanId: input.mealPlanId,
+    notes: input.notes,
+  });
+
+  return { ...eaten, cookId: cook.id };
+}

--- a/web/src/lib/nutrition/quantity.ts
+++ b/web/src/lib/nutrition/quantity.ts
@@ -39,11 +39,12 @@ const VULGAR: Record<string, number> = {
   "⅛": 0.125,
 };
 
-// Units we can act on. Anything else (a "handful", a "bunch") is not a measurement we can
+// Units we can act on. Anything else (a bare "handful") is not a measurement we can
 // resolve, and is treated as unquantified rather than coerced into one.
 //
 // Mass/volume units pass straight through to fdc.ts's DIRECT_GRAMS or USDA portion tables.
-// Countable units ("large", "slice") are resolved against USDA's own portion data.
+// Countable and produce/container units ("large", "slice", "bunch") are resolved against
+// USDA's own portion data.
 const UNIT_ALIASES: Record<string, string> = {
   g: "g",
   gram: "g",
@@ -93,6 +94,27 @@ const UNIT_ALIASES: Record<string, string> = {
   drumsticks: "drumstick",
   wing: "wing",
   wings: "wing",
+
+  // Produce and container units USDA models as real portions ("1 bunch spinach = 340g",
+  // "1 package (10 oz) = 284g"). These belong here for the same reason "large" does: they
+  // are USDA portion descriptors gramsFor resolves against measured data, NOT bare counts.
+  // Without them, "1/2 bunch spinach" fell through to the bare-count branch and became
+  // qty 0.5 unit "each" — silently resolved against whatever spinach portion USDA returned
+  // first, so a recipe backfilled with "bunch" or "package" carried a wrong number wearing a
+  // confident badge. Where USDA has no portion for the unit, gramsFor still flags it inexact.
+  bunch: "bunch",
+  bunches: "bunch",
+  package: "package",
+  packages: "package",
+  pkg: "package",
+  bag: "bag",
+  bags: "bag",
+  head: "head",
+  heads: "head",
+  stalk: "stalk",
+  stalks: "stalk",
+  sprig: "sprig",
+  sprigs: "sprig",
 };
 
 // number: "2", "2.5", "1/2", "1 1/2", "½", "1½"


### PR DESCRIPTION
## What
Marking a recipe-backed planned meal eaten (the "Ate it" button) flipped its `status` and logged **no macros**. So this morning's `3 eggs + spinach` breakfast showed 0 in today's totals — you did what the plan said and got nothing back. That's the same unrewarded loop that stopped meal logging in May.

Root cause: a plan carries no macros of its own by design — it reads them through `cook_id` or `recipe_id`. A freeform plan (name only) has neither, so "no recipe attached" and "no macros logged" are literally the same null.

## Changes
- **`eatFromRecipe`** (`cooks.ts`): creates a `cook` from the recipe and eats a portion in one call. Macros land in `meal_log`; any surplus (recipe `typical_portions` > 1) becomes fridge leftovers. A recipe *is* "one time you made food" the moment you eat it — this is `createCook` + `eatFromCook`, already-shipped functions, tied together.
- **`POST /api/meals/eat`** now accepts `recipe_id` as an alternative to `cook_id`.
- **`KitchenPanel`**: a recipe-backed plan with resolved macros shows **"Ate this"** (logs macros); a name-only stub still falls back to the macro-less "Ate it". Surfaced `recipes.macros_computed_at` through the plan API + meals page so the panel can tell the two apart.

### Also fixed (latent bug)
`lexQuantity` documented "bunch" as unresolvable but didn't treat it that way — a number before any unrecognized unit fell through to the bare-count branch, so `1/2 bunch spinach` became `qty 0.5, unit "each"` and silently resolved against whatever spinach portion USDA returned first. These are real USDA portion descriptors (`1 bunch = 340g`), so `bunch`/`package`/`bag`/`head`/`stalk`/`sprig` now pass through to `gramsFor` like `large` does for eggs. A bare `handful` (no USDA portion) stays unquantified.

## Verification
- `tsc --noEmit`, `eslint`, `prettier --check` all green on changed files.
- Lexer unit-checked: `1/2 bunch spinach` → `{qty:0.5, unit:"bunch"}`; `2 eggs` still `{qty:2, unit:"each"}`.
- The DB write path (`cook` → `meal_log` → plan link, macros from USDA) was exercised live against self-hosted Supabase to backfill today's breakfast — **377 kcal / 23.7P / 7.3C / 28.9F**, all USDA-derived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
