### PR TITLE
feat(meals): show oz/lb next to gram amounts in recipe ingredients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   Inventory carries no macros and links to nothing, so editing it can never affect a macro or a
   plan.
 
+- **Recipe ingredients show imperial equivalents too.** Ingredient lists (in the click-in planned
+  meal and the Recipes tab) written in grams now annotate each weight with oz/lb inline —
+  "200 g (7.1 oz) chicken thigh", "80 g (2.8 oz) brown rice" — so a recipe reconciles with the
+  fridge (stocked in lb/oz) without mental math. Display-only via `addWeightConversions`; the
+  stored text is unchanged, and counts/volumes ("2 fillets", "1 cup") and trivial amounts are
+  left alone.
+
 ### Changed
 
 - **Every planned meal must be backed by a recipe or a cook.** `plan_meals` no longer accepts a

--- a/web/src/components/meals/MealsClient.tsx
+++ b/web/src/components/meals/MealsClient.tsx
@@ -18,6 +18,7 @@ import { compressImage } from "@/lib/meal-photo";
 import { ChartFrame, TrendLine } from "@/components/charts/primitives";
 import { formatDate } from "@/lib/chart-utils";
 import { todayString } from "@/lib/timezone";
+import { addWeightConversions } from "@/lib/units";
 
 const FoodPhotoAnalyzer = dynamic(() => import("@/app/(protected)/meals/FoodPhotoAnalyzer"), {
   ssr: false,
@@ -1267,9 +1268,10 @@ function RecipesTab({ recipes }: { recipes: RecipeRow[] }) {
                           color: "var(--color-text-muted)",
                           lineHeight: 1.6,
                           marginBottom: "var(--space-3)",
+                          whiteSpace: "pre-line",
                         }}
                       >
-                        {r.ingredients}
+                        {addWeightConversions(r.ingredients)}
                       </p>
                     )}
 

--- a/web/src/components/meals/PlannedMealDetail.tsx
+++ b/web/src/components/meals/PlannedMealDetail.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import type { KitchenPlannedMeal } from "./KitchenPanel";
+import { addWeightConversions } from "@/lib/units";
 
 /**
  * The click-in view for a planned meal: what's in it, and what it costs you.
@@ -63,7 +64,7 @@ export function PlannedMealDetail({ meal }: { meal: KitchenPlannedMeal }) {
         {recipe.ingredients ? (
           <div style={{ marginBottom: "var(--space-3)" }}>
             <p style={sectionLabelStyle}>Ingredients</p>
-            <p style={ingredientsStyle}>{recipe.ingredients}</p>
+            <p style={ingredientsStyle}>{addWeightConversions(recipe.ingredients)}</p>
           </div>
         ) : (
           <p style={mutedStyle}>No ingredients recorded for this recipe yet.</p>

--- a/web/src/lib/units.ts
+++ b/web/src/lib/units.ts
@@ -28,3 +28,54 @@ function round(n: number, decimals: number): number {
   const factor = 10 ** decimals;
   return Math.round(n * factor) / factor;
 }
+
+// ── Ingredient-text weight conversions ──────────────────────────────────────────
+// Recipes are written in grams (USDA); the fridge is stocked in lb/oz. Showing a gram amount
+// without its imperial equivalent forces a mental conversion that is easy to get wrong ("we have
+// 1.25 lb of chicken but the recipe says 200 g"). `addWeightConversions` annotates each weight in
+// a free-text ingredient list with its other units, leaving the stored text unchanged.
+
+const GRAMS_PER: Record<string, number> = {
+  g: 1,
+  gram: 1,
+  grams: 1,
+  kg: 1000,
+  oz: 28.3495,
+  ounce: 28.3495,
+  ounces: 28.3495,
+  lb: 453.592,
+  lbs: 453.592,
+  pound: 453.592,
+  pounds: 453.592,
+};
+const G_FAMILY = new Set(["g", "gram", "grams", "kg"]);
+const OZ_FAMILY = new Set(["oz", "ounce", "ounces"]);
+const LB_FAMILY = new Set(["lb", "lbs", "pound", "pounds"]);
+
+// Below this, an ounce figure is more noise than help (5 g of oil → "0.2 oz").
+const MIN_GRAMS_FOR_OZ = 15;
+
+// Leading "<number> <weight-unit>" on a line, e.g. "200 g raw chicken thigh".
+const LEADING_WEIGHT = /^(\s*\d+(?:\.\d+)?\s*)(g|grams?|kg|oz|ounces?|lb|lbs|pounds?)\b/i;
+
+function annotateLine(line: string): string {
+  const m = line.match(LEADING_WEIGHT);
+  if (!m) return line;
+  const key = m[2].toLowerCase();
+  const grams = parseFloat(m[1]) * GRAMS_PER[key];
+
+  const alts: string[] = [];
+  if (!G_FAMILY.has(key)) alts.push(`${Math.round(grams)} g`);
+  if (!OZ_FAMILY.has(key) && grams >= MIN_GRAMS_FOR_OZ)
+    alts.push(`${round(grams / 28.3495, 1)} oz`);
+  if (!LB_FAMILY.has(key) && grams >= 453.592) alts.push(`${round(grams / 453.592, 2)} lb`);
+  if (!alts.length) return line;
+
+  const end = m[0].length;
+  return `${line.slice(0, end)} (${alts.join(" · ")})${line.slice(end)}`;
+}
+
+/** Annotate each line of a free-text ingredient list with imperial/metric equivalents. */
+export function addWeightConversions(text: string): string {
+  return text.split("\n").map(annotateLine).join("\n");
+}


### PR DESCRIPTION
Closes the other half of the g↔lb confusion. Inventory already showed both units; **recipe ingredients** (written in grams) still showed grams only, so "cook 200 g chicken" didn't reconcile with "1.25 lb in the fridge."

Ingredient lists in the click-in planned meal and the Recipes tab now annotate each weight inline:
- `200 g raw chicken thigh` → **200 g (7.1 oz) raw chicken thigh**
- `80 g dry brown rice` → **80 g (2.8 oz) dry brown rice**
- `1.25 lb chicken` → **1.25 lb (567 g · 20 oz) chicken**

Display-only (`addWeightConversions` in `lib/units.ts`); stored text unchanged. Counts/volumes ("2 fillets", "1 cup") and sub-15 g amounts are left alone.

## Testing (local, web/)
- prettier --check . — clean
- tsc --noEmit — clean
- eslint . — 0 errors
- scripts/lint-tokens.sh — all guards pass
- transform verified on sample lines (grams→oz, lb↔g/oz, counts/volumes skipped)