### PR TITLE
feat(meals): click into a planned meal to see its recipe + macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **Click into a planned meal to see what's in it.** A planned meal showed only its label —
+  "Tilapia x2 + rice" told you nothing about how much tilapia or how much rice, because a
+  freeform plan records no amounts and no macros. Every planned-meal row (in both "Planned
+  today" and "This week") now expands: a recipe- or cook-backed plan reveals its ingredients
+  and USDA macros read THROUGH the recipe/cook (never restated on the plan), and a freeform
+  plan with no amounts expands to a **"turn this into a recipe"** form. Filling the amounts
+  once (`2 tilapia fillets`, `1 cup rice`) creates a reusable recipe, resolves its macros
+  through USDA, and adopts the plan — which then becomes one-tap loggable. New `POST /api/recipes`
+  (create + optional resolve + optional plan-link) and a shared `PlannedMealDetail` component;
+  `WeekPlan` became a client component to carry the expand state. The plan queries now select the
+  recipe's ingredients and full macros and the cook's macros.
+
 - **A recipe-backed plan now logs its macros.** `PATCH /api/meal-plan` (above) records that a
   planned meal happened, but logs no macros — right for freeform text, wrong for a meal you
   actually cooked from a recipe whose macros are already known. So marking "3 eggs + spinach"

--- a/web/src/app/(protected)/meals/page.tsx
+++ b/web/src/app/(protected)/meals/page.tsx
@@ -79,8 +79,9 @@ export default async function MealsPage() {
           .from("meal_plans")
           .select(
             "id, date, meal_type, portions, status, name, " +
-              "recipes(id, name, calories, macros_computed_at), " +
-              "cooks(id, name, portions, portions_remaining)",
+              "recipes(id, name, ingredients, calories, protein_g, carbs_g, fat_g, fiber_g, " +
+              "typical_portions, macros_confidence, macros_computed_at), " +
+              "cooks(id, name, portions, portions_remaining, calories, protein_g, carbs_g, fat_g, fiber_g)",
           )
           .eq("user_id", userId)
           .gte("date", todayString())

--- a/web/src/app/api/meal-plan/route.ts
+++ b/web/src/app/api/meal-plan/route.ts
@@ -28,8 +28,9 @@ export async function GET(req: NextRequest) {
       .from("meal_plans")
       .select(
         "id, date, meal_type, portions, status, name, notes, " +
-          "recipes(id, name, calories, macros_computed_at), " +
-          "cooks(id, name, portions, portions_remaining)",
+          "recipes(id, name, ingredients, calories, protein_g, carbs_g, fat_g, fiber_g, " +
+          "typical_portions, macros_confidence, macros_computed_at), " +
+          "cooks(id, name, portions, portions_remaining, calories, protein_g, carbs_g, fat_g, fiber_g)",
       )
       .eq("user_id", user.id)
       .gte("date", start)

--- a/web/src/app/api/recipes/route.ts
+++ b/web/src/app/api/recipes/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { resolveRecipeMacros } from "@/lib/nutrition/recipe-macros";
+
+/**
+ * Create a recipe — and, when asked, resolve its macros and adopt a planned meal in one call.
+ *
+ * This is the "turn a freeform plan into a real recipe" path. A plan like "Tilapia x2 + rice"
+ * carries no amounts and no macros: it's just text, so nothing can say how much tilapia or how
+ * much rice. Writing the amounts once as a recipe fixes that permanently — the recipe owns
+ * USDA-derived macros, and the plan that points at it becomes one-tap loggable.
+ *
+ * `resolve` runs the ingredient text through the same USDA pipeline the meal logger uses
+ * (local model identifies foods, USDA supplies grams). It can fail on ingredients too vague to
+ * match — that is not fatal here: the recipe is still saved with its text, just without macros,
+ * and the caller is told so it can ask the user to tighten the amounts.
+ */
+export async function POST(req: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  let body: {
+    name?: string;
+    ingredients?: string;
+    instructions?: string;
+    tags?: string[];
+    resolve?: boolean;
+    link_plan_id?: string;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const name = body.name?.trim();
+  if (!name) return NextResponse.json({ error: "name is required" }, { status: 400 });
+  const ingredients = body.ingredients?.trim() || null;
+
+  try {
+    const db = createServiceClient();
+    const { data: recipe, error } = await db
+      .from("recipes")
+      .insert({
+        user_id: user.id,
+        name,
+        ingredients,
+        instructions: body.instructions?.trim() || null,
+        tags: body.tags ?? null,
+      })
+      .select("id, name")
+      .single();
+    if (error) throw new Error(error.message);
+
+    // Resolve macros if asked and there is ingredient text to resolve. A failure here leaves
+    // the recipe intact (text saved, macros null) rather than losing the user's input.
+    let macrosResolved = false;
+    let macrosError: string | null = null;
+    if (body.resolve && ingredients) {
+      try {
+        await resolveRecipeMacros(db, user.id, recipe.id);
+        macrosResolved = true;
+      } catch (e) {
+        macrosError = e instanceof Error ? e.message : "Could not resolve macros";
+      }
+    }
+
+    // Adopt a planned meal, if one was named. Guard the one-source rule: a plan already backed
+    // by a cook (leftovers) must not also point at a recipe.
+    if (body.link_plan_id) {
+      const { error: linkErr } = await db
+        .from("meal_plans")
+        .update({ recipe_id: recipe.id, updated_at: new Date().toISOString() })
+        .eq("id", body.link_plan_id)
+        .eq("user_id", user.id)
+        .is("cook_id", null);
+      if (linkErr) throw new Error(`recipe saved, but linking the plan failed: ${linkErr.message}`);
+    }
+
+    return NextResponse.json({ recipe, macrosResolved, macrosError });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Failed to create recipe";
+    console.error("[POST /api/recipes]", err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/web/src/components/meals/KitchenPanel.tsx
+++ b/web/src/components/meals/KitchenPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { PlannedMealDetail } from "./PlannedMealDetail";
 
 /**
  * The kitchen: what's planned today, and what's already in the fridge.
@@ -34,15 +35,32 @@ export interface KitchenPlannedMeal {
   status: string;
   name: string | null;
   // macros_computed_at distinguishes a real recipe from a name-only stub: only a resolved
-  // recipe can be cooked-and-logged in one tap. calories is shown as a preview of what the tap
-  // will log.
+  // recipe can be cooked-and-logged in one tap. The rest feeds the click-in detail view —
+  // ingredients and macros are surfaced there so a plan isn't just an opaque label.
   recipes: {
     id: string;
     name: string;
+    ingredients: string | null;
     calories: number | null;
+    protein_g: number | null;
+    carbs_g: number | null;
+    fat_g: number | null;
+    fiber_g: number | null;
+    typical_portions: number | null;
+    macros_confidence: string | null;
     macros_computed_at: string | null;
   } | null;
-  cooks: { id: string; name: string; portions: number; portions_remaining: number } | null;
+  cooks: {
+    id: string;
+    name: string;
+    portions: number;
+    portions_remaining: number;
+    calories: number | null;
+    protein_g: number | null;
+    carbs_g: number | null;
+    fat_g: number | null;
+    fiber_g: number | null;
+  } | null;
 }
 
 interface KitchenPanelProps {
@@ -76,6 +94,7 @@ function ageLabel(dateStr: string): { text: string; stale: boolean } {
 export function KitchenPanel({ leftovers, plan }: KitchenPanelProps) {
   const router = useRouter();
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   // Data comes from the server component, so "Ate this" just needs to invalidate it:
@@ -213,72 +232,84 @@ export function KitchenPanel({ leftovers, plan }: KitchenPanelProps) {
             // stub (macros_computed_at null) can't — it falls through to the status-only path.
             const recipe = p.recipes;
             const canEatRecipe = !cook && !!recipe && !!recipe.macros_computed_at;
+            const expanded = expandedId === p.id;
             return (
-              <div key={p.id} style={rowStyle}>
-                <div>
-                  <span style={nameStyle}>{label}</span>
-                  <span style={subStyle}>
-                    {p.meal_type}
-                    {canEatRecipe ? " · from recipe" : ""}
-                    {!cook && recipe && !recipe.macros_computed_at ? " · needs cooking" : ""}
-                    {!cook && !recipe ? " · off-plan" : ""}
-                  </span>
-                </div>
-                <div style={{ display: "flex", gap: "var(--space-2)", flexShrink: 0 }}>
-                  {canEat ? (
-                    // Cook-backed: log the known macros AND decrement the fridge.
-                    <button
-                      type="button"
-                      disabled={busyId === p.id}
-                      onClick={() => eat(cook.id, { mealType: p.meal_type, mealPlanId: p.id })}
-                      style={eatButtonStyle(busyId === p.id)}
-                    >
-                      {busyId === p.id ? "Logging…" : "Ate this"}
-                    </button>
-                  ) : canEatRecipe ? (
-                    // Recipe-backed with known macros: cook it and log a portion in one tap.
-                    <button
-                      type="button"
-                      disabled={busyId === p.id}
-                      onClick={() =>
-                        eatRecipe(recipe.id, { mealType: p.meal_type, mealPlanId: p.id })
-                      }
-                      style={eatButtonStyle(busyId === p.id)}
-                      title={
-                        recipe.calories != null
-                          ? `Logs this recipe's macros (~${recipe.calories} kcal for the batch) and adds any surplus to the fridge.`
-                          : "Cooks this recipe and logs a portion's macros."
-                      }
-                    >
-                      {busyId === p.id ? "Logging…" : "Ate this"}
-                    </button>
-                  ) : (
-                    // No cook and no resolved recipe — nothing to log macros from, but the
-                    // outcome is still worth recording. Confirming intent beats a silent row.
-                    <button
-                      type="button"
-                      disabled={busyId === p.id}
-                      onClick={() => mark(p.id, "eaten")}
-                      style={eatButtonStyle(busyId === p.id)}
-                      title={
-                        recipe
-                          ? "Marks it eaten. This recipe has no macros yet, so none are logged."
-                          : "Marks it eaten. No macros are logged."
-                      }
-                    >
-                      {busyId === p.id ? "Saving…" : "Ate it"}
-                    </button>
-                  )}
+              <div key={p.id}>
+                <div style={rowStyle}>
                   <button
                     type="button"
-                    disabled={busyId === p.id}
-                    onClick={() => mark(p.id, "skipped")}
-                    style={skipButtonStyle(busyId === p.id)}
-                    title="Didn't eat this. A skip is data — it's how the plan finds out it was wrong."
+                    onClick={() => setExpandedId(expanded ? null : p.id)}
+                    aria-expanded={expanded}
+                    style={expanderStyle}
                   >
-                    Skip
+                    <span style={caretStyle}>{expanded ? "▾" : "▸"}</span>
+                    <span style={{ minWidth: 0 }}>
+                      <span style={nameStyle}>{label}</span>
+                      <span style={subStyle}>
+                        {p.meal_type}
+                        {canEatRecipe ? " · from recipe" : ""}
+                        {!cook && recipe && !recipe.macros_computed_at ? " · needs cooking" : ""}
+                        {!cook && !recipe ? " · tap for amounts" : ""}
+                      </span>
+                    </span>
                   </button>
+                  <div style={{ display: "flex", gap: "var(--space-2)", flexShrink: 0 }}>
+                    {canEat ? (
+                      // Cook-backed: log the known macros AND decrement the fridge.
+                      <button
+                        type="button"
+                        disabled={busyId === p.id}
+                        onClick={() => eat(cook.id, { mealType: p.meal_type, mealPlanId: p.id })}
+                        style={eatButtonStyle(busyId === p.id)}
+                      >
+                        {busyId === p.id ? "Logging…" : "Ate this"}
+                      </button>
+                    ) : canEatRecipe ? (
+                      // Recipe-backed with known macros: cook it and log a portion in one tap.
+                      <button
+                        type="button"
+                        disabled={busyId === p.id}
+                        onClick={() =>
+                          eatRecipe(recipe.id, { mealType: p.meal_type, mealPlanId: p.id })
+                        }
+                        style={eatButtonStyle(busyId === p.id)}
+                        title={
+                          recipe.calories != null
+                            ? `Logs this recipe's macros (~${recipe.calories} kcal for the batch) and adds any surplus to the fridge.`
+                            : "Cooks this recipe and logs a portion's macros."
+                        }
+                      >
+                        {busyId === p.id ? "Logging…" : "Ate this"}
+                      </button>
+                    ) : (
+                      // No cook and no resolved recipe — nothing to log macros from, but the
+                      // outcome is still worth recording. Confirming intent beats a silent row.
+                      <button
+                        type="button"
+                        disabled={busyId === p.id}
+                        onClick={() => mark(p.id, "eaten")}
+                        style={eatButtonStyle(busyId === p.id)}
+                        title={
+                          recipe
+                            ? "Marks it eaten. This recipe has no macros yet, so none are logged."
+                            : "Marks it eaten. No macros are logged."
+                        }
+                      >
+                        {busyId === p.id ? "Saving…" : "Ate it"}
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      disabled={busyId === p.id}
+                      onClick={() => mark(p.id, "skipped")}
+                      style={skipButtonStyle(busyId === p.id)}
+                      title="Didn't eat this. A skip is data — it's how the plan finds out it was wrong."
+                    >
+                      Skip
+                    </button>
+                  </div>
                 </div>
+                {expanded && <PlannedMealDetail meal={p} />}
               </div>
             );
           })}
@@ -337,6 +368,27 @@ const rowStyle: React.CSSProperties = {
   gap: "var(--space-4)",
   padding: "var(--space-3) 0",
   borderBottom: "1px solid var(--rule-soft)",
+};
+
+// The name doubles as the expand toggle — a transparent, full-height button so the whole
+// label is a tap target, with a caret to signal there's more underneath.
+const expanderStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "baseline",
+  gap: "var(--space-2)",
+  minWidth: 0,
+  flex: 1,
+  background: "none",
+  border: "none",
+  padding: 0,
+  textAlign: "left",
+  cursor: "pointer",
+};
+
+const caretStyle: React.CSSProperties = {
+  fontSize: "var(--t-micro)",
+  color: "var(--color-text-faint)",
+  flexShrink: 0,
 };
 
 const nameStyle: React.CSSProperties = {

--- a/web/src/components/meals/PlannedMealDetail.tsx
+++ b/web/src/components/meals/PlannedMealDetail.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { KitchenPlannedMeal } from "./KitchenPanel";
+
+/**
+ * The click-in view for a planned meal: what's in it, and what it costs you.
+ *
+ * A plan carries no macros of its own — it points at a recipe or a cook, and those own the
+ * numbers (see .claude/rules/data-sources.md). So this reads through whichever one is attached:
+ *   recipe-backed  -> the recipe's ingredients + USDA macros (per serving if it splits)
+ *   cook-backed    -> the cook's macros for one portion
+ *   freeform       -> nothing to show, because nothing was specified. "Tilapia x2 + rice" never
+ *                     recorded how much tilapia or how much rice. The fix isn't to guess here;
+ *                     it's to write the amounts down once as a recipe — which is what the form
+ *                     below does, resolving USDA macros and adopting this plan in one step.
+ */
+
+interface Macros {
+  calories: number | null;
+  protein_g: number | null;
+  carbs_g: number | null;
+  fat_g: number | null;
+  fiber_g: number | null;
+}
+
+function round(n: number | null): number | null {
+  return n == null ? null : Math.round(n * 10) / 10;
+}
+
+function MacroLine({ m, label, portions }: { m: Macros; label: string; portions?: number }) {
+  const div = portions && portions > 1 ? portions : 1;
+  const cal = m.calories == null ? null : Math.round(m.calories / div);
+  const p = round(m.protein_g == null ? null : m.protein_g / div);
+  const c = round(m.carbs_g == null ? null : m.carbs_g / div);
+  const f = round(m.fat_g == null ? null : m.fat_g / div);
+  if (cal == null && p == null) return null;
+  return (
+    <div style={macroRowStyle}>
+      <span style={macroLabelStyle}>{label}</span>
+      <span style={macroValsStyle}>
+        {cal != null ? `${cal} kcal` : "—"}
+        {p != null ? ` · ${p}g P` : ""}
+        {c != null ? ` · ${c}g C` : ""}
+        {f != null ? ` · ${f}g F` : ""}
+      </span>
+    </div>
+  );
+}
+
+export function PlannedMealDetail({ meal }: { meal: KitchenPlannedMeal }) {
+  const router = useRouter();
+  const recipe = meal.recipes;
+  const cook = meal.cooks;
+
+  // ── Recipe-backed ──────────────────────────────────────────────────────────
+  if (recipe) {
+    const hasMacros = !!recipe.macros_computed_at;
+    const typ = recipe.typical_portions ?? null;
+    return (
+      <div style={detailBoxStyle}>
+        {recipe.ingredients ? (
+          <div style={{ marginBottom: hasMacros ? "var(--space-3)" : 0 }}>
+            <p style={sectionLabelStyle}>Ingredients</p>
+            <p style={ingredientsStyle}>{recipe.ingredients}</p>
+          </div>
+        ) : (
+          <p style={mutedStyle}>No ingredients recorded for this recipe yet.</p>
+        )}
+        {hasMacros ? (
+          <>
+            {typ && typ > 1 && <MacroLine m={recipe} label="Per serving" portions={typ} />}
+            <MacroLine m={recipe} label={typ && typ > 1 ? `Whole recipe (${typ})` : "This meal"} />
+            {recipe.macros_confidence && recipe.macros_confidence !== "high" && (
+              <p style={confidenceStyle}>
+                {recipe.macros_confidence} confidence — amounts are estimates, not measured.
+              </p>
+            )}
+          </>
+        ) : (
+          <p style={mutedStyle}>Macros not resolved yet for this recipe.</p>
+        )}
+      </div>
+    );
+  }
+
+  // ── Cook-backed (leftovers) ─────────────────────────────────────────────────
+  if (cook) {
+    return (
+      <div style={detailBoxStyle}>
+        <p style={sectionLabelStyle}>From the fridge</p>
+        <p style={ingredientsStyle}>
+          {cook.name} · {cook.portions_remaining} of {cook.portions} portion
+          {cook.portions === 1 ? "" : "s"} left
+        </p>
+        <MacroLine m={cook} label="One portion" portions={cook.portions > 0 ? cook.portions : 1} />
+      </div>
+    );
+  }
+
+  // ── Freeform: nothing specified. Offer to make it a recipe. ──────────────────
+  return <FreeformConvert meal={meal} onDone={() => router.refresh()} />;
+}
+
+function FreeformConvert({ meal, onDone }: { meal: KitchenPlannedMeal; onDone: () => void }) {
+  const [name, setName] = useState(meal.name ?? "");
+  const [ingredients, setIngredients] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [warn, setWarn] = useState<string | null>(null);
+
+  async function save() {
+    if (!name.trim() || !ingredients.trim()) {
+      setError("Add a name and at least one ingredient with an amount.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    setWarn(null);
+    try {
+      const res = await fetch("/api/recipes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          ingredients: ingredients.trim(),
+          resolve: true,
+          link_plan_id: meal.id,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? "Couldn't save that");
+        return;
+      }
+      if (data.macrosError) {
+        // Recipe was saved and linked, but USDA couldn't resolve every amount. Refresh anyway —
+        // the plan now shows the ingredients; the numbers can be tightened later.
+        setWarn(data.macrosError);
+        setTimeout(onDone, 1400);
+        return;
+      }
+      onDone();
+    } catch {
+      setError("Couldn't save that");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div style={detailBoxStyle}>
+      <p style={mutedStyle}>
+        This meal has no amounts recorded. Write them down once and it becomes a reusable recipe
+        with macros.
+      </p>
+      <label style={sectionLabelStyle} htmlFor={`name-${meal.id}`}>
+        Recipe name
+      </label>
+      <input
+        id={`name-${meal.id}`}
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        style={inputStyle}
+        placeholder="Tilapia & rice"
+      />
+      <label
+        style={{ ...sectionLabelStyle, marginTop: "var(--space-3)" }}
+        htmlFor={`ing-${meal.id}`}
+      >
+        Ingredients — one per line, with amounts
+      </label>
+      <textarea
+        id={`ing-${meal.id}`}
+        value={ingredients}
+        onChange={(e) => setIngredients(e.target.value)}
+        rows={4}
+        style={{ ...inputStyle, resize: "vertical", fontFamily: "inherit" }}
+        placeholder={"2 tilapia fillets\n1 cup cooked white rice"}
+      />
+      {error && <p style={errorStyle}>{error}</p>}
+      {warn && (
+        <p style={confidenceStyle}>Saved, but some amounts were too vague for USDA: {warn}</p>
+      )}
+      <button type="button" onClick={save} disabled={busy} style={saveButtonStyle(busy)}>
+        {busy ? "Saving…" : "Save as recipe"}
+      </button>
+    </div>
+  );
+}
+
+const detailBoxStyle: React.CSSProperties = {
+  padding: "var(--space-3) 0 var(--space-4)",
+  borderTop: "1px solid var(--rule-soft)",
+};
+
+const sectionLabelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: "var(--t-micro)",
+  fontWeight: 600,
+  color: "var(--color-text-muted)",
+  textTransform: "uppercase",
+  letterSpacing: "0.04em",
+  marginBottom: "var(--space-1)",
+};
+
+const ingredientsStyle: React.CSSProperties = {
+  fontSize: "var(--t-meta)",
+  color: "var(--color-text)",
+  lineHeight: 1.6,
+  whiteSpace: "pre-line",
+};
+
+const mutedStyle: React.CSSProperties = {
+  fontSize: "var(--t-meta)",
+  color: "var(--color-text-muted)",
+  lineHeight: 1.6,
+  marginBottom: "var(--space-3)",
+};
+
+const macroRowStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  gap: "var(--space-3)",
+  padding: "var(--space-1) 0",
+};
+
+const macroLabelStyle: React.CSSProperties = {
+  fontSize: "var(--t-micro)",
+  color: "var(--color-text-muted)",
+};
+
+const macroValsStyle: React.CSSProperties = {
+  fontSize: "var(--t-meta)",
+  color: "var(--color-text)",
+  fontVariantNumeric: "tabular-nums",
+  textAlign: "right",
+};
+
+const confidenceStyle: React.CSSProperties = {
+  fontSize: "var(--t-micro)",
+  color: "var(--color-text-muted)",
+  fontStyle: "italic",
+  marginTop: "var(--space-2)",
+};
+
+const errorStyle: React.CSSProperties = {
+  fontSize: "var(--t-micro)",
+  color: "var(--color-danger)",
+  marginTop: "var(--space-2)",
+};
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  fontSize: "var(--t-meta)",
+  color: "var(--color-text)",
+  background: "var(--color-surface)",
+  border: "1px solid var(--rule-soft)",
+  borderRadius: "var(--r-1)",
+  padding: "var(--space-2)",
+};
+
+function saveButtonStyle(pending: boolean): React.CSSProperties {
+  return {
+    marginTop: "var(--space-3)",
+    fontFamily: "var(--font-body), system-ui, sans-serif",
+    fontSize: "var(--t-micro)",
+    fontWeight: 500,
+    color: "var(--color-text-on-cta)",
+    background: "var(--accent)",
+    border: "none",
+    borderRadius: "var(--r-1)",
+    padding: "0 var(--space-4)",
+    minHeight: 36,
+    cursor: pending ? "wait" : "pointer",
+    opacity: pending ? 0.5 : 1,
+  };
+}

--- a/web/src/components/meals/WeekPlan.tsx
+++ b/web/src/components/meals/WeekPlan.tsx
@@ -1,4 +1,8 @@
+"use client";
+
+import { useState } from "react";
 import type { KitchenPlannedMeal } from "./KitchenPanel";
+import { PlannedMealDetail } from "./PlannedMealDetail";
 
 /**
  * The week ahead, as planned.
@@ -10,9 +14,10 @@ import type { KitchenPlannedMeal } from "./KitchenPanel";
  * Empty days are rendered, not hidden. A gap is the most useful thing on this panel: it's the
  * list of decisions still owed, and it's what the Sunday planning session exists to close.
  *
- * Macros are deliberately absent. `meal_plans` carries none of its own (see
- * .claude/rules/data-sources.md) — a plan points at a cook or a recipe, and those own the
- * numbers. Restating macros here would mean either duplicating them or inventing them.
+ * The row itself stays macro-free — `meal_plans` carries no macros of its own (see
+ * .claude/rules/data-sources.md). But each row expands: clicking one reveals the ingredients
+ * and macros read THROUGH its recipe or cook, never restated on the plan. A freeform meal with
+ * no amounts expands to a form that turns it into a recipe.
  */
 
 const MEAL_ORDER = ["breakfast", "lunch", "dinner", "snack"];
@@ -38,6 +43,8 @@ export function WeekPlan({
   days: string[];
   today: string;
 }) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
   const byDate = new Map<string, KitchenPlannedMeal[]>();
   for (const p of week) {
     const list = byDate.get(p.date) ?? [];
@@ -90,29 +97,41 @@ export function WeekPlan({
                 const name = p.cooks?.name ?? p.recipes?.name ?? p.name ?? "Meal";
                 const eaten = p.status === "eaten";
                 const skipped = p.status === "skipped";
+                const expanded = expandedId === p.id;
                 return (
-                  <div key={p.id} style={rowStyle}>
-                    <span style={mealTypeStyle}>{p.meal_type}</span>
-                    <span
-                      style={{
-                        ...nameStyle,
-                        color: eaten || skipped ? "var(--color-text-muted)" : "var(--color-text)",
-                        textDecoration: skipped ? "line-through" : undefined,
-                      }}
+                  <div key={p.id}>
+                    <button
+                      type="button"
+                      onClick={() => setExpandedId(expanded ? null : p.id)}
+                      aria-expanded={expanded}
+                      style={rowButtonStyle}
                     >
-                      {name}
-                    </span>
-                    <span style={statusStyle}>
-                      {eaten
-                        ? "eaten"
-                        : skipped
-                          ? "skipped"
-                          : p.cooks
-                            ? "ready"
-                            : p.recipes
-                              ? "needs cooking"
-                              : ""}
-                    </span>
+                      <span style={mealTypeStyle}>{p.meal_type}</span>
+                      <span
+                        style={{
+                          ...nameStyle,
+                          color: eaten || skipped ? "var(--color-text-muted)" : "var(--color-text)",
+                          textDecoration: skipped ? "line-through" : undefined,
+                        }}
+                      >
+                        {name}
+                      </span>
+                      <span style={statusStyle}>
+                        {eaten
+                          ? "eaten"
+                          : skipped
+                            ? "skipped"
+                            : p.cooks
+                              ? "ready"
+                              : p.recipes
+                                ? "needs cooking"
+                                : "no amounts"}
+                        <span style={{ marginLeft: 6, color: "var(--color-text-faint)" }}>
+                          {expanded ? "▾" : "▸"}
+                        </span>
+                      </span>
+                    </button>
+                    {expanded && <PlannedMealDetail meal={p} />}
                   </div>
                 );
               })
@@ -138,12 +157,19 @@ const dayHeadStyle: React.CSSProperties = {
   marginBottom: "var(--space-2)",
 };
 
-const rowStyle: React.CSSProperties = {
+// The whole row is the expand toggle. Grid layout preserved; button reset applied so it reads
+// as a row, not a control.
+const rowButtonStyle: React.CSSProperties = {
   display: "grid",
   gridTemplateColumns: "72px 1fr auto",
   alignItems: "baseline",
   gap: "var(--space-3)",
   padding: "var(--space-1) 0",
+  width: "100%",
+  background: "none",
+  border: "none",
+  textAlign: "left",
+  cursor: "pointer",
 };
 
 const mealTypeStyle: React.CSSProperties = {


### PR DESCRIPTION
## What
A planned meal only ever showed its label. "Tilapia x2 + rice" told you nothing about *how much* tilapia or rice — because a freeform plan records no amounts and no macros (a plan reads macros through a recipe or cook; freeform text has neither).

## Changes
Every planned-meal row — in both **Planned today** and **This week** — now expands on click:
- **Recipe-backed** → ingredients + USDA macros (per-serving if it splits), read *through* the recipe, never restated on the plan.
- **Cook-backed** → the cook's macros for one portion, plus what's left in the fridge.
- **Freeform** → a **"turn this into a recipe"** form. Fill the amounts once (`2 tilapia fillets`, `1 cup rice`), and it creates a reusable recipe, resolves macros through USDA, and adopts the plan — which then becomes one-tap loggable via the existing "Ate this".

New `POST /api/recipes` (create + optional `resolve` + optional `link_plan_id`, all in one call) and a shared `PlannedMealDetail` component. `WeekPlan` became a client component to hold the expand state. The plan queries (`meals/page.tsx` and `GET /api/meal-plan`) now select the recipe's `ingredients` + full macros and the cook's macros.

## Verification
- `tsc`, `eslint`, `prettier`, and a full `next build` all green.
- The freeform→recipe **Ollama pipeline was exercised end-to-end** on the literal example: a throwaway "2 tilapia fillets / 1 cup cooked white rice" resolved to **428 kcal / 50.8g P / 44.5g C / 4.4g F** (high confidence) — qwen identified the foods, the lexer read the amounts, USDA supplied the grams. Throwaway deleted after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
