### PR TITLE
fix(nutrition): ml and l were resolving to 100x their real weight

### DIFF
--- a/web/src/__tests__/grams-for.test.ts
+++ b/web/src/__tests__/grams-for.test.ts
@@ -1,0 +1,70 @@
+// Unit tests for gram conversion (nutrition/fdc.ts -> gramsFor).
+// Run with: node --experimental-strip-types --test src/__tests__/grams-for.test.ts
+// (from the web/ directory)
+//
+// WHY THIS EXISTS
+//
+// Sibling to quantity.test.ts. That file pins that the NUMBER reaching USDA is the number
+// the user wrote. This one pins that the number is then converted to the right WEIGHT.
+//
+// The bug that prompted it: `ml` was a recognised alias in quantity.ts, so the lexer
+// correctly produced {qty: 750, unit: "ml"} for "750 ml red wine". But gramsFor had no
+// entry for it in DIRECT_GRAMS, and "ml" is not in GENERIC_UNITS either, so it fell all
+// the way through to the step-4 fallback:
+//
+//     FALLBACK_GRAMS[u] ?? FALLBACK_GRAMS.serving   // = 100 g
+//     -> 750 * 100 = 75,000 g
+//
+// A 750 ml bottle of wine resolved to 62,250 kcal. Every ml/l quantity was silently 100x
+// its real weight. The confidence guard caught it only as "low" — it still emitted the
+// number, and a `low` badge is not the same as refusing to answer.
+//
+// A correctly-lexed quantity is not enough. It has to land in a unit table too, and the
+// failure mode when it doesn't is a wrong number, not an error.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { gramsFor } from "../lib/nutrition/fdc.ts";
+
+// USDA returns per-food portion rows; most beverages have none, which is what pushed
+// "ml" down to the fallback branch in the first place.
+const NO_PORTIONS: never[] = [];
+
+test("ml converts at water density, not via the 100g serving fallback", () => {
+  const r = gramsFor(750, "ml", NO_PORTIONS);
+  assert.equal(r.grams, 750, "750 ml must be 750 g, not 75,000");
+  assert.equal(r.exact, true, "a stated volume is the user's own measurement");
+});
+
+test("litres scale by 1000", () => {
+  assert.equal(gramsFor(1, "l", NO_PORTIONS).grams, 1000);
+  assert.equal(gramsFor(1.5, "liters", NO_PORTIONS).grams, 1500);
+});
+
+test("ml aliases all resolve", () => {
+  for (const u of ["ml", "milliliter", "milliliters"]) {
+    assert.equal(gramsFor(250, u, NO_PORTIONS).grams, 250, `${u} should be 1 g/ml`);
+  }
+});
+
+test("a 750 ml bottle lands in a plausible calorie range for wine", () => {
+  // Regression guard in the units that actually matter. USDA 174833 (Cabernet Sauvignon)
+  // is ~83 kcal/100 g, so a bottle is ~620 kcal — not ~62,000.
+  const { grams } = gramsFor(750, "ml", NO_PORTIONS);
+  const kcal = (grams / 100) * 83;
+  assert.ok(kcal > 500 && kcal < 750, `expected ~620 kcal for a bottle, got ${Math.round(kcal)}`);
+});
+
+test("existing weight units are unchanged", () => {
+  assert.equal(gramsFor(5, "g", NO_PORTIONS).grams, 5);
+  assert.equal(gramsFor(1, "kg", NO_PORTIONS).grams, 1000);
+  assert.equal(Math.round(gramsFor(1, "lb", NO_PORTIONS).grams), 454);
+  assert.equal(Math.round(gramsFor(1, "oz", NO_PORTIONS).grams), 28);
+});
+
+test("an unknown unit still falls back, and still says so", () => {
+  // The fallback branch is correct behaviour for a genuinely unknown unit — what was
+  // wrong was ml reaching it. `exact: false` is what downgrades the confidence badge.
+  const r = gramsFor(2, "handful", NO_PORTIONS);
+  assert.equal(r.exact, false);
+});

