### PR TITLE
fix(planner,onboarding): enforce equipment caps on written plans, write real target keys

### DIFF
--- a/web/src/app/(protected)/onboarding/page.tsx
+++ b/web/src/app/(protected)/onboarding/page.tsx
@@ -97,11 +97,19 @@ async function saveNutritionTargets(
   "use server";
   const user = await getUser();
   if (!user) return;
+  // These MUST be the *_goal keys. Onboarding used to write calorie_target /
+  // protein_target_g / carb_target_g / fat_target_g, which nothing else in the app
+  // reads — every consumer (meals page, MacroSummaryCard, settings, the profile MCP
+  // tool, the briefing script) reads calorie_goal / protein_goal / carbs_goal /
+  // fat_goal. The Mifflin-St Jeor result computed here was therefore written to
+  // dead keys and the meals page showed no targets until the user separately hit
+  // "Apply" in settings, which uses a different (bodyweight-multiplier) formula.
+  // Note carbs_goal is plural.
   const rows = [
-    { key: "calorie_target", value: calories },
-    { key: "protein_target_g", value: proteinG },
-    { key: "carb_target_g", value: carbsG },
-    { key: "fat_target_g", value: fatG },
+    { key: "calorie_goal", value: calories },
+    { key: "protein_goal", value: proteinG },
+    { key: "carbs_goal", value: carbsG },
+    { key: "fat_goal", value: fatG },
   ].filter((r) => r.value.trim());
   for (const row of rows) await upsert(user.id, row.key, row.value);
 }
@@ -224,10 +232,10 @@ export default async function OnboardingPage() {
         initialWorkoutDaysPerWeek={v["workout_days_per_week"] ?? ""}
         initialWorkoutPrefs={JSON.parse(v["workout_preferences"] ?? "[]") as string[]}
         initialEquipment={JSON.parse(v["equipment_preference"] ?? "[]") as string[]}
-        initialCalorieTarget={v["calorie_target"] ?? ""}
-        initialProteinTarget={v["protein_target_g"] ?? ""}
-        initialCarbTarget={v["carb_target_g"] ?? ""}
-        initialFatTarget={v["fat_target_g"] ?? ""}
+        initialCalorieTarget={v["calorie_goal"] ?? ""}
+        initialProteinTarget={v["protein_goal"] ?? ""}
+        initialCarbTarget={v["carbs_goal"] ?? ""}
+        initialFatTarget={v["fat_goal"] ?? ""}
         initialWatchlist={JSON.parse(v["stock_watchlist"] ?? "[]") as string[]}
         initialSportsFavorites={JSON.parse(v["sports_favorites"] ?? "[]") as SportsFavorite[]}
         saveNameAndLocationAction={saveNameAndLocation}

--- a/web/src/app/api/internal/plan/route.ts
+++ b/web/src/app/api/internal/plan/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServiceClient } from "@/lib/supabase/service";
+import { validateWeights } from "@/lib/fitness/equipment-validation";
 
 interface WorkoutExercise {
   exercise: string;
@@ -491,6 +492,37 @@ export async function POST(request: NextRequest) {
       skipped: true,
       message: `Plan already exists for week of ${nextMondayStr}`,
     });
+  }
+
+  // Equipment caps. `validateWeights` already backs the MCP assign_workout and
+  // update_workout_exercise tools, but the weekly planner wrote model-chosen loads
+  // straight through without it — the one path that writes a whole week at once was
+  // the one path with no cap check. A plan prescribing 30 lb against a 25 lb pair is
+  // not executable, and silently writing it produces a week the user cannot perform.
+  if (workout_days.length > 0) {
+    const allExercises = workout_days.flatMap((d) => [
+      ...(d.warmup ?? []),
+      ...(d.workout ?? []),
+      ...(d.cooldown ?? []),
+    ]);
+    const { valid, violations } = await validateWeights({
+      supabase: db,
+      userId: uid,
+      exercises: allExercises,
+    });
+    if (!valid) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "plan exceeds available equipment",
+          violations: violations.map(
+            (v) =>
+              `${v.exercise}: ${v.requested_weight} lb requested, ${v.max_available} lb is the heaviest ${v.equipment_type} available`,
+          ),
+        },
+        { status: 422 },
+      );
+    }
   }
 
   const errors: string[] = [];


### PR DESCRIPTION
Two independent bugs of the same shape: **real, correct code wired to nothing.**

## 1. Equipment caps skipped the only path that writes a whole week

`validateWeights` already hard-rejects over-cap loads for the MCP `assign_workout` and
`update_workout_exercise` tools. `POST /api/internal/plan` — the path the weekly planner
uses — wrote model-chosen loads straight to `workout_plans` with no check at all.

This matters because exercise selection, sets, reps and loads in this system are **authored by
a model**, not by an algorithm. The equipment cap was the one deterministic guard against that
model prescribing something unperformable, and it was bypassed on the highest-volume write path.

A plan asking for 30 lb against a 25 lb dumbbell pair is not executable. Silently writing it
produces a week the user physically cannot perform, discovered mid-session.

Now validated before the upsert, `422` with per-exercise detail:

```json
{ "ok": false, "error": "plan exceeds available equipment",
  "violations": ["DB Goblet Squat: 30 lb requested, 25 lb is the heaviest dumbbell available"] }
```

## 2. Onboarding wrote nutrition targets to keys nothing reads

`saveNutritionTargets` wrote `calorie_target` / `protein_target_g` / `carb_target_g` /
`fat_target_g`.

Every consumer reads `calorie_goal` / `protein_goal` / `carbs_goal` / `fat_goal`:

- `web/src/app/(protected)/meals/page.tsx`
- `web/src/components/meals/MacroSummaryCard.tsx`
- `web/src/components/settings/profile-form.tsx`
- `web/src/lib/tools/profile.ts` (documents these as canonical)
- `scripts/fetch_briefing_data.py`

Grep confirms the `*_target*` keys appear **nowhere outside onboarding**.

The consequence is bigger than a naming slip: the Mifflin-St Jeor calculation in `targets.ts` —
which `.claude/rules/data-sources.md` documents as the source of truth for macro targets, and
which correctly accounts for age, sex, height, activity and goal — was computed at onboarding
and **thrown away**. The meals page showed no targets at all until the user separately hit
"Apply" on the settings callout, which uses an unrelated `goalWeight × {12|15|17}` bodyweight
multiplier that ignores age, sex, height and training frequency entirely.

`targets.ts` was effectively dead code despite being the documented approach. Note `carbs_goal`
is plural. The read-back now uses the same keys so the form repopulates.

**No migration required:** the only account already carries `*_goal` keys, and nothing ever read
the `*_target*` rows.

## Verification

`tsc --noEmit` clean, `eslint` clean, `prettier --check` clean on both files — the CI job named
`eslint` also runs `prettier --check .`, so passing eslint alone proves nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmYCWGC4UF6EuyPKEuraF
