### PR TITLE
fix(meals): inherit plan date when logging a planned meal, not UTC today

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **Logging a planned meal in the evening no longer lands it on tomorrow.** `eatFromCook` stamped
+  the `meal_log` row with `new Date().toISOString().slice(0,10)` — a **UTC** date — so tapping
+  "Ate this" after ~5pm PT (past UTC midnight) logged the meal on the next day, splitting it from
+  the plan it satisfied and throwing off today's totals. A plan-linked meal now **inherits its
+  `meal_plan.date`** (explicit `date` still wins; UTC remains only as the last resort for a
+  free-form, plan-less log). Fixes a real 2026-07-19 mislog (Sunday lunch recorded on Monday).
+
 - **A meal logged from the fridge now shows what it was.** The "Logged today" list read a meal's
   name from `recipes(name) ?? notes`, but a one-tap "Ate this" writes a `cook_id`, not a recipe —
   so a logged cook had no name and rendered as "—" (or, worse, showed an internal note). The

--- a/web/src/lib/nutrition/cooks.ts
+++ b/web/src/lib/nutrition/cooks.ts
@@ -204,11 +204,27 @@ export async function eatFromCook(
     fiber_g: Math.round(one.fiber_g * portions * 10) / 10,
   };
 
+  // A plan-linked meal belongs on its plan's own date. Deriving the log date from UTC instead
+  // lands an evening log on "tomorrow" once it is past UTC midnight but still today locally
+  // (6:40pm PT = 01:40Z the next day is what put a Sunday lunch on Monday). Prefer an explicit
+  // date, then the linked plan's date, then UTC as a last resort for a free-form, plan-less log.
+  let logDate = input.date;
+  if (!logDate && input.mealPlanId) {
+    const { data: plan } = await db
+      .from("meal_plans")
+      .select("date")
+      .eq("id", input.mealPlanId)
+      .eq("user_id", userId)
+      .maybeSingle();
+    logDate = (plan?.date as string | undefined) ?? undefined;
+  }
+  logDate = logDate ?? new Date().toISOString().slice(0, 10);
+
   const { data: logged, error: logErr } = await db
     .from("meal_log")
     .insert({
       user_id: userId,
-      date: input.date ?? new Date().toISOString().slice(0, 10),
+      date: logDate,
       meal_type: input.mealType ?? null,
       cook_id: cook.id,
       meal_plan_id: input.mealPlanId ?? null,


### PR DESCRIPTION
## Bug
Tapping **"Ate this"** on a planned meal in the evening (PT) logged it on **tomorrow**. Reported live 2026-07-19: a Sunday lunch (Linguine leftover, 690 kcal, plan dated 07-19) landed in `meal_log` as **07-20**, detached from its plan and skewing today's totals.

## Root cause
`eatFromCook` (`web/src/lib/nutrition/cooks.ts`) wrote:
```ts
date: input.date ?? new Date().toISOString().slice(0, 10)  // UTC
```
The "Ate this" client didn't pass a `date`, so it fell to the **UTC** date. At 6:40pm PT it's already 01:40 the next day in UTC → the meal logs on tomorrow.

## Fix
A plan-linked meal now inherits its **`meal_plan.date`**:
1. explicit `input.date` (unchanged, still wins)
2. the linked plan's `date` (new)
3. UTC today — last resort only for a free-form, plan-less log

## Data
The one mislogged row (2026-07-19 lunch) was corrected in prod directly (07-20 → 07-19); today's totals are right.

## Test
- `prettier --check` ✅ · `eslint` ✅ · `tsc` shows no errors in `cooks.ts` (only pre-existing stale `.next` route types + locally-uninstalled MCP SDK).
- Logic: with `mealPlanId` and no `date`, `logDate` resolves to the plan's date; free-form logs are unchanged.

## Follow-up (not here)
`cooks.ts:116` (`cooked_on`) and any other UTC `slice(0,10)` defaults have the same near-midnight skew — lower impact (cook date, not the logged day). Worth a sweep + a shared `localToday(userTz)` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)