### PR TITLE
fix(meals): show the cook name for meals logged from the fridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **A meal logged from the fridge now shows what it was.** The "Logged today" list read a meal's
+  name from `recipes(name) ?? notes`, but a one-tap "Ate this" writes a `cook_id`, not a recipe —
+  so a logged cook had no name and rendered as "—" (or, worse, showed an internal note). The
+  meal_log query now also joins `cooks(name)` and the display prefers it, so "Eggs & Spinach" and
+  "Linguine…" show up as themselves. (A cook with unresolved macros still logs 0 kcal — that's a
+  data gap in the cook, not this display.)
+
 ### Added
 
 - **Click into a planned meal to see what's in it.** A planned meal showed only its label —

--- a/web/src/app/(protected)/meals/page.tsx
+++ b/web/src/app/(protected)/meals/page.tsx
@@ -38,7 +38,7 @@ export default async function MealsPage() {
     supabase
       .from("meal_log")
       .select(
-        "id, date, meal_type, notes, calories, protein_g, carbs_g, fat_g, fiber_g, sugar_g, recipes(name)",
+        "id, date, meal_type, notes, calories, protein_g, carbs_g, fat_g, fiber_g, sugar_g, recipes(name), cooks(name)",
       )
       .gte("date", daysAgoString(6))
       .order("date", { ascending: false })

--- a/web/src/components/meals/MealsClient.tsx
+++ b/web/src/components/meals/MealsClient.tsx
@@ -32,6 +32,9 @@ export interface MealRow {
   notes: string | null;
   user_context: string | null;
   recipes: { name: string } | null;
+  // A meal logged from a cook (the "Ate this" path) carries the cook, not a recipe. Without
+  // this the row had no name to show and rendered as "—".
+  cooks: { name: string } | null;
   calories: number | null;
   protein_g: number | null;
   carbs_g: number | null;
@@ -337,7 +340,7 @@ function MealRowDisplay({ meal, onClick, onRelog, onDelete }: MealRowDisplayProp
           wordBreak: "break-word",
         }}
       >
-        {meal.recipes?.name ?? meal.notes ?? "—"}
+        {meal.cooks?.name ?? meal.recipes?.name ?? meal.notes ?? "—"}
       </span>
       {macroStr && (
         <div
@@ -675,7 +678,7 @@ function TodayTab({
   const quickLogRef = useRef<HTMLDivElement>(null);
 
   function prefillLog(m: MealRow) {
-    const name = m.recipes?.name ?? m.notes ?? "";
+    const name = m.cooks?.name ?? m.recipes?.name ?? m.notes ?? "";
     setLogDesc(name);
     setLogMealType(
       (MEAL_TYPES as readonly string[]).includes(m.meal_type)
@@ -731,7 +734,7 @@ function TodayTab({
     const byKey = new Map<string, MealRow>();
     const sorted = [...pastMeals].sort((a, b) => (a.date < b.date ? 1 : -1));
     for (const m of sorted) {
-      const key = normalizeName(m.recipes?.name ?? m.notes);
+      const key = normalizeName(m.cooks?.name ?? m.recipes?.name ?? m.notes);
       if (!key) continue;
       if (!byKey.has(key)) byKey.set(key, m);
     }


### PR DESCRIPTION
## Bug
A meal logged via one-tap **"Ate this"** showed no name in "Logged today" — it rendered as "—" (or an internal note). Marking the linguine leftovers eaten produced a nameless row, which read as broken.

## Cause
The meal_log query joined `recipes(name)` only. A cook-backed log carries `cook_id`, not `recipe_id`, so `recipes` is null and the display fell through to `notes` (also null) → "—".

## Fix
Join `cooks(name)` in the meal_log query and prefer it in the display: `cooks?.name ?? recipes?.name ?? notes`. Now "Eggs & Spinach", "Linguine…" etc. show as themselves.

Note: a cook with **unresolved macros** still logs 0 kcal — that's a data gap in the cook itself (an ad-hoc cook logged without ingredients), handled separately, not a display issue.

## Verification
`tsc`, `eslint`, `prettier` green on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
