### PR TITLE
feat(inventory): move inventory to its own page

### DIFF
--- a/web/src/app/(protected)/inventory/page.tsx
+++ b/web/src/app/(protected)/inventory/page.tsx
@@ -1,0 +1,53 @@
+export const dynamic = "force-dynamic";
+
+import type { Metadata } from "next";
+import { createClient } from "@/lib/supabase/server";
+import { InventoryPanel, type InventoryItem } from "@/components/meals/InventoryPanel";
+
+export const metadata: Metadata = {
+  title: "Inventory",
+  description: "What's in the fridge, freezer, and pantry.",
+};
+
+export default async function InventoryPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const userId = user?.id;
+
+  // Fetched server-side so the panel has no loading flash; router.refresh() re-runs this
+  // after every add/edit/move/remove. Oldest and soonest-to-expire first, so what to cook
+  // next is always at the top.
+  const { data: inventoryData } = userId
+    ? await supabase
+        .from("inventory_items")
+        .select("id, name, quantity, unit, location, category, added_date, expires_on, notes")
+        .eq("user_id", userId)
+        .order("location", { ascending: true })
+        .order("expires_on", { ascending: true, nullsFirst: false })
+        .order("name", { ascending: true })
+    : { data: [] };
+
+  return (
+    <div className="max-w-2xl">
+      <div style={{ marginBottom: "var(--space-5)" }}>
+        <h1
+          className="font-heading font-semibold"
+          style={{ fontSize: "var(--t-h1)", color: "var(--color-text)" }}
+        >
+          Inventory
+        </h1>
+        <p
+          className="mt-1"
+          style={{ fontSize: "var(--t-micro)", color: "var(--color-text-muted)" }}
+        >
+          Fridge, freezer &amp; pantry — soonest-to-expire first. Move to the freezer in one tap so
+          nothing turns.
+        </p>
+      </div>
+
+      <InventoryPanel items={(inventoryData ?? []) as unknown as InventoryItem[]} />
+    </div>
+  );
+}

--- a/web/src/app/(protected)/meals/page.tsx
+++ b/web/src/app/(protected)/meals/page.tsx
@@ -8,7 +8,6 @@ import {
   type KitchenCook,
   type KitchenPlannedMeal,
 } from "@/components/meals/KitchenPanel";
-import { InventoryPanel, type InventoryItem } from "@/components/meals/InventoryPanel";
 import { WeekPlan } from "@/components/meals/WeekPlan";
 import MealsClient, {
   type MealRow,
@@ -54,12 +53,7 @@ export default async function MealsPage() {
 
   // Wave 2 — these all need user.id from Wave 1.
   const userId = user?.id;
-  const [
-    { data: recipesData },
-    { data: leftoversData },
-    { data: planData },
-    { data: inventoryData },
-  ] = await Promise.all([
+  const [{ data: recipesData }, { data: leftoversData }, { data: planData }] = await Promise.all([
     userId
       ? supabase
           .from("recipes")
@@ -93,17 +87,6 @@ export default async function MealsPage() {
           .gte("date", todayString())
           .lte("date", daysAheadString(6))
           .order("date", { ascending: true })
-      : Promise.resolve({ data: [] }),
-    // Raw ingredients on hand — the fridge/freezer/pantry the planner cooks into. Oldest and
-    // soonest-to-expire first, so the panel surfaces what to use before it turns.
-    userId
-      ? supabase
-          .from("inventory_items")
-          .select("id, name, quantity, unit, location, category, added_date, expires_on, notes")
-          .eq("user_id", userId)
-          .order("location", { ascending: true })
-          .order("expires_on", { ascending: true, nullsFirst: false })
-          .order("name", { ascending: true })
       : Promise.resolve({ data: [] }),
   ]);
 
@@ -228,8 +211,6 @@ export default async function MealsPage() {
         leftovers={(leftoversData ?? []) as unknown as KitchenCook[]}
         plan={weekPlan.filter((p) => p.date === today)}
       />
-
-      <InventoryPanel items={(inventoryData ?? []) as unknown as InventoryItem[]} />
 
       <WeekPlan week={weekPlan} days={getNextNDays(7)} today={today} />
 

--- a/web/src/components/meals/InventoryPanel.tsx
+++ b/web/src/components/meals/InventoryPanel.tsx
@@ -176,27 +176,6 @@ export function InventoryPanel({ items }: InventoryPanelProps) {
 
   return (
     <section style={{ marginBottom: "var(--space-6)" }}>
-      <h2
-        className="font-heading font-semibold"
-        style={{
-          fontSize: "var(--t-h3)",
-          color: "var(--color-text)",
-          marginBottom: "var(--space-1)",
-        }}
-      >
-        In the kitchen
-      </h2>
-      <p
-        style={{
-          fontSize: "var(--t-micro)",
-          color: "var(--color-text-muted)",
-          marginBottom: "var(--space-4)",
-        }}
-      >
-        Raw ingredients on hand — the planner cooks these down oldest-first. Move to the freezer in
-        one tap so nothing turns.
-      </p>
-
       {error && (
         <p
           style={{

--- a/web/src/components/nav.tsx
+++ b/web/src/components/nav.tsx
@@ -15,6 +15,7 @@ import {
   CalendarDays,
   Bell,
   Library,
+  Refrigerator,
   MoreHorizontal,
   X,
   LogOut,
@@ -35,6 +36,7 @@ const NAV_ITEMS = [
   { href: "/journal", label: "Journal", icon: BookOpen },
   { href: "/library", label: "Library", icon: Library },
   { href: "/meals", label: "Meals", icon: UtensilsCrossed },
+  { href: "/inventory", label: "Inventory", icon: Refrigerator },
   { href: "/notifications", label: "Notifications", icon: Bell },
   { href: "/settings", label: "Settings", icon: Settings },
 ];


### PR DESCRIPTION
Moves the inventory out of the Meals tab (it was long and cluttering the page) into a dedicated **/inventory** page with its own nav entry (Refrigerator icon).

## Changes
- New `web/src/app/(protected)/inventory/page.tsx` — fetches inventory server-side, renders the panel under an `Inventory` h1.
- Removed `InventoryPanel` (+ its Wave-2 fetch and imports) from the Meals page.
- `InventoryPanel` drops its in-section header/intro; the page now carries the h1 + subtitle.
- Nav: added `{ /inventory, Inventory, Refrigerator }` after Meals.

## Testing (local, in web/)
- prettier --check . — clean
- tsc --noEmit — clean
- eslint . — 0 errors (pre-existing warnings only)
- scripts/lint-tokens.sh — all guards pass