### PR TITLE
fix(briefing): stop flagging on-target effort as a load cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **The briefing stopped telling the coach to undo the current training rule.**
+  `scripts/fetch_briefing_data.py` still printed `FLAG: effort >=8 — drop next session load 10%`
+  and `FLAG: effort >=9 — cut a set next session` on every logged session. Those bands were
+  **retired 2026-07-18**: 8-9/10 is roughly 1-3 RIR, which is the productive zone the program
+  now targets, and proximity to failure matters *more* at light loads — with the dumbbells
+  capped at 25 lb, "light load, far from failure" is the one combination the evidence calls
+  clearly ineffective. `coach_check.py::post_session` was updated at the time; this script was
+  missed, so the two halves of the coaching loop disagreed, and the briefing kept advising a
+  load cut on exactly the sessions that went well. Observed live on 2026-07-26: the 7/23
+  session (effort 8, DB Reverse Lunge @ 20 lb at RPE 8-9 — on target) was flagged for a 10%
+  reduction. Bands now mirror `coach_check.py`: 7-9 reads as on-target, 10 backs off, 6 and
+  below prompt more reps or load, and a missing score is called out as the thing that tunes the
+  next session. Load reductions remain driven solely by measured performance decrement
+  (`coach_check.py::regressions`), never by a set feeling hard.
+
 - **Deploys now actually reach the browser (service-worker stale cache).** The service worker
   cached `/_next/static/*` **cache-first** under a fixed cache name. Turbopack chunk filenames
   are not reliably content-hashed, so a deploy's changed code shipped under a name the cache

--- a/scripts/fetch_briefing_data.py
+++ b/scripts/fetch_briefing_data.py
@@ -518,16 +518,26 @@ def main():
             # measured performance decrement (coach_check.py::regressions), never from
             # a set feeling hard.
             #
-            # The bands only apply to PROGRAMMED lifting (workout_plan_id not null), the
-            # same filter coach_check.py::programmed_sessions uses. Walk pull-ups are
-            # logged as strength_sessions with a null plan id and are grease-the-groove:
-            # deliberately submaximal and never to failure, because at a ~4-rep max the
-            # limiter is strength/skill and frequent low-fatigue practice is what raises
-            # it. Scoring those against the lifting bands tells the coach to add load to
-            # the one thing that must stay easy.
+            # The bands only apply to PROGRAMMED LIFTING. Two kinds of session must be
+            # exempt, and they look different in the data:
+            #   1. Ad-hoc bonus work (basketball, walk pull-ups done off-plan) — null
+            #      workout_plan_id, the same filter coach_check.py::programmed_sessions uses.
+            #   2. Grease-the-groove pull-ups. These DO carry a workout_plan_id whenever a
+            #      "Daily Pull-ups (GtG)" plan exists for the date, so the null check alone
+            #      does not catch them. They are deliberately submaximal and never taken to
+            #      failure: at a ~4-rep max the limiter is strength/skill, so frequent
+            #      low-fatigue practice is what raises it. A low effort score on GtG is the
+            #      protocol working, not a shortfall — scoring it against the lifting bands
+            #      tells the coach to add load to the one thing that must stay easy.
+            # Detect (2) from the sets already in hand rather than a second query.
+            gtg = bool(rows) and all(
+                "grease-the-groove" in (r.get("exercise_name") or "").lower() for r in rows
+            )
             effort = s.get("perceived_effort")
             if s.get("workout_plan_id") is None:
-                flag = "  (unprogrammed — grease-the-groove/bonus; effort bands do not apply)"
+                flag = "  (unprogrammed bonus work — effort bands do not apply)"
+            elif gtg:
+                flag = "  (grease-the-groove — submaximal by design; effort bands do not apply)"
             elif effort is None:
                 flag = "  FLAG: no effort score — it's what tunes the next session"
             elif effort >= 10:

