### PR TITLE
fix(sync): return None cleanly for unconnected integration instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **An unconnected integration no longer crashes the sync with a misleading traceback.**
+  `load_integration` read `.data` off `maybe_single().execute()`, which returns `None` (not a
+  response object) when zero rows match in this postgrest-py version — so a provider that simply
+  isn't connected (e.g. `google_health`) raised `AttributeError: 'NoneType' object has no
+  attribute 'data'` and looked like a code failure / "no workouts this week" instead of a
+  connection gap. It now returns `None` cleanly, so callers hit their real guard (e.g. "Google
+  Health not connected — authorize via /settings").
+
 - **A meal logged from the fridge now shows what it was.** The "Logged today" list read a meal's
   name from `recipes(name) ?? notes`, but a one-tap "Ate this" writes a `cook_id`, not a recipe —
   so a logged cook had no name and rendered as "—" (or, worse, showed an internal note). The

--- a/scripts/_integrations.py
+++ b/scripts/_integrations.py
@@ -23,14 +23,18 @@ def _require_encryption_key() -> str:
 def load_integration(client, user_id: str, provider: str) -> dict | None:
     """Return {refresh_token, scopes, connected_at} for (user_id, provider), or None if not found."""
     key = _require_encryption_key()
-    row = (
+    resp = (
         client.table("user_integrations")
         .select("refresh_token_encrypted, scopes, connected_at")
         .eq("user_id", user_id)
         .eq("provider", provider)
         .maybe_single()
         .execute()
-    ).data
+    )
+    # maybe_single().execute() returns None (not a response object) when zero rows
+    # match in this postgrest-py version — guard so an unconnected provider returns
+    # None cleanly instead of raising AttributeError on `.data`.
+    row = resp.data if resp else None
     if not row:
         return None
 


### PR DESCRIPTION
## What
`load_integration` crashed with `AttributeError: 'NoneType' object has no attribute 'data'` whenever a provider row didn't exist, instead of returning `None`.

## Root cause
`.maybe_single().execute()` returns `None` (not a response object) when zero rows match in the installed postgrest-py version. The code read `.data` off that directly. So an **unconnected** provider looked like a code failure.

## Impact (real-world)
`run-syncs.py` → `sync-google-health.py` traceback'd on a fresh session. `google_health` is **not currently connected** on the live self-hosted DB (only `oura`, `google`, `fitbit` rows exist), so every sync run crashed and body-comp/workout data silently stopped refreshing — masquerading as "no workouts this week."

## Fix
Guard the response: `row = resp.data if resp else None`. Callers now hit their existing guards — `sync-google-health.py` prints `Google Health not connected — authorize via /settings`.

## Test
```
$ python3 scripts/sync-google-health.py
Google Health not connected — authorize via /settings   # was: traceback
```

## Follow-up (not in this PR)
The actual data fix is reconnecting Google Health via `/settings` — **first verify the Google Cloud OAuth app is "In production," not "Testing"** (Testing-mode refresh tokens expire after 7 days; consent was 2026-07-14). See homelab memory `project_mrbridge_google_health_port`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)