### PR TITLE
Fix briefing crash on tasks with null priority

### DIFF
--- a/scripts/fetch_briefing_data.py
+++ b/scripts/fetch_briefing_data.py
@@ -306,7 +306,7 @@ def main():
     if tasks:
         for t in tasks:
             due = f" | Due: {t['due_date']}" if t.get("due_date") else ""
-            print(f"- [{t.get('priority', '—').upper()}] {t['title']}{due}")
+            print(f"- [{(t.get('priority') or '—').upper()}] {t['title']}{due}")
     else:
         print("- None")
 


### PR DESCRIPTION
## Problem
`fetch_briefing_data.py` renders the ACTIVE TASKS block with `t.get('priority', '—').upper()`.

`dict.get(key, default)` returns the default only when the key is **absent**. A task row where `priority` is explicitly `null` returns `None`, and `None.upper()` raises `AttributeError` — aborting the entire briefing, so tasks, habits, and recovery never print. Hit live on 2026-07-20.

## Fix
`(t.get('priority') or '—').upper()` — handles both absent and null.

One line. No CI on `scripts/` (path-filtered to `web/`); verified with `python -m py_compile`.