--- a/web/src/lib/nutrition/fdc.ts
+++ b/web/src/lib/nutrition/fdc.ts
@@ -418,6 +418,22 @@ const DIRECT_GRAMS: Record<string, number> = {
   ounces: 28.3495,
   lb: 453.592,
   pound: 453.592,
+  // Volume, at water density (1 ml = 1 g). An approximation, but a small one for the
+  // liquids people actually log: wine 0.99, milk 1.03, juice ~1.05. Oil (0.92) and
+  // honey (1.4) are the outliers.
+  //
+  // These were MISSING, and the failure was not graceful. `ml` is a known alias in
+  // quantity.ts, so the lexer happily produced {qty: 750, unit: "ml"} — but gramsFor
+  // had no direct conversion, "ml" is not in GENERIC_UNITS either, so it fell through
+  // to the step-4 fallback of FALLBACK_GRAMS.serving = 100g and returned
+  // 750 x 100 = 75,000 g. A 750 ml bottle of wine resolved to 62,250 kcal.
+  // Any ml/l quantity was silently 100x its real weight.
+  ml: 1,
+  milliliter: 1,
+  milliliters: 1,
+  l: 1000,
+  liter: 1000,
+  liters: 1000,
 };
 
 /**


### PR DESCRIPTION
## The bug

Logging a real drink surfaced this. `750 ml red wine` resolved to:

```
Cabernet Sauvignon (750 ml bottle): 62250 kcal / 52.5P / 1950C / 0F  [low]
  750 ml red wine -> Alcoholic Beverage, wine, table, red, Cabernet Sauvignon
     (FDC 174833, 75000g, quantified=true)
```

**75,000 g for 750 ml.** Every `ml` or `l` quantity was silently 100x its real weight.

## Mechanism

`ml` *is* a recognised alias in `quantity.ts`, so the lexer did its job — `{qty: 750, unit: "ml"}`
is correct. The failure is one layer down in `gramsFor`:

1. `DIRECT_GRAMS` has no `ml` → step 1 misses
2. no USDA portion matches `"ml"` (most beverages have no portion rows) → step 2 misses
3. `ml` is not in `GENERIC_UNITS` → step 3 misses
4. step 4: `FALLBACK_GRAMS[u] ?? FALLBACK_GRAMS.serving` = **100 g** → `750 × 100`

## The guard fired and it wasn't enough

The result came back `confidence: low`, because step 4 returns `exact: false`. That is the
system working as designed — and it still wrote 62,250 kcal into a recipe row.

A confidence downgrade is not a refusal. It is a badge on a number that is still there, still
summed into a daily total. `low` is meant to mean "this portion was assumed"; it should not
also have to mean "this may be off by four orders of magnitude."

## Fix

`ml`/`milliliter`/`milliliters` = 1, `l`/`liter`/`liters` = 1000, at water density.

That is an approximation and the comment says so: wine 0.99, milk 1.03, juice ~1.05, with oil
(0.92) and honey (1.4) the outliers. A few percent beats ten thousand percent. A stated volume
is the user's own measurement, so it returns `exact: true` alongside the other direct units.

## Tests

New `src/__tests__/grams-for.test.ts`, a deliberate sibling to `quantity.test.ts`:

> That file pins that the **number** reaching USDA is the number the user wrote.
> This one pins that the number converts to the right **weight**.

A correctly-lexed quantity is not sufficient — it has to land in a unit table too, and the
failure mode when it doesn't is a wrong number rather than an error. Includes a range assertion
that a 750 ml bottle lands at ~620 kcal rather than ~62,000, and a case confirming a genuinely
unknown unit (`handful`) still falls back with `exact: false`, since that branch is correct
behaviour — what was wrong was `ml` reaching it.

## Verification

```
6 new tests pass · 10 existing quantity tests still pass
tsc --noEmit clean · eslint clean · prettier clean
```

Post-deploy the wine recipe needs re-resolving with `?force=1` to overwrite the bad row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmYCWGC4UF6EuyPKEuraF
