### PR TITLE
feat(meals): fridge/freezer/pantry inventory

### DIFF
--- a/supabase/migrations/20260721000000_add_inventory_items.sql
+++ b/supabase/migrations/20260721000000_add_inventory_items.sql
@@ -1,0 +1,61 @@
+-- ---------------------------------------------------------------------------
+-- inventory_items: raw ingredients on hand — the fridge/freezer/pantry.
+--
+-- `cooks` already tracks PREPARED leftovers (portions_remaining). This table is its
+-- raw-ingredient counterpart: the salmon, rice and frozen steak you bought but have not
+-- cooked yet. Together they answer the question the weekly planner should ask FIRST —
+-- "what do I already have?" — so it plans INTO the kitchen instead of around it, oldest
+-- and soonest-to-expire first, and remembers the frozen steak without being told each time.
+-- ---------------------------------------------------------------------------
+
+create table if not exists inventory_items (
+  id          uuid primary key default gen_random_uuid(),
+  user_id     uuid not null references auth.users (id) on delete cascade,
+
+  name        text not null,
+
+  -- Deliberately loose: "2 steaks", "340 g", "1 bag". A weight (g/oz/lb) or a count
+  -- (each/portion/can/bunch) — whatever matches how the item is actually stored. Null
+  -- quantity means "on hand, amount untracked" (a pantry staple like rice or oil).
+  quantity    numeric(10, 2),
+  unit        text,
+
+  -- Where it lives drives perishability AND how the planner treats it: fresh fish in the
+  -- fridge must be cooked within days; the same fish in the freezer is next-week inventory.
+  location    text not null default 'fridge'
+              constraint inventory_items_location_check
+              check (location in ('fridge', 'freezer', 'pantry', 'counter')),
+
+  category    text,
+
+  added_date  date not null default current_date,
+  -- Estimated fresh-window end. Powers the "use soon" flag; null for shelf-stable items.
+  expires_on  date,
+
+  notes       text,
+  metadata    jsonb not null default '{}'::jsonb,
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
+
+create index if not exists inventory_items_user_idx on inventory_items (user_id);
+create index if not exists inventory_items_user_location_idx on inventory_items (user_id, location);
+-- The "what's about to turn?" query — perishables sorted by fresh window.
+create index if not exists inventory_items_user_expires_idx on inventory_items (user_id, expires_on)
+  where expires_on is not null;
+
+comment on table inventory_items is
+  'Raw ingredients on hand (fridge/freezer/pantry). The counterpart to cooks (prepared '
+  'leftovers): together they are everything already in the kitchen the planner can spend.';
+comment on column inventory_items.quantity is
+  'Null = on hand but amount untracked (a staple). Otherwise a count or a weight, paired '
+  'with unit. Loose by design — this is a shopping/perishability aid, not lab inventory.';
+comment on column inventory_items.location is
+  'Drives perishability: the same protein is "cook this week" in the fridge and "next week" '
+  'in the freezer. Moving fridge->freezer is how "I froze it" is recorded.';
+
+alter table inventory_items enable row level security;
+
+drop policy if exists inventory_items_owner_all on inventory_items;
+create policy inventory_items_owner_all on inventory_items
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);

--- a/web/src/app/(protected)/meals/page.tsx
+++ b/web/src/app/(protected)/meals/page.tsx
@@ -8,6 +8,7 @@ import {
   type KitchenCook,
   type KitchenPlannedMeal,
 } from "@/components/meals/KitchenPanel";
