### PR TITLE
feat(fitness): end-of-workout feedback box works without logging sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **The end-of-workout feedback box works without logging sets.** The "how did it feel?" recap
+  (perceived effort + notes) only appeared once a set had been logged — it could only PATCH an
+  existing `strength_session`, and a session was created by the set logger. Do your workout
+  without logging every set in the app and the box never opened, so a real coaching signal went
+  uncaptured. `PATCH /api/strength-sessions` now accepts `performed_on` (+ `workout_plan_id`) and
+  finds-or-creates the session itself, and `EndOfWorkoutRecap` always renders on today's workout
+  and fills in its session id after the first save. Effort and notes can now be logged for any
+  workout, set-tracked or not.
+
 - **Recipes show how to cook them, not just what's in them.** Recipes have carried an
   `instructions` field all along, but neither the click-in planned-meal detail nor the Recipes
   tab rendered it — you saw the ingredient list and the macros, but not the method. Both now

--- a/web/src/app/api/strength-sessions/route.ts
+++ b/web/src/app/api/strength-sessions/route.ts
@@ -15,7 +15,12 @@ interface LogSetBody {
 }
 
 interface RecapBody {
-  session_id: string;
+  // Either identify the session directly, or let it be found/created for a date. The latter is
+  // what lets the end-of-workout box stand on its own: you can say how a workout felt without
+  // having logged a single set (no set = no session existed = nowhere to write the note before).
+  session_id?: string;
+  performed_on?: string;
+  workout_plan_id?: string | null;
   perceived_effort?: number | null;
   notes?: string | null;
   completed_at?: string;
@@ -112,8 +117,8 @@ export async function PATCH(req: Request) {
     return Response.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  if (!body.session_id) {
-    return Response.json({ error: "session_id is required" }, { status: 400 });
+  if (!body.session_id && !body.performed_on) {
+    return Response.json({ error: "session_id or performed_on is required" }, { status: 400 });
   }
   if (body.perceived_effort != null && (body.perceived_effort < 1 || body.perceived_effort > 10)) {
     return Response.json({ error: "perceived_effort must be between 1 and 10" }, { status: 400 });
@@ -125,6 +130,45 @@ export async function PATCH(req: Request) {
   } = await supabase.auth.getUser();
   if (!user) return Response.json({ error: "Unauthorized" }, { status: 401 });
 
+  // Resolve the session. With no session_id, find the one for that date, or create it — so a
+  // note can be saved for a workout that was never set-logged. Mirrors the POST create path.
+  let sessionId = body.session_id ?? null;
+  if (!sessionId) {
+    const { data: existing, error: lookupErr } = await supabase
+      .from("strength_sessions")
+      .select("id")
+      .eq("user_id", user.id)
+      .eq("performed_on", body.performed_on!)
+      .order("created_at", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+    if (lookupErr) return Response.json({ error: lookupErr.message }, { status: 500 });
+    if (existing) {
+      sessionId = existing.id;
+    } else {
+      const { data: created, error: createErr } = await supabase
+        .from("strength_sessions")
+        .insert({
+          user_id: user.id,
+          workout_plan_id: body.workout_plan_id ?? null,
+          performed_on: body.performed_on!,
+          started_at: new Date().toISOString(),
+        })
+        .select("id")
+        .single();
+      if (createErr || !created) {
+        return Response.json(
+          { error: createErr?.message ?? "failed to create session" },
+          { status: 500 },
+        );
+      }
+      sessionId = created.id;
+    }
+  }
+  if (!sessionId) {
+    return Response.json({ error: "Could not resolve session" }, { status: 500 });
+  }
+
   const updates: Record<string, unknown> = {
     completed_at: body.completed_at ?? new Date().toISOString(),
   };
@@ -134,7 +178,7 @@ export async function PATCH(req: Request) {
   const { data, error } = await supabase
     .from("strength_sessions")
     .update(updates)
-    .eq("id", body.session_id)
+    .eq("id", sessionId)
     .eq("user_id", user.id)
     .select()
     .single();
@@ -143,7 +187,7 @@ export async function PATCH(req: Request) {
   if (!data) return Response.json({ error: "Session not found" }, { status: 404 });
 
   // Fire-and-forget PR computation on session completion
-  upsertExercisePRs(supabase, user.id, body.session_id).catch(() => {});
+  upsertExercisePRs(supabase, user.id, sessionId).catch(() => {});
 
   return Response.json(data);
 }

--- a/web/src/components/fitness/end-of-workout-recap.tsx
+++ b/web/src/components/fitness/end-of-workout-recap.tsx
@@ -6,38 +6,32 @@ import { Loader2 } from "lucide-react";
 
 interface Props {
   sessionId: string | null;
+  // Used to find-or-create the session when none exists yet, so the box works without any set
+  // having been logged. One is required — the session is looked up by date if there's no id.
+  performedOn: string;
+  workoutPlanId: string | null;
   initialPerceivedEffort: number | null;
   initialNotes: string | null;
   completedAt: string | null;
 }
 
 export function EndOfWorkoutRecap({
-  sessionId,
+  sessionId: initialSessionId,
+  performedOn,
+  workoutPlanId,
   initialPerceivedEffort,
   initialNotes,
   completedAt,
 }: Props) {
   const router = useRouter();
+  // The id can arrive null (no set logged yet) and get filled in once we save and the server
+  // creates the session — hold it in state so a second save updates rather than duplicates.
+  const [sessionId, setSessionId] = useState<string | null>(initialSessionId);
   const [effort, setEffort] = useState<number | null>(initialPerceivedEffort);
   const [notes, setNotes] = useState<string>(initialNotes ?? "");
   const [pending, setPending] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<string | null>(completedAt);
-
-  if (!sessionId) {
-    return (
-      <p
-        style={{
-          fontSize: 11,
-          color: "var(--color-text-faint, var(--color-text-muted))",
-          fontStyle: "italic",
-          marginTop: 8,
-        }}
-      >
-        Log a set above to open the end-of-workout recap.
-      </p>
-    );
-  }
 
   async function save() {
     setErr(null);
@@ -47,7 +41,10 @@ export function EndOfWorkoutRecap({
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          session_id: sessionId,
+          // Prefer the id when we have it; otherwise let the server resolve by date.
+          session_id: sessionId ?? undefined,
+          performed_on: performedOn,
+          workout_plan_id: workoutPlanId,
           perceived_effort: effort,
           notes: notes.trim() === "" ? null : notes,
         }),
@@ -58,6 +55,7 @@ export function EndOfWorkoutRecap({
         return;
       }
       const data = await res.json();
+      if (data?.id) setSessionId(data.id);
       setSavedAt(data?.completed_at ?? new Date().toISOString());
       router.refresh();
     } catch (e) {
@@ -132,7 +130,7 @@ export function EndOfWorkoutRecap({
 
       <div style={{ marginBottom: 10 }}>
         <label
-          htmlFor={`recap-notes-${sessionId}`}
+          htmlFor={`recap-notes-${performedOn}`}
           style={{
             fontSize: 11,
             color: "var(--color-text-muted)",
@@ -144,7 +142,7 @@ export function EndOfWorkoutRecap({
           <span style={{ color: "var(--color-text-faint)" }}>(optional — how did it feel?)</span>
         </label>
         <textarea
-          id={`recap-notes-${sessionId}`}
+          id={`recap-notes-${performedOn}`}
           value={notes}
           onChange={(e) => setNotes(e.target.value)}
           rows={2}

--- a/web/src/components/fitness/weekly-workout-plan.tsx
+++ b/web/src/components/fitness/weekly-workout-plan.tsx
@@ -643,6 +643,8 @@ export function WeeklyWorkoutPlan({
                   {day.isToday && (
                     <EndOfWorkoutRecap
                       sessionId={todaySession?.id ?? null}
+                      performedOn={day.date}
+                      workoutPlanId={day.plan?.id ?? null}
                       initialPerceivedEffort={todaySession?.perceived_effort ?? null}
                       initialNotes={todaySession?.notes ?? null}
                       completedAt={todaySession?.completed_at ?? null}


### PR DESCRIPTION
## What
The end-of-workout feedback box (perceived effort + "how did it feel?" notes) existed but only appeared **after you logged a set** — it could only `PATCH` an existing `strength_session`, and sessions were created by the set logger. Do your workout without logging every set in the app and the box never opened, showing only "Log a set above to open the recap." A real coaching signal (how training is going) went uncaptured.

## Fix
- `PATCH /api/strength-sessions` now accepts `performed_on` (+ `workout_plan_id`) as an alternative to `session_id`, and **finds-or-creates** the session itself — mirroring the existing `POST` create path.
- `EndOfWorkoutRecap` always renders on today's workout (no more "log a set first" placeholder), sends `performed_on`, and adopts the returned session id after the first save so a second save updates rather than duplicates.

Now effort + notes can be logged for any workout, whether or not you set-track it — giving the coaching loop the extra reference point.

## Verification
- `tsc`, `eslint`, `prettier` green.
- Create-by-date path exercised against the live DB: a session was created with **no set logged**, then effort (7) + notes persisted correctly; test row cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
