### PR TITLE
docs(claude): point project memory at the private jl-homelab repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,22 @@
 
 @.claude/rules/core.md
 
+## Project memory (cross-device, private)
+
+Durable project facts — coaching/health state, self-host architecture, decisions,
+gotchas — live **committed** in the **private** `jl-homelab` repo at
+`.claude/memory/mrbridge/` (locally `~/jl-homelab/.claude/memory/mrbridge/`).
+
+**This repo is public, so that memory must NEVER be written here** — it contains
+personal health data. The private repo keeps it consistent across devices via `git pull`.
+
+- At session start, read `~/jl-homelab/.claude/memory/mrbridge/README.md` (the index),
+  then the files relevant to the task.
+- Write durable facts THERE (committed via PR to jl-homelab), not only into the
+  device-local `~/.claude` auto-memory store, which does not sync between machines.
+- This is distinct from the "Memory Update Rules" in `core.md`, which govern **live app
+  data** in Supabase — a different thing.
+
 ## graphify
 
 This project has a graphify knowledge graph at graphify-out/.


### PR DESCRIPTION
## What
Adds a "Project memory (cross-device, private)" section to `CLAUDE.md` pointing Claude at the mr-bridge memory now committed in the **private** `jl-homelab` repo (`.claude/memory/mrbridge/`, companion PR Theioz/jl-homelab#530).

## Why
mr-bridge project memory (coaching/health state, self-host architecture, decisions) had lived only in the device-local `~/.claude` store, which doesn't sync across Jason's machines — so context diverged per device. It can't be committed *here* because this repo is public and the memory contains personal health data. Co-locating it in the private homelab repo fixes both: cross-device consistency + privacy. This tells Claude to read it at session start and write durable facts there, distinct from the Supabase live-data rules in `core.md`.

No code or behavior change — documentation/instruction only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