+import { InventoryPanel, type InventoryItem } from "@/components/meals/InventoryPanel";
 import { WeekPlan } from "@/components/meals/WeekPlan";
 import MealsClient, {
   type MealRow,
@@ -53,7 +54,12 @@ export default async function MealsPage() {
 
   // Wave 2 — these all need user.id from Wave 1.
   const userId = user?.id;
-  const [{ data: recipesData }, { data: leftoversData }, { data: planData }] = await Promise.all([
+  const [
+    { data: recipesData },
+    { data: leftoversData },
+    { data: planData },
+    { data: inventoryData },
+  ] = await Promise.all([
     userId
       ? supabase
           .from("recipes")
@@ -87,6 +93,17 @@ export default async function MealsPage() {
           .gte("date", todayString())
           .lte("date", daysAheadString(6))
           .order("date", { ascending: true })
+      : Promise.resolve({ data: [] }),
+    // Raw ingredients on hand — the fridge/freezer/pantry the planner cooks into. Oldest and
+    // soonest-to-expire first, so the panel surfaces what to use before it turns.
+    userId
+      ? supabase
+          .from("inventory_items")
+          .select("id, name, quantity, unit, location, category, added_date, expires_on, notes")
+          .eq("user_id", userId)
+          .order("location", { ascending: true })
+          .order("expires_on", { ascending: true, nullsFirst: false })
+          .order("name", { ascending: true })
       : Promise.resolve({ data: [] }),
   ]);
 
@@ -211,6 +228,8 @@ export default async function MealsPage() {
         leftovers={(leftoversData ?? []) as unknown as KitchenCook[]}
         plan={weekPlan.filter((p) => p.date === today)}
       />
+
+      <InventoryPanel items={(inventoryData ?? []) as unknown as InventoryItem[]} />
 
       <WeekPlan week={weekPlan} days={getNextNDays(7)} today={today} />
 

--- a/web/src/app/api/inventory/[id]/route.ts
+++ b/web/src/app/api/inventory/[id]/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { deleteItem, updateItem } from "@/lib/nutrition/inventory";
+
+/**
+ * Edit an item: draw its quantity down as it's used, move it fridge->freezer when frozen,
+ * fix an expiry or a note. Only the supplied fields change.
+ */
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  try {
+    const db = createServiceClient();
+    const item = await updateItem(db, user.id, id, body);
+    return NextResponse.json({ item });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Failed to update item";
+    const client = /not found|must be|cannot be blank|location/i.test(msg);
+    if (!client) console.error("[PATCH /api/inventory/[id]]", err);
+    return NextResponse.json({ error: msg }, { status: client ? 400 : 500 });
+  }
+}
+
+/** Used up or tossed — remove it. */
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    const db = createServiceClient();
+    await deleteItem(db, user.id, id);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Failed to remove item";
+    console.error("[DELETE /api/inventory/[id]]", err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/web/src/app/api/inventory/route.ts
+++ b/web/src/app/api/inventory/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { createItem, listInventory } from "@/lib/nutrition/inventory";
+
+/** What's in the kitchen: raw ingredients on hand, by location, soonest-to-expire first. */
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    const db = createServiceClient();
+    return NextResponse.json({ items: await listInventory(db, user.id) });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Failed to load inventory";
+    console.error("[GET /api/inventory]", err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+/** Add an item to the kitchen. Name is required; everything else is optional. */
+export async function POST(req: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  try {
+    const db = createServiceClient();
+    const item = await createItem(db, user.id, body);
+    return NextResponse.json({ item });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Failed to add item";
+    // Bad input (no name, bad quantity/location) is the user's to fix.
+    const client = /needs a name|must be|cannot be blank|location/i.test(msg);
+    if (!client) console.error("[POST /api/inventory]", err);
+    return NextResponse.json({ error: msg }, { status: client ? 400 : 500 });
+  }
+}

--- a/web/src/components/meals/InventoryPanel.tsx
+++ b/web/src/components/meals/InventoryPanel.tsx
@@ -1,0 +1,515 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * The kitchen inventory: raw ingredients on hand, by location.
+ *
+ * The fridge-leftovers panel (KitchenPanel) only knows about food already COOKED. It was blind
+ * to the raw salmon and the frozen steak, which is why planning had to be TOLD what was on hand
+ * every week. This panel closes that gap: fridge / freezer / pantry, soonest-to-expire first,
+ * with a "use soon" flag so nothing quietly turns. Moving an item to the freezer is one tap —
+ * that is how "I froze it" gets recorded, and how the planner learns the steak is next-week food.
+ *
+ * No macros here by design — an inventory item is a location and a rough quantity, not a
+ * nutrition record.
+ */
+
+export interface InventoryItem {
+  id: string;
+  name: string;
+  quantity: number | null;
+  unit: string | null;
+  location: string;
+  category: string | null;
+  added_date: string;
+  expires_on: string | null;
+  notes: string | null;
+}
+
+const LOCATIONS = ["fridge", "freezer", "pantry", "counter"] as const;
+const LOCATION_LABEL: Record<string, string> = {
+  fridge: "Fridge",
+  freezer: "Freezer",
+  pantry: "Pantry",
+  counter: "Counter",
+};
+
+function daysUntil(dateStr: string): number {
+  const then = new Date(`${dateStr}T00:00:00`);
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  return Math.round((then.getTime() - now.getTime()) / 86_400_000);
+}
+
+// Fresh window as a short badge. Danger colour when it's within two days or already past —
+// those are the items the next cook should spend first.
+function expiryLabel(dateStr: string | null): { text: string; urgent: boolean } | null {
+  if (!dateStr) return null;
+  const d = daysUntil(dateStr);
+  if (d < 0) return { text: "expired", urgent: true };
+  if (d === 0) return { text: "use today", urgent: true };
+  if (d <= 2) return { text: `use in ${d}d`, urgent: true };
+  return { text: `${d}d left`, urgent: false };
+}
+
+function quantityLabel(item: InventoryItem): string {
+  if (item.quantity == null) return item.unit ?? "on hand";
+  const qty = String(Number(item.quantity));
+  return item.unit ? `${qty} ${item.unit}` : qty;
+}
+
+interface InventoryPanelProps {
+  items: InventoryItem[];
+}
+
+const EMPTY_FORM = {
+  name: "",
+  quantity: "",
+  unit: "",
+  location: "fridge",
+  category: "",
+  expires_on: "",
+  notes: "",
+};
+type FormState = typeof EMPTY_FORM;
+
+export function InventoryPanel({ items }: InventoryPanelProps) {
+  const router = useRouter();
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState<FormState>(EMPTY_FORM);
+  const [adding, setAdding] = useState(false);
+  const [addForm, setAddForm] = useState<FormState>(EMPTY_FORM);
+
+  // Every mutation writes through the API then invalidates the server component, same pattern
+  // as KitchenPanel — no local cache to keep in sync.
+  async function call(url: string, method: string, body?: unknown): Promise<boolean> {
+    setError(null);
+    try {
+      const res = await fetch(url, {
+        method,
+        headers: body ? { "Content-Type": "application/json" } : undefined,
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      if (!res.ok) {
+        setError((await res.json().catch(() => ({}))).error ?? "Something went wrong");
+        return false;
+      }
+      router.refresh();
+      return true;
+    } catch {
+      setError("Something went wrong");
+      return false;
+    }
+  }
+
+  async function move(item: InventoryItem, location: string) {
+    if (location === item.location) return;
+    setBusyId(item.id);
+    await call(`/api/inventory/${item.id}`, "PATCH", { location });
+    setBusyId(null);
+  }
+
+  async function remove(id: string) {
+    setBusyId(id);
+    await call(`/api/inventory/${id}`, "DELETE");
+    setBusyId(null);
+  }
+
+  function startEdit(item: InventoryItem) {
+    setEditingId(item.id);
+    setEditForm({
+      name: item.name,
+      quantity: item.quantity == null ? "" : String(item.quantity),
+      unit: item.unit ?? "",
+      location: item.location,
+      category: item.category ?? "",
+      expires_on: item.expires_on ?? "",
+      notes: item.notes ?? "",
+    });
+  }
+
+  async function saveEdit(id: string) {
+    setBusyId(id);
+    const ok = await call(`/api/inventory/${id}`, "PATCH", {
+      name: editForm.name,
+      quantity: editForm.quantity === "" ? null : editForm.quantity,
+      unit: editForm.unit,
+      location: editForm.location,
+      category: editForm.category,
+      expires_on: editForm.expires_on || null,
+      notes: editForm.notes,
+    });
+    setBusyId(null);
+    if (ok) setEditingId(null);
+  }
+
+  async function addItem() {
+    if (!addForm.name.trim()) {
+      setError("Name is required");
+      return;
+    }
+    setBusyId("__add__");
+    const ok = await call("/api/inventory", "POST", {
+      name: addForm.name,
+      quantity: addForm.quantity === "" ? null : addForm.quantity,
+      unit: addForm.unit,
+      location: addForm.location,
+      category: addForm.category,
+      expires_on: addForm.expires_on || null,
+      notes: addForm.notes,
+    });
+    setBusyId(null);
+    if (ok) {
+      setAddForm(EMPTY_FORM);
+      setAdding(false);
+    }
+  }
+
+  const byLocation = LOCATIONS.map((loc) => ({
+    loc,
+    rows: items.filter((i) => i.location === loc),
+  })).filter((g) => g.rows.length > 0);
+
+  return (
+    <section style={{ marginBottom: "var(--space-6)" }}>
+      <h2
+        className="font-heading font-semibold"
+        style={{
+          fontSize: "var(--t-h3)",
+          color: "var(--color-text)",
+          marginBottom: "var(--space-1)",
+        }}
+      >
+        In the kitchen
+      </h2>
+      <p
+        style={{
+          fontSize: "var(--t-micro)",
+          color: "var(--color-text-muted)",
+          marginBottom: "var(--space-4)",
+        }}
+      >
+        Raw ingredients on hand — the planner cooks these down oldest-first. Move to the freezer in
+        one tap so nothing turns.
+      </p>
+
+      {error && (
+        <p
+          style={{
+            fontSize: "var(--t-micro)",
+            color: "var(--color-danger)",
+            marginBottom: "var(--space-3)",
+          }}
+        >
+          {error}
+        </p>
+      )}
+
+      {byLocation.length === 0 && (
+        <p
+          style={{
+            fontSize: "var(--t-body)",
+            color: "var(--color-text-muted)",
+            marginBottom: "var(--space-4)",
+          }}
+        >
+          Nothing tracked yet.
+        </p>
+      )}
+
+      {byLocation.map(({ loc, rows }) => (
+        <div key={loc} style={{ marginBottom: "var(--space-5)" }}>
+          <p style={labelStyle}>{LOCATION_LABEL[loc]}</p>
+          {rows.map((item) => {
+            const editing = editingId === item.id;
+            const exp = expiryLabel(item.expires_on);
+            if (editing) {
+              return (
+                <div key={item.id} style={editRowStyle}>
+                  <FormFields form={editForm} setForm={setEditForm} />
+                  <div style={{ display: "flex", gap: "var(--space-2)" }}>
+                    <button
+                      type="button"
+                      disabled={busyId === item.id}
+                      onClick={() => saveEdit(item.id)}
+                      style={eatButtonStyle(busyId === item.id)}
+                    >
+                      {busyId === item.id ? "Saving…" : "Save"}
+                    </button>
+                    <button
+                      type="button"
+                      disabled={busyId === item.id}
+                      onClick={() => setEditingId(null)}
+                      style={skipButtonStyle(busyId === item.id)}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              );
+            }
+            return (
+              <div key={item.id} style={rowStyle}>
+                <div style={{ minWidth: 0 }}>
+                  <span style={nameStyle}>{item.name}</span>
+                  <span style={subStyle}>
+                    {quantityLabel(item)}
+                    {item.category ? ` · ${item.category}` : ""}
+                    {exp ? " · " : ""}
+                    {exp && (
+                      <span style={{ color: exp.urgent ? "var(--color-danger)" : undefined }}>
+                        {exp.text}
+                      </span>
+                    )}
+                  </span>
+                </div>
+                <div style={{ display: "flex", gap: "var(--space-2)", flexShrink: 0 }}>
+                  <select
+                    value={item.location}
+                    disabled={busyId === item.id}
+                    onChange={(e) => move(item, e.target.value)}
+                    aria-label={`Move ${item.name} to another location`}
+                    style={selectStyle}
+                  >
+                    {LOCATIONS.map((l) => (
+                      <option key={l} value={l}>
+                        {LOCATION_LABEL[l]}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    disabled={busyId === item.id}
+                    onClick={() => startEdit(item)}
+                    style={skipButtonStyle(busyId === item.id)}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    disabled={busyId === item.id}
+                    onClick={() => remove(item.id)}
+                    style={skipButtonStyle(busyId === item.id)}
+                    title="Remove — used up or thrown out."
+                  >
+                    {busyId === item.id ? "…" : "Remove"}
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ))}
+
+      {adding ? (
+        <div style={editRowStyle}>
+          <FormFields form={addForm} setForm={setAddForm} />
+          <div style={{ display: "flex", gap: "var(--space-2)" }}>
+            <button
+              type="button"
+              disabled={busyId === "__add__"}
+              onClick={addItem}
+              style={eatButtonStyle(busyId === "__add__")}
+            >
+              {busyId === "__add__" ? "Adding…" : "Add item"}
+            </button>
+            <button
+              type="button"
+              disabled={busyId === "__add__"}
+              onClick={() => {
+                setAdding(false);
+                setAddForm(EMPTY_FORM);
+              }}
+              style={skipButtonStyle(busyId === "__add__")}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <button type="button" onClick={() => setAdding(true)} style={addTriggerStyle}>
+          + Add item
+        </button>
+      )}
+    </section>
+  );
+}
+
+function FormFields({
+  form,
+  setForm,
+}: {
+  form: FormState;
+  setForm: (updater: (f: FormState) => FormState) => void;
+}) {
+  const set =
+    (key: keyof FormState) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) =>
+      setForm((f) => ({ ...f, [key]: e.target.value }));
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-2)" }}>
+      <input
+        value={form.name}
+        onChange={set("name")}
+        placeholder="Name"
+        aria-label="Name"
+        style={{ ...inputStyle, flex: "2 1 140px" }}
+      />
+      <input
+        value={form.quantity}
+        onChange={set("quantity")}
+        placeholder="Qty"
+        inputMode="decimal"
+        aria-label="Quantity"
+        style={{ ...inputStyle, flex: "1 1 60px" }}
+      />
+      <input
+        value={form.unit}
+        onChange={set("unit")}
+        placeholder="Unit"
+        aria-label="Unit"
+        style={{ ...inputStyle, flex: "1 1 70px" }}
+      />
+      <select
+        value={form.location}
+        onChange={set("location")}
+        aria-label="Location"
+        style={{ ...selectStyle, flex: "1 1 90px" }}
+      >
+        {LOCATIONS.map((l) => (
+          <option key={l} value={l}>
+            {LOCATION_LABEL[l]}
+          </option>
+        ))}
+      </select>
+      <input
+        value={form.category}
+        onChange={set("category")}
+        placeholder="Category"
+        aria-label="Category"
+        style={{ ...inputStyle, flex: "1 1 90px" }}
+      />
+      <input
+        value={form.expires_on}
+        onChange={set("expires_on")}
+        type="date"
+        aria-label="Expires on"
+        style={{ ...inputStyle, flex: "1 1 130px" }}
+      />
+      <input
+        value={form.notes}
+        onChange={set("notes")}
+        placeholder="Notes"
+        aria-label="Notes"
+        style={{ ...inputStyle, flex: "3 1 160px" }}
+      />
+    </div>
+  );
+}
+
+const labelStyle: React.CSSProperties = {
+  fontSize: "var(--t-micro)",
+  fontWeight: 500,
+  color: "var(--color-text-muted)",
+  textTransform: "uppercase",
+  letterSpacing: "0.04em",
+  marginBottom: "var(--space-2)",
+};
+
+const rowStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "var(--space-4)",
+  padding: "var(--space-3) 0",
+  borderBottom: "1px solid var(--rule-soft)",
+};
+
+const editRowStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--space-3)",
+  padding: "var(--space-3) 0",
+  borderBottom: "1px solid var(--rule-soft)",
+};
+
+const nameStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: "var(--t-body)",
+  color: "var(--color-text)",
+};
+
+const subStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: "var(--t-micro)",
+  color: "var(--color-text-muted)",
+  marginTop: 2,
+};
+
+const inputStyle: React.CSSProperties = {
+  fontFamily: "var(--font-body), system-ui, sans-serif",
+  fontSize: "var(--t-micro)",
+  color: "var(--color-text)",
+  background: "var(--color-surface)",
+  border: "1px solid var(--rule-soft)",
+  borderRadius: "var(--r-1)",
+  padding: "0 var(--space-2)",
+  minHeight: 36,
+};
+
+const selectStyle: React.CSSProperties = {
+  ...inputStyle,
+  cursor: "pointer",
+};
+
+const addTriggerStyle: React.CSSProperties = {
+  fontFamily: "var(--font-body), system-ui, sans-serif",
+  fontSize: "var(--t-micro)",
+  fontWeight: 500,
+  color: "var(--color-text-muted)",
+  background: "transparent",
+  border: "1px dashed var(--rule-soft)",
+  borderRadius: "var(--r-1)",
+  padding: "0 var(--space-4)",
+  minHeight: 36,
+  cursor: "pointer",
+};
+
+function skipButtonStyle(pending: boolean): React.CSSProperties {
+  return {
+    fontFamily: "var(--font-body), system-ui, sans-serif",
+    fontSize: "var(--t-micro)",
+    fontWeight: 500,
+    color: "var(--color-text-muted)",
+    background: "transparent",
+    border: "1px solid var(--rule-soft)",
+    borderRadius: "var(--r-1)",
+    padding: "0 var(--space-3)",
+    minHeight: 36,
+    flexShrink: 0,
+    cursor: pending ? "wait" : "pointer",
+    opacity: pending ? 0.5 : 1,
+    transition: "opacity var(--motion-fast) var(--ease-out-quart)",
+  };
+}
+
+function eatButtonStyle(pending: boolean): React.CSSProperties {
+  return {
+    fontFamily: "var(--font-body), system-ui, sans-serif",
+    fontSize: "var(--t-micro)",
+    fontWeight: 500,
+    color: "var(--color-text-on-cta)",
+    background: "var(--accent)",
+    border: "none",
+    borderRadius: "var(--r-1)",
+    padding: "0 var(--space-4)",
+    minHeight: 36,
+    flexShrink: 0,
+    cursor: pending ? "wait" : "pointer",
+    opacity: pending ? 0.5 : 1,
+    transition: "opacity var(--motion-fast) var(--ease-out-quart)",
+  };
+}

--- a/web/src/lib/nutrition/inventory.ts
+++ b/web/src/lib/nutrition/inventory.ts
@@ -1,0 +1,145 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Inventory: the raw ingredients on hand — fridge, freezer, pantry.
+ *
+ * This is the counterpart to `cooks` (prepared leftovers). `cooks` answers "what can I eat
+ * without cooking?"; this answers "what do I already have to cook WITH?". The weekly planner
+ * reads both first, so it spends the kitchen down — oldest and soonest-to-expire first —
+ * before it ever proposes a grocery run.
+ *
+ * Unlike cooks/recipes, an inventory item carries NO macros. It is a location, a rough
+ * quantity and a fresh-window — a shopping and perishability aid, not a nutrition record.
+ * Nothing here computes or stores a calorie.
+ */
+
+export const INVENTORY_LOCATIONS = ["fridge", "freezer", "pantry", "counter"] as const;
+export type InventoryLocation = (typeof INVENTORY_LOCATIONS)[number];
+
+export interface InventoryItemRow {
+  id: string;
+  name: string;
+  quantity: number | null;
+  unit: string | null;
+  location: InventoryLocation;
+  category: string | null;
+  added_date: string;
+  expires_on: string | null;
+  notes: string | null;
+}
+
+const SELECT = "id, name, quantity, unit, location, category, added_date, expires_on, notes";
+
+/**
+ * Everything on hand, grouped-friendly: by location, then soonest-to-expire (staples with no
+ * expiry sort last within a location), then name. This ordering is the whole point — the
+ * first perishable in the list is the first thing to cook.
+ */
+export async function listInventory(
+  db: SupabaseClient,
+  userId: string,
+): Promise<InventoryItemRow[]> {
+  const { data, error } = await db
+    .from("inventory_items")
+    .select(SELECT)
+    .eq("user_id", userId)
+    .order("location", { ascending: true })
+    .order("expires_on", { ascending: true, nullsFirst: false })
+    .order("name", { ascending: true });
+
+  if (error) throw new Error(`inventory query failed: ${error.message}`);
+  return (data ?? []) as InventoryItemRow[];
+}
+
+function normalizeLocation(loc: unknown): InventoryLocation {
+  if (typeof loc === "string" && (INVENTORY_LOCATIONS as readonly string[]).includes(loc)) {
+    return loc as InventoryLocation;
+  }
+  throw new Error(`location must be one of: ${INVENTORY_LOCATIONS.join(", ")}`);
+}
+
+function normalizeQuantity(q: unknown): number | null {
+  if (q == null || q === "") return null;
+  const n = Number(q);
+  if (!Number.isFinite(n) || n < 0) throw new Error("quantity must be a number >= 0");
+  return n;
+}
+
+export interface InventoryInput {
+  name?: string;
+  quantity?: number | string | null;
+  unit?: string | null;
+  location?: string;
+  category?: string | null;
+  added_date?: string | null;
+  expires_on?: string | null;
+  notes?: string | null;
+}
+
+/** Add something to the kitchen. Name is the only hard requirement. */
+export async function createItem(
+  db: SupabaseClient,
+  userId: string,
+  input: InventoryInput,
+): Promise<InventoryItemRow> {
+  const name = input.name?.trim();
+  if (!name) throw new Error("An inventory item needs a name");
+
+  const row = {
+    user_id: userId,
+    name,
+    quantity: normalizeQuantity(input.quantity),
+    unit: input.unit?.trim() || null,
+    location: input.location ? normalizeLocation(input.location) : "fridge",
+    category: input.category?.trim() || null,
+    added_date: input.added_date || undefined, // fall back to the column default (today)
+    expires_on: input.expires_on || null,
+    notes: input.notes?.trim() || null,
+  };
+
+  const { data, error } = await db.from("inventory_items").insert(row).select(SELECT).single();
+  if (error) throw new Error(`inventory insert failed: ${error.message}`);
+  return data as InventoryItemRow;
+}
+
+/**
+ * Edit an item in place — change the quantity as it's used down, move fridge->freezer when
+ * it's frozen, fix an expiry, correct a note. Only the fields supplied are touched.
+ */
+export async function updateItem(
+  db: SupabaseClient,
+  userId: string,
+  id: string,
+  patch: InventoryInput,
+): Promise<InventoryItemRow> {
+  const set: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if ("name" in patch) {
+    const n = patch.name?.trim();
+    if (!n) throw new Error("name cannot be blank");
+    set.name = n;
+  }
+  if ("quantity" in patch) set.quantity = normalizeQuantity(patch.quantity);
+  if ("unit" in patch) set.unit = patch.unit?.trim() || null;
+  if ("location" in patch && patch.location != null)
+    set.location = normalizeLocation(patch.location);
+  if ("category" in patch) set.category = patch.category?.trim() || null;
+  if ("expires_on" in patch) set.expires_on = patch.expires_on || null;
+  if ("notes" in patch) set.notes = patch.notes?.trim() || null;
+
+  const { data, error } = await db
+    .from("inventory_items")
+    .update(set)
+    .eq("id", id)
+    .eq("user_id", userId) // service client bypasses RLS — this IS the ownership check
+    .select(SELECT)
+    .maybeSingle();
+  if (error) throw new Error(`inventory update failed: ${error.message}`);
+  if (!data) throw new Error("Item not found");
+  return data as InventoryItemRow;
+}
+
+/** Used up or thrown out — remove it. */
+export async function deleteItem(db: SupabaseClient, userId: string, id: string): Promise<void> {
+  const { error } = await db.from("inventory_items").delete().eq("id", id).eq("user_id", userId);
+  if (error) throw new Error(`inventory delete failed: ${error.message}`);
+}


### PR DESCRIPTION
## What

Adds a **fridge / freezer / pantry inventory** — the raw-ingredient counterpart to `cooks` (which only tracks prepared leftovers). The Meals page gains an **"In the kitchen"** panel grouped by location, sorted soonest-to-expire first, with a "use soon" flag, **one-tap move-to-freezer**, inline edit, and add/remove.

## Why

Planning was blind to raw ingredients — the salmon and the frozen steak had to be described by hand every week. Now the planner (and the app) can see what's actually on hand and cook it down oldest-first, so nothing turns and the grocery run isn't planned around food that's already in the fridge.

## Changes

- **`inventory_items` table** + migration `20260721000000_add_inventory_items.sql`. Owner RLS mirrors `cooks` (single `*` policy, `auth.uid() = user_id`). Location is a checked enum (`fridge/freezer/pantry/counter`); `quantity` is nullable (null = staple, amount untracked); `expires_on` powers the use-soon flag.
- **`lib/nutrition/inventory.ts`** — `listInventory` / `createItem` / `updateItem` / `deleteItem`, each `(db, userId, …)` chaining `.eq("user_id", userId)`. **No macros by design** — an item is a location + rough quantity, not a nutrition record.
- **`/api/inventory`** (GET/POST) and **`/api/inventory/[id]`** (PATCH/DELETE) — thin auth+parse wrappers over the lib, session client for auth, service client for the write, same pattern as `/api/cooks` and `/api/meal-plan`.
- **`InventoryPanel.tsx`** — grouped, token-only styling, no inline hover handlers (passes `lint-tokens`). Wired into the Meals page Wave-2 fetch.

## Testing

Ran the full CI gate locally in `web/`:
- `prettier --check .` — clean
- `tsc --noEmit` — clean
- `eslint .` — 0 errors (only pre-existing `<img>`/unused-var warnings in unrelated files)
- `scripts/lint-tokens.sh` — all 4 guards pass

## Deploy note

The `inventory_items` table was **already created on the prod DB** (self-hosted Supabase on compute-core) and seeded, so the deployed image will find it immediately. The migration file is for repo/schema parity and fresh installs — it is `create table if not exists` and matches the live table exactly, so re-applying is a no-op. Deploy = `docker compose build mr-bridge && docker compose up -d --force-recreate mr-bridge` on compute-core (app is baked into the image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjutUpAER7V6quVNbkrbYt
