### PR TITLE
fix(planner): call the app on a host-local origin, not the tailnet host

### DIFF
--- a/.claude/commands/weekly-plan.md
+++ b/.claude/commands/weekly-plan.md
@@ -16,11 +16,17 @@ not be quietly interpreted away.
 
 ## Steps
 
+> **Run these on compute-core with `INTERNAL_APP_URL=http://localhost:3000`.** The script
+> calls the app's own API, and `APP_URL` (the tailnet host) is **not reachable from
+> compute-core** — the hostname resolves to a tailnet IP on another node that the ACL does
+> not grant. Using it fails at connect, which looks like the app being down rather than a
+> config problem.
+
 1. **Fetch the context** (AI-free endpoint — profile, equipment, last week's sets with
    per-set RPE, recovery, meals, habits):
 
    ```bash
-   python3 scripts/weekly_plan.py context --week-start <YYYY-MM-DD>
+   INTERNAL_APP_URL=http://localhost:3000 python3 scripts/weekly_plan.py context --week-start <YYYY-MM-DD>
    ```
 
    `<YYYY-MM-DD>` is the **Monday** of the week to plan. Default to next Monday.
@@ -41,7 +47,7 @@ not be quietly interpreted away.
 4. **Submit:**
 
    ```bash
-   python3 scripts/weekly_plan.py submit /tmp/plan.json --week-start <YYYY-MM-DD>
+   INTERNAL_APP_URL=http://localhost:3000 python3 scripts/weekly_plan.py submit /tmp/plan.json --week-start <YYYY-MM-DD>
    ```
 
    This writes `workout_plans` rows and the meal-prep task.

--- a/.env.example
+++ b/.env.example
@@ -81,8 +81,15 @@ CRON_SECRET=<random-string>
 # reintroduce the typo.
 NTFY_TOPIC=<your-ntfy-topic>
 
-# Where a tapped notification opens. Tailnet-only.
+# Where a tapped notification opens. Tailnet-only — this hostname resolves to a tailnet
+# IP, so it is reachable from your phone/laptop on the tailnet but NOT from compute-core
+# itself (the ACL does not grant compute-core -> the node serving it).
 APP_URL=https://mr-bridge.jl-infra-lab.com
+
+# Origin for HOST-LOCAL server-to-server calls — scripts on compute-core calling the app's
+# own API (scripts/weekly_plan.py context|submit). Must NOT be APP_URL: a call to the
+# tailnet host from compute-core fails at connect, which reads as "the app is down".
+INTERNAL_APP_URL=http://localhost:3000
 
 # Share links go to people OUTSIDE the tailnet, so they must resolve on the PUBLIC
 # host. Using APP_URL here would hand recipients an unreachable link.

--- a/scripts/weekly_plan.py
+++ b/scripts/weekly_plan.py
@@ -34,12 +34,26 @@ if env_file.exists():
 # /api/cron/weekly-plan disabled. Do not reintroduce it: generation happens in a
 # Claude Code session, not here.
 
-APP_URL = os.environ.get("APP_URL")
-if not APP_URL:
+# API_BASE — the origin THIS SCRIPT uses for its own server-to-server calls.
+#
+# Deliberately not APP_URL. APP_URL is the tailnet-only app host (see
+# web/src/lib/share-url.ts, which already documents that distinction for share links).
+# This script runs ON compute-core, and compute-core cannot reach that host:
+# mr-bridge.jl-infra-lab.com resolves to a tailnet IP belonging to a *different* node,
+# and the Tailscale ACL does not grant compute-core -> that node. A call to APP_URL
+# from here fails at connect, not at auth — so it looks like the app is down.
+#
+# Precedence:
+#   INTERNAL_APP_URL   loopback/LAN origin for host-local calls, e.g. http://localhost:3000
+#   APP_URL            fallback for dev or a single-host deploy where they are the same
+API_BASE = os.environ.get("INTERNAL_APP_URL") or os.environ.get("APP_URL")
+if not API_BASE:
     raise SystemExit(
-        "APP_URL must be set. It previously defaulted to the Vercel deployment, which was "
-        "decommissioned in the 2026-07-13 self-host cutover — the default silently pointed "
-        "every submit at a dead host."
+        "Set INTERNAL_APP_URL (preferred, e.g. http://localhost:3000) or APP_URL.\n"
+        "This previously defaulted to the Vercel deployment, decommissioned in the "
+        "2026-07-13 self-host cutover, so the default silently pointed every submit at a "
+        "dead host. Note APP_URL alone is not reachable from compute-core — it is the "
+        "tailnet app host on another node."
     )
 CRON_SECRET = os.environ["CRON_SECRET"]
 
