### PR TITLE
feat(meals): show cooking instructions in recipe detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **Recipes show how to cook them, not just what's in them.** Recipes have carried an
+  `instructions` field all along, but neither the click-in planned-meal detail nor the Recipes
+  tab rendered it — you saw the ingredient list and the macros, but not the method. Both now
+  show a "How to make it" section (line breaks preserved) whenever a recipe has instructions.
+  Threaded `instructions` through the plan queries and the recipes query.
+
 ### Fixed
 
 - **A meal logged from the fridge now shows what it was.** The "Logged today" list read a meal's

--- a/web/src/app/(protected)/meals/page.tsx
+++ b/web/src/app/(protected)/meals/page.tsx
@@ -57,7 +57,7 @@ export default async function MealsPage() {
     userId
       ? supabase
           .from("recipes")
-          .select("id, name, cuisine, tags, ingredients")
+          .select("id, name, cuisine, tags, ingredients, instructions")
           .eq("user_id", userId)
           .order("name")
       : Promise.resolve({ data: [] }),
@@ -79,7 +79,7 @@ export default async function MealsPage() {
           .from("meal_plans")
           .select(
             "id, date, meal_type, portions, status, name, " +
-              "recipes(id, name, ingredients, calories, protein_g, carbs_g, fat_g, fiber_g, " +
+              "recipes(id, name, ingredients, instructions, calories, protein_g, carbs_g, fat_g, fiber_g, " +
               "typical_portions, macros_confidence, macros_computed_at), " +
               "cooks(id, name, portions, portions_remaining, calories, protein_g, carbs_g, fat_g, fiber_g)",
           )

--- a/web/src/app/api/meal-plan/route.ts
+++ b/web/src/app/api/meal-plan/route.ts
@@ -28,7 +28,7 @@ export async function GET(req: NextRequest) {
       .from("meal_plans")
       .select(
         "id, date, meal_type, portions, status, name, notes, " +
-          "recipes(id, name, ingredients, calories, protein_g, carbs_g, fat_g, fiber_g, " +
+          "recipes(id, name, ingredients, instructions, calories, protein_g, carbs_g, fat_g, fiber_g, " +
           "typical_portions, macros_confidence, macros_computed_at), " +
           "cooks(id, name, portions, portions_remaining, calories, protein_g, carbs_g, fat_g, fiber_g)",
       )

--- a/web/src/components/meals/KitchenPanel.tsx
+++ b/web/src/components/meals/KitchenPanel.tsx
@@ -41,6 +41,7 @@ export interface KitchenPlannedMeal {
     id: string;
     name: string;
     ingredients: string | null;
+    instructions: string | null;
     calories: number | null;
     protein_g: number | null;
     carbs_g: number | null;

--- a/web/src/components/meals/MealsClient.tsx
+++ b/web/src/components/meals/MealsClient.tsx
@@ -49,6 +49,7 @@ export interface RecipeRow {
   cuisine: string | null;
   tags: string[] | null;
   ingredients: string | null;
+  instructions: string | null;
 }
 
 export interface MacroGoals {
@@ -1270,6 +1271,33 @@ function RecipesTab({ recipes }: { recipes: RecipeRow[] }) {
                       >
                         {r.ingredients}
                       </p>
+                    )}
+
+                    {r.instructions && (
+                      <div style={{ marginBottom: "var(--space-3)" }}>
+                        <p
+                          style={{
+                            fontSize: "var(--t-micro)",
+                            fontWeight: 600,
+                            color: "var(--color-text-muted)",
+                            textTransform: "uppercase",
+                            letterSpacing: "0.04em",
+                            marginBottom: "var(--space-1)",
+                          }}
+                        >
+                          How to make it
+                        </p>
+                        <p
+                          style={{
+                            fontSize: "var(--t-meta)",
+                            color: "var(--color-text)",
+                            lineHeight: 1.6,
+                            whiteSpace: "pre-line",
+                          }}
+                        >
+                          {r.instructions}
+                        </p>
+                      </div>
                     )}
 
                     {isUsing ? (

--- a/web/src/components/meals/PlannedMealDetail.tsx
+++ b/web/src/components/meals/PlannedMealDetail.tsx
@@ -61,12 +61,18 @@ export function PlannedMealDetail({ meal }: { meal: KitchenPlannedMeal }) {
     return (
       <div style={detailBoxStyle}>
         {recipe.ingredients ? (
-          <div style={{ marginBottom: hasMacros ? "var(--space-3)" : 0 }}>
+          <div style={{ marginBottom: "var(--space-3)" }}>
             <p style={sectionLabelStyle}>Ingredients</p>
             <p style={ingredientsStyle}>{recipe.ingredients}</p>
           </div>
         ) : (
           <p style={mutedStyle}>No ingredients recorded for this recipe yet.</p>
+        )}
+        {recipe.instructions && (
+          <div style={{ marginBottom: hasMacros ? "var(--space-3)" : 0 }}>
+            <p style={sectionLabelStyle}>How to make it</p>
+            <p style={ingredientsStyle}>{recipe.instructions}</p>
+          </div>
         )}
         {hasMacros ? (
           <>


### PR DESCRIPTION
## What
Recipes have a cooking-`instructions` field (populated for every recipe), but nothing rendered it — the click-in planned-meal detail and the Recipes tab showed ingredients + macros only, so you couldn't see *how* to cook the dish.

## Changes
Both the **click-in planned-meal detail** (`PlannedMealDetail`) and the **Recipes tab** (`MealsClient`) now show a **"How to make it"** section with the instructions (line breaks preserved) whenever a recipe has them. Threaded `instructions` through the plan queries (`meals/page.tsx`, `GET /api/meal-plan`) and the recipes query, plus the `KitchenPlannedMeal.recipes` and `RecipeRow` types.

## Verification
`tsc`, `eslint`, `prettier` all green on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
