### PR TITLE
fix(pwa): stop the service worker serving stale JS after deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **Deploys now actually reach the browser (service-worker stale cache).** The service worker
+  cached `/_next/static/*` **cache-first** under a fixed cache name. Turbopack chunk filenames
+  are not reliably content-hashed, so a deploy's changed code shipped under a name the cache
+  already held — and cache-first served the old copy indefinitely, making new features look like
+  they never deployed until the cache was cleared by hand. Switched to **stale-while-revalidate**
+  (the cache is refreshed from the network on every request) and bumped the cache version
+  (`mb-static-v1` → `v2`) so the activate handler purges the poisoned cache once. Deploys now
+  self-update within a reload.
+
 - **Logging a planned meal in the evening no longer lands it on tomorrow.** `eatFromCook` stamped
   the `meal_log` row with `new Date().toISOString().slice(0,10)` — a **UTC** date — so tapping
   "Ate this" after ~5pm PT (past UTC midnight) logged the meal on the next day, splitting it from

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -2,7 +2,14 @@
 // Caches Next.js static assets (/_next/static/*) and Google Fonts.
 // No API, auth, or navigation caching — those always hit the network.
 
-const CACHE = "mb-static-v1";
+// NOTE: Turbopack's static chunk filenames are NOT reliably content-hashed, so a new deploy can
+// ship changed code under a filename the cache already holds. A cache-FIRST strategy therefore
+// served stale JS indefinitely (a deploy's changes never reached the browser until the SW cache
+// was cleared by hand). Two guards now prevent that: the cache version is bumped on any change
+// that could poison it (the activate handler deletes every other cache), and the fetch strategy
+// is stale-while-revalidate — the cache is refreshed from the network on every request, so a
+// changed asset is picked up on the next load instead of never.
+const CACHE = "mb-static-v2";
 
 self.addEventListener("install", () => {
   self.skipWaiting();
@@ -38,20 +45,21 @@ self.addEventListener("fetch", (event) => {
   const url = new URL(req.url);
   if (!isCacheableStatic(url)) return;
 
+  // Stale-while-revalidate: serve the cache immediately when present, but always fetch in the
+  // background and overwrite the cache, so the *next* load gets fresh code. With no cache yet,
+  // wait on the network. Offline falls back to whatever is cached.
   event.respondWith(
     caches.open(CACHE).then(async (cache) => {
       const cached = await cache.match(req);
-      if (cached) return cached;
-      try {
-        const res = await fetch(req);
-        if (res.ok && (res.type === "basic" || res.type === "cors")) {
-          cache.put(req, res.clone());
-        }
-        return res;
-      } catch (err) {
-        if (cached) return cached;
-        throw err;
-      }
+      const network = fetch(req)
+        .then((res) => {
+          if (res.ok && (res.type === "basic" || res.type === "cors")) {
+            cache.put(req, res.clone());
+          }
+          return res;
+        })
+        .catch(() => cached);
+      return cached || network;
     }),
   );
 });


### PR DESCRIPTION
**Root cause of "I deployed but nothing changed."** The service worker cached `/_next/static/*` **cache-first** under a fixed cache name (`mb-static-v1`). Turbopack chunk filenames are not reliably content-hashed, so a deploy shipped changed code under a filename the cache already held — cache-first then served the **old** copy indefinitely. New features (inventory conversions, recipe instructions, etc.) looked undeployed until the SW cache was cleared by hand.

## Fix
- **Stale-while-revalidate** instead of cache-first: the cache is refreshed from the network on every request, so a changed asset is picked up on the next load.
- **Cache version bump** `mb-static-v1` → `v2`: the activate handler deletes every non-current cache, purging the poisoned one once.
- Result: deploys self-update within a reload; offline still falls back to cache.

## Testing (local, web/)
- prettier --check . — clean
- tsc --noEmit — clean
- eslint . — 0 errors