@@ -420,7 +434,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.cmd == "context":
-        status, text = fetch(f"{APP_URL}/api/internal/plan?week_start={args.week_start}")
+        status, text = fetch(f"{API_BASE}/api/internal/plan?week_start={args.week_start}")
         if status != 200:
             print(f"failed to fetch context: {status}\n{text}", file=sys.stderr)
             sys.exit(1)
@@ -475,7 +489,7 @@ def main() -> None:
             )
             sys.exit(1)
         body = json.dumps({**plan, "week_start": args.week_start}).encode()
-        status, text = fetch(f"{APP_URL}/api/internal/plan", method="POST", body=body)
+        status, text = fetch(f"{API_BASE}/api/internal/plan", method="POST", body=body)
         if status not in (200, 201):
             print(f"submit failed: {status}\n{text}", file=sys.stderr)
             sys.exit(1)


### PR DESCRIPTION
## The bug

`weekly_plan.py context|submit` called `APP_URL` — on this deployment
`https://mr-bridge.jl-infra-lab.com`. That hostname resolves to **100.103.184.12**, a tailnet
IP belonging to a *different* node, and the Tailscale ACL does not grant compute-core → that
node. The script runs **on** compute-core, so every call died at connect.

It surfaced as `HTTP 000` — no status, no auth error. That reads as "the app is down" rather
than "wrong origin", which is the expensive kind of failure.

## Why this isn't a DNS fix

Worth stating, because the first instinct is to go fix name resolution:

- The name resolves **correctly** via AdGuard (192.168.68.51) and via 1.1.1.1 — both return
  100.103.184.12.
- That address is genuinely **unreachable from compute-core**, by ACL design. Surface↔node is
  LAN-by-IP with no tailnet grant.
- So compute-core reaching its own public hostname would need either a hairpin through the
  reverse proxy or an ACL grant that deliberately does not exist.

A host-local origin is the correct answer for host-local calls. Nothing in the network needs
to change.

(Separately noted while diagnosing: `resolvectl` shows `tailscale0` claiming the root routing
domain `~.`, so the systemd-resolved stub routes *every* query to MagicDNS at
`fd7a:115c:a1e0::53` first, and that intermittently times out — `getent hosts` on this name
failed while `github.com` succeeded moments later. Syncs are unaffected — `sync_log` shows
oura/google_health `ok` through today — so this is a latency annoyance, not an outage. Out of
scope here.)

## The fix

`INTERNAL_APP_URL`, falling back to `APP_URL` so dev and single-host deploys where the two are
the same keep working:

```python
API_BASE = os.environ.get("INTERNAL_APP_URL") or os.environ.get("APP_URL")
```

`web/src/lib/share-url.ts` already documents `APP_URL` as *"the tailnet-only app host"* — the
same distinction, for outbound share links. It was simply missing for the app calling itself.
This makes the pair explicit:

| Var | Reachable from | Used for |
|---|---|---|
| `APP_URL` | tailnet clients (phone, laptop) | notification click-through |
| `SHARE_BASE_URL` | public internet | `/share/*` links |
| `INTERNAL_APP_URL` | the host itself | scripts calling the app's own API |

Documented in `.env.example` and in `/weekly-plan`, which is where the commands actually get
copied from.

## Verification

On compute-core against the running container:

```
APP_URL only          -> urllib connection failure          (reproduces the bug)
INTERNAL_APP_URL set  -> "## PLANNING CONTEXT — coming week 2026-08-03 to 2026-08-09"
neither set           -> fails loudly naming both vars
```

`py_compile` clean. CI is path-filtered to `web/`, so this gets no lint or typecheck.

## Deploy note

`INTERNAL_APP_URL=http://localhost:3000` needs adding to the live `~/docker/mr-bridge/.env` on
compute-core, and to the `mr-bridge-env` Vaultwarden note so the two don't drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmYCWGC4UF6EuyPKEuraF