--- a/scripts/fetch_briefing_data.py
+++ b/scripts/fetch_briefing_data.py
@@ -162,7 +162,7 @@ def main():
     def q_strength_sessions():
         return (
             client.table("strength_sessions")
-            .select("id,performed_on,perceived_effort,notes")
+            .select("id,performed_on,perceived_effort,notes,workout_plan_id")
             .eq("user_id", uid)
             .order("performed_on", desc=True)
             .limit(3)
@@ -517,8 +517,18 @@ def main():
             # the one combination the evidence calls ineffective. Reductions come from
             # measured performance decrement (coach_check.py::regressions), never from
             # a set feeling hard.
+            #
+            # The bands only apply to PROGRAMMED lifting (workout_plan_id not null), the
+            # same filter coach_check.py::programmed_sessions uses. Walk pull-ups are
+            # logged as strength_sessions with a null plan id and are grease-the-groove:
+            # deliberately submaximal and never to failure, because at a ~4-rep max the
+            # limiter is strength/skill and frequent low-fatigue practice is what raises
+            # it. Scoring those against the lifting bands tells the coach to add load to
+            # the one thing that must stay easy.
             effort = s.get("perceived_effort")
-            if effort is None:
+            if s.get("workout_plan_id") is None:
+                flag = "  (unprogrammed — grease-the-groove/bonus; effort bands do not apply)"
+            elif effort is None:
                 flag = "  FLAG: no effort score — it's what tunes the next session"
             elif effort >= 10:
                 flag = "  FLAG: effort 10 — couldn't finish; that's a load problem, back off next session"

--- a/scripts/fetch_briefing_data.py
+++ b/scripts/fetch_briefing_data.py
@@ -509,12 +509,25 @@ def main():
     if sessions:
         for s in sessions:
             rows = sets_by_session.get(s["id"], [])
+            # Effort bands mirror coach_check.py::post_session. The target is 1-3 RIR on
+            # the last set of each exercise, so 7-9 is the productive zone, NOT a fault.
+            # The bands here used to cut load at >=8 and a set at >=9; that rule was
+            # retired 2026-07-18 because proximity to failure matters more at light
+            # loads and the dumbbells cap at 25 lb, making "light and far from failure"
+            # the one combination the evidence calls ineffective. Reductions come from
+            # measured performance decrement (coach_check.py::regressions), never from
+            # a set feeling hard.
             effort = s.get("perceived_effort")
-            flag = ""
-            if effort and effort >= 9:
-                flag = "  FLAG: effort >=9 — cut a set next session"
-            elif effort and effort >= 8:
-                flag = "  FLAG: effort >=8 — drop next session load 10%"
+            if effort is None:
+                flag = "  FLAG: no effort score — it's what tunes the next session"
+            elif effort >= 10:
+                flag = "  FLAG: effort 10 — couldn't finish; that's a load problem, back off next session"
+            elif effort >= 7:
+                flag = "  — effort on target (1-3 reps left in the tank); hold or progress"
+            elif effort == 6:
+                flag = "  FLAG: effort 6 — fine for re-entry, light for growth; add reps before load"
+            else:
+                flag = f"  FLAG: effort {effort} — under target; add reps or load next session"
             print(f"- {s['performed_on']} | effort {effort or '—'}/10 | {len(rows)} sets{flag}")
             if s.get("notes"):
                 print(f"    note: {s['notes']}")


### PR DESCRIPTION
## Problem

The briefing was telling the coach to undo the current training rule.

`scripts/fetch_briefing_data.py` still printed the effort bands that were **retired 2026-07-18**:

```
FLAG: effort >=8 — drop next session load 10%
FLAG: effort >=9 — cut a set next session
```

Those bands are inverted under the program as it stands now. Target is **1-3 RIR on the last set of each exercise**, so 8-9/10 is the productive zone, not a fault. Proximity to failure matters *more* at light loads, and the dumbbells cap at 25 lb — "light load, far from failure" is the one combination the evidence calls clearly ineffective. The 10% cut was also unexecutable: 10% off a fixed 25 lb pair is 22.5 lb, which isn't owned.

`coach_check.py::post_session` was corrected at the time and carries a comment explaining the change. This script was missed, so the two halves of the coaching loop disagreed.

**Observed live 2026-07-26:** the 7/23 session (effort 8; DB Reverse Lunge @ 20 lb at RPE 8-9, i.e. on target) was flagged for a 10% load reduction.

## Second defect found while verifying

With the bands corrected, the 7/21 **grease-the-groove pull-up** session (effort 5) started reading `under target; add reps or load`. GtG is deliberately submaximal and never taken to failure — at a ~4-rep max the limiter is strength/skill, so frequent low-fatigue practice is what raises it. A low score there is the protocol working.

Gating on a null `workout_plan_id` (what `coach_check.py::programmed_sessions` uses) does **not** catch these: GtG sessions do carry a plan id whenever a "Daily Pull-ups (GtG)" plan exists for that date. Verified against live data — session 2026-07-21 → plan `82cbd0bd` "Daily Pull-ups (GtG)".

Detection now comes from the session's own sets (every exercise is grease-the-groove), which the print path already holds, so no extra query. A null plan id still exempts ad-hoc bonus work.

## Change

Bands now mirror `coach_check.py::post_session`:

| Effort | Reads as |
|---|---|
| none | FLAG: no score — it's what tunes the next session |
| 10 | FLAG: couldn't finish; load problem, back off |
| 7-9 | on target (1-3 reps left in the tank); hold or progress |
| 6 | FLAG: fine for re-entry, light for growth; add reps before load |
| <=5 | FLAG: under target; add reps or load |

Exempt: unprogrammed bonus work, and grease-the-groove.

Load reductions remain driven solely by measured performance decrement (`coach_check.py::regressions`), never by a set feeling hard.

## Verification

Run against live self-hosted Supabase on compute-core, before and after.

Before:
```
- 2026-07-25 | effort 7/10 | 17 sets
- 2026-07-23 | effort 8/10 | 18 sets  FLAG: effort >=8 — drop next session load 10%
- 2026-07-21 | effort 5/10 | 1 sets
```

After:
```
- 2026-07-25 | effort 7/10 | 17 sets  — effort on target (1-3 reps left in the tank); hold or progress
- 2026-07-23 | effort 8/10 | 18 sets  — effort on target (1-3 reps left in the tank); hold or progress
- 2026-07-21 | effort 5/10 | 1 sets  (grease-the-groove — submaximal by design; effort bands do not apply)
```

`python -m py_compile` clean. CI is path-filtered to `web/`, so a scripts-only PR gets no lint or typecheck — compile-checked by hand.

CHANGELOG.md updated under `[Unreleased] / Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017g65aFmvE9csTmmGuLCZPe
