### PR TITLE
Persist unquantified ingredients; cap incomplete resolves at low confidence

### DIFF
--- a/web/src/lib/nutrition/recipe-macros.ts
+++ b/web/src/lib/nutrition/recipe-macros.ts
@@ -125,6 +125,15 @@ export async function resolveRecipeMacros(
   }));
   const unquantified = items.filter((i) => !i.quantified).map((i) => i.input);
 
+  // An ingredient that could not be quantified or matched is ABSENT from the total, so an
+  // incomplete resolve silently understates a real plate — a 200g chicken thigh dropping out
+  // took one recipe from ~40g protein to ~12g with nothing in the row to show for it. The
+  // unmatched list was already persisted; the unquantified list was computed and thrown away,
+  // which is exactly the trace that went missing. Persist both, and never let a total that is
+  // known to be missing an ingredient read above "low".
+  const incomplete = unquantified.length > 0 || estimate.unmatched.length > 0;
+  if (incomplete) total.confidence = "low";
+
   const { error: writeErr } = await db
     .from("recipes")
     .update({
@@ -141,6 +150,7 @@ export async function resolveRecipeMacros(
         macro_items: items,
         macro_notes: total.notes,
         macro_unmatched: estimate.unmatched,
+        macro_unquantified: unquantified,
       },
     })
     .eq("id", recipeId)


### PR DESCRIPTION
## Problem
`resolveRecipeMacros()` drops any ingredient the pipeline cannot quantify or match from the total (correct — a wrong match is worse than an omission), but it persisted **only** `macro_unmatched`. The `unquantified` list was computed and thrown away.

The result is a silent, traceless understatement of a real plate. While planning the week of 7/20 the resolver dropped a **200 g chicken thigh** from one recipe — taking it from ~40 g protein to **11.6 g** — with an empty `macro_unmatched` and nothing else to show an ingredient was missing. The same run matched frozen berries to a granola bar and Greek yogurt to regular. The drop is nondeterministic across runs, so a re-resolve is not a reliable check.

## Fix
- Persist `macro_unquantified` alongside `macro_unmatched`, so a dropped ingredient always leaves an audit trace.
- Force `macros_confidence` to `low` whenever the total is known to be missing an ingredient (`unquantified` or `unmatched` non-empty). Extends the existing "invented amounts make high unreachable" guard to the omission case.

## Not covered
The underlying nondeterministic model matching is unchanged; this makes its failures **loud and auditable** rather than silent.

## Testing
Formatting not verifiable locally — neither homelab host has node/prettier. **Relying on CI's `eslint`/`prettier --check` job.** Style matched to the surrounding file by hand.
