### PR TITLE
fix(fitness): reject workout plans whose superset metadata does not render

### DIFF
--- a/.claude/commands/weekly-plan.md
+++ b/.claude/commands/weekly-plan.md
@@ -41,8 +41,16 @@ not be quietly interpreted away.
    python3 scripts/weekly_plan.py validate /tmp/plan.json
    ```
 
-   It checks weekly muscle coverage, recovery spacing between hard sessions, and same-day
-   redundancy. If it fails, FIX THE PLAN and re-run. Do not submit a plan that fails.
+   It checks weekly muscle coverage, recovery spacing between hard sessions, same-day
+   redundancy, and **superset metadata**. If it fails, FIX THE PLAN and re-run. Do not
+   submit a plan that fails.
+
+   On superset days, every working exercise needs `"superset"` (`"A1"`, `"A2"`, `"B1"`, …)
+   and `"pair_with"` (the partner's exact `exercise` name), with partners **adjacent** in
+   the `workout` array — the UI groups consecutive same-letter entries, so position is
+   load-bearing. A day named "(supersets)" with no slots renders as straight sets; the
+   validator now rejects that rather than letting the plan display something other than
+   what it means.
 
 4. **Submit:**
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,27 @@
+name: Python tests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/**'
+      - 'tests/**'
+      - '.github/workflows/python-tests.yml'
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+      # weekly_plan.py resolves these at import time; the pure validators never use them.
+      CRON_SECRET: test
+      INTERNAL_APP_URL: http://localhost:3000
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      # Deliberately no pip install: these tests cover the stdlib-only structural
+      # validators, so they must keep running on a bare interpreter. Anything needing
+      # supabase/requests belongs in a separate job with scripts/requirements.txt.
+      - name: Run unit tests
+        run: python3 -m unittest discover -s tests -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **The planner validator now rejects broken superset metadata.** A superset renders only from
+  per-exercise `superset` / `pair_with` fields; the plan `name` and `notes` are display text and
+  control nothing. Week 2 (7/27, 7/29, 8/01) was written with neither field, so three sessions
+  named "(supersets)" — whose notes described "3 pairs x 3 rounds" — rendered as six standalone
+  straight sets. Nothing errored; the plan simply meant something different from what it showed,
+  and only an eyeball caught it. `validate_supersets()` in `scripts/weekly_plan.py` now fails the
+  plan on: a "(supersets)" day with no slots, partial slotting, malformed slots, non-contiguous
+  pairs (grouping is positional — `groupBySuperset` walks *consecutive* same-letter entries, so
+  a split pair renders as two broken groups), lone or self-paired slots, `pair_with` that isn't
+  reciprocal or names an exercise outside the group, out-of-order slot digits, and members of a
+  pair disagreeing on `sets` (the group header shows one round count for both). Wired into both
+  `validate` and the correction prompt, and the planner prompt now documents the fields so plans
+  are written right rather than only caught afterward. Covered by `tests/` — the project's first
+  Python tests — run in CI by a new stdlib-only `python-tests` workflow, since a guard against a
+  *silent* failure is itself worthless if it silently stops firing.
+
 - **Sessions auto-load Mr. Bridge context on start.** A new `SessionStart` hook (wired in
   `.claude/settings.json`, handled by `.claude/hooks/scripts/hooks.py`) injects an instruction
   that makes any session launched in this repo read the rules + private project memory and run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **The briefing stopped telling the coach to undo the current training rule.**
+  `scripts/fetch_briefing_data.py` still printed `FLAG: effort >=8 — drop next session load 10%`
+  and `FLAG: effort >=9 — cut a set next session` on every logged session. Those bands were
+  **retired 2026-07-18**: 8-9/10 is roughly 1-3 RIR, which is the productive zone the program
+  now targets, and proximity to failure matters *more* at light loads — with the dumbbells
+  capped at 25 lb, "light load, far from failure" is the one combination the evidence calls
+  clearly ineffective. `coach_check.py::post_session` was updated at the time; this script was
+  missed, so the two halves of the coaching loop disagreed, and the briefing kept advising a
+  load cut on exactly the sessions that went well. Observed live on 2026-07-26: the 7/23
+  session (effort 8, DB Reverse Lunge @ 20 lb at RPE 8-9 — on target) was flagged for a 10%
+  reduction. Bands now mirror `coach_check.py`: 7-9 reads as on-target, 10 backs off, 6 and
+  below prompt more reps or load, and a missing score is called out as the thing that tunes the
+  next session. Load reductions remain driven solely by measured performance decrement
+  (`coach_check.py::regressions`), never by a set feeling hard.
+
 - **Deploys now actually reach the browser (service-worker stale cache).** The service worker
   cached `/_next/static/*` **cache-first** under a fixed cache name. Turbopack chunk filenames
   are not reliably content-hashed, so a deploy's changed code shipped under a name the cache

--- a/README.md
+++ b/README.md
@@ -570,7 +570,10 @@ mr-bridge-assistant/
 │
 ├── .github/
 │   └── workflows/
-│       └── weekly-review-nudge.yml        # Sunday 8pm ntfy.sh push (runs in cloud)
+│       ├── weekly-review-nudge.yml        # Sunday 8pm ntfy.sh push (runs in cloud)
+│       ├── lint.yml                       # Token guards, eslint + prettier, typecheck, depcheck
+│       ├── smoke.yml                      # Playwright a11y + perf smokes
+│       └── python-tests.yml               # stdlib-only unittest run over tests/
 │
 ├── docs/
 │   ├── notifications-setup.md             # Android, macOS, Windows ntfy setup guide
@@ -592,7 +595,11 @@ mr-bridge-assistant/
 │   ├── check_task_due_alerts.py           # Task due-date push alerts (grouped, per-task 24h dedup)
 │   ├── check_weather_alert.py             # Severe weather push alerts
 │   ├── notify.sh                          # Push notifications: macOS (osascript) + Android/Windows (ntfy.sh)
+│   ├── weekly_plan.py                     # Weekly planner: context / validate / submit (structural rules live here)
 │   └── update-references.sh              # Pull latest best practices submodule
+│
+├── tests/                                 # Python unit tests (stdlib unittest, no deps)
+│   └── test_weekly_plan_supersets.py      # Superset-metadata validator
 │
 └── voice/                                 # Jarvis mode (voice interface)
     ├── bridge_voice.py                    # Wake word → STT → Claude API → TTS

--- a/scripts/fetch_briefing_data.py
+++ b/scripts/fetch_briefing_data.py
@@ -518,16 +518,26 @@ def main():
             # measured performance decrement (coach_check.py::regressions), never from
             # a set feeling hard.
             #
-            # The bands only apply to PROGRAMMED lifting (workout_plan_id not null), the
-            # same filter coach_check.py::programmed_sessions uses. Walk pull-ups are
-            # logged as strength_sessions with a null plan id and are grease-the-groove:
-            # deliberately submaximal and never to failure, because at a ~4-rep max the
-            # limiter is strength/skill and frequent low-fatigue practice is what raises
-            # it. Scoring those against the lifting bands tells the coach to add load to
-            # the one thing that must stay easy.
+            # The bands only apply to PROGRAMMED LIFTING. Two kinds of session must be
+            # exempt, and they look different in the data:
+            #   1. Ad-hoc bonus work (basketball, walk pull-ups done off-plan) — null
+            #      workout_plan_id, the same filter coach_check.py::programmed_sessions uses.
+            #   2. Grease-the-groove pull-ups. These DO carry a workout_plan_id whenever a
+            #      "Daily Pull-ups (GtG)" plan exists for the date, so the null check alone
+            #      does not catch them. They are deliberately submaximal and never taken to
+            #      failure: at a ~4-rep max the limiter is strength/skill, so frequent
+            #      low-fatigue practice is what raises it. A low effort score on GtG is the
+            #      protocol working, not a shortfall — scoring it against the lifting bands
+            #      tells the coach to add load to the one thing that must stay easy.
+            # Detect (2) from the sets already in hand rather than a second query.
+            gtg = bool(rows) and all(
+                "grease-the-groove" in (r.get("exercise_name") or "").lower() for r in rows
+            )
             effort = s.get("perceived_effort")
             if s.get("workout_plan_id") is None:
-                flag = "  (unprogrammed — grease-the-groove/bonus; effort bands do not apply)"
+                flag = "  (unprogrammed bonus work — effort bands do not apply)"
+            elif gtg:
+                flag = "  (grease-the-groove — submaximal by design; effort bands do not apply)"
             elif effort is None:
                 flag = "  FLAG: no effort score — it's what tunes the next session"
             elif effort >= 10:

--- a/scripts/fetch_briefing_data.py
+++ b/scripts/fetch_briefing_data.py
@@ -162,7 +162,7 @@ def main():
     def q_strength_sessions():
         return (
             client.table("strength_sessions")
-            .select("id,performed_on,perceived_effort,notes")
+            .select("id,performed_on,perceived_effort,notes,workout_plan_id")
             .eq("user_id", uid)
             .order("performed_on", desc=True)
             .limit(3)
@@ -517,8 +517,18 @@ def main():
             # the one combination the evidence calls ineffective. Reductions come from
             # measured performance decrement (coach_check.py::regressions), never from
             # a set feeling hard.
+            #
+            # The bands only apply to PROGRAMMED lifting (workout_plan_id not null), the
+            # same filter coach_check.py::programmed_sessions uses. Walk pull-ups are
+            # logged as strength_sessions with a null plan id and are grease-the-groove:
+            # deliberately submaximal and never to failure, because at a ~4-rep max the
+            # limiter is strength/skill and frequent low-fatigue practice is what raises
+            # it. Scoring those against the lifting bands tells the coach to add load to
+            # the one thing that must stay easy.
             effort = s.get("perceived_effort")
-            if effort is None:
+            if s.get("workout_plan_id") is None:
+                flag = "  (unprogrammed — grease-the-groove/bonus; effort bands do not apply)"
+            elif effort is None:
                 flag = "  FLAG: no effort score — it's what tunes the next session"
             elif effort >= 10:
                 flag = "  FLAG: effort 10 — couldn't finish; that's a load problem, back off next session"

--- a/scripts/fetch_briefing_data.py
+++ b/scripts/fetch_briefing_data.py
@@ -509,12 +509,25 @@ def main():
     if sessions:
         for s in sessions:
             rows = sets_by_session.get(s["id"], [])
+            # Effort bands mirror coach_check.py::post_session. The target is 1-3 RIR on
+            # the last set of each exercise, so 7-9 is the productive zone, NOT a fault.
+            # The bands here used to cut load at >=8 and a set at >=9; that rule was
+            # retired 2026-07-18 because proximity to failure matters more at light
+            # loads and the dumbbells cap at 25 lb, making "light and far from failure"
+            # the one combination the evidence calls ineffective. Reductions come from
+            # measured performance decrement (coach_check.py::regressions), never from
+            # a set feeling hard.
             effort = s.get("perceived_effort")
-            flag = ""
-            if effort and effort >= 9:
-                flag = "  FLAG: effort >=9 — cut a set next session"
-            elif effort and effort >= 8:
-                flag = "  FLAG: effort >=8 — drop next session load 10%"
+            if effort is None:
+                flag = "  FLAG: no effort score — it's what tunes the next session"
+            elif effort >= 10:
+                flag = "  FLAG: effort 10 — couldn't finish; that's a load problem, back off next session"
+            elif effort >= 7:
+                flag = "  — effort on target (1-3 reps left in the tank); hold or progress"
+            elif effort == 6:
+                flag = "  FLAG: effort 6 — fine for re-entry, light for growth; add reps before load"
+            else:
+                flag = f"  FLAG: effort {effort} — under target; add reps or load next session"
             print(f"- {s['performed_on']} | effort {effort or '—'}/10 | {len(rows)} sets{flag}")
             if s.get("notes"):
                 print(f"    note: {s['notes']}")

--- a/scripts/weekly_plan.py
+++ b/scripts/weekly_plan.py
@@ -217,6 +217,147 @@ def shape_plan(plan: dict) -> tuple[list[str], list[dict]]:
     return all_exercises, day_plans
 
 
+# ── Superset integrity ───────────────────────────────────────────────────────
+#
+# The UI renders a superset only when each exercise carries BOTH `superset` (a slot
+# like "A1"/"A2") and `pair_with` (the partner's exact `exercise` name), AND the
+# partners are ADJACENT in the array — groupBySuperset() in
+# web/src/components/fitness/weekly-workout-plan.tsx walks the list and groups
+# CONSECUTIVE entries sharing a slot letter. Position is load-bearing; slot letters
+# alone are not enough.
+#
+# 2026-07-27: the Week 2 rows (7/27, 7/29, 8/01) were written with neither field. They
+# rendered as six standalone straight sets while the plan name still said "(supersets)"
+# and the notes still described "3 pairs x 3 rounds". Nothing errored — the plan just
+# silently meant something different from what it displayed, and the difference was only
+# caught by eye. That is exactly the class of failure this file exists to make impossible.
+
+SLOT_RE = re.compile(r"^([A-Z])(\d+)$")
+
+
+def _work_entries(day: dict) -> list[dict]:
+    """The working block only — warmups and cooldowns are never supersetted."""
+    return [e for e in (day.get("workout") or []) if e.get("exercise")]
+
+
+def validate_supersets(plan: dict) -> list[str]:
+    """Structural check on antagonist-superset metadata. Returns human-readable problems.
+
+    A day is exempt entirely if it declares no slots AND its name does not claim to be
+    a superset day — plenty of days (grease-the-groove pull-ups) are a single exercise.
+    """
+    problems: list[str] = []
+
+    for day in plan.get("workout_days", []):
+        date = day.get("date", "?")
+        name = day.get("name") or ""
+        entries = _work_entries(day)
+        if not entries:
+            continue
+
+        slotted = [e for e in entries if e.get("superset")]
+
+        if not slotted:
+            # The bug that motivated this check: the name promises pairs, the data has none.
+            if "superset" in name.lower():
+                problems.append(
+                    f"{date}: name says \"{name}\" but no exercise carries a `superset` slot — "
+                    "the UI will render 6 standalone straight sets. Add `superset` (A1/A2/B1/…) "
+                    "and `pair_with` to every working exercise, ordered so partners are adjacent."
+                )
+            continue
+
+        if len(slotted) != len(entries):
+            bare = [e["exercise"] for e in entries if not e.get("superset")]
+            problems.append(
+                f"{date}: `superset` is set on {len(slotted)}/{len(entries)} working exercises — "
+                f"missing on {', '.join(bare)}. Partial slotting renders as a mix of groups and "
+                "orphans; slot every working exercise or none."
+            )
+            continue
+
+        slots = [str(e["superset"]).strip().upper() for e in entries]
+        malformed = [s for s in slots if not SLOT_RE.match(s)]
+        if malformed:
+            problems.append(
+                f"{date}: malformed superset slot(s) {malformed} — expected a letter then a "
+                "digit, e.g. A1, A2, B1."
+            )
+            continue
+
+        # Consecutive runs by letter. A letter appearing in more than one run means the
+        # partners are separated in the array, which the UI groups as two broken groups.
+        runs: list[tuple[str, list[int]]] = []
+        for i, slot in enumerate(slots):
+            letter = slot[0]
+            if runs and runs[-1][0] == letter:
+                runs[-1][1].append(i)
+            else:
+                runs.append((letter, [i]))
+
+        seen: dict[str, int] = {}
+        for letter, _ in runs:
+            seen[letter] = seen.get(letter, 0) + 1
+        split = sorted(l for l, n in seen.items() if n > 1)
+        if split:
+            problems.append(
+                f"{date}: superset group(s) {split} are not contiguous — order is "
+                f"{', '.join(slots)}. Grouping is positional, so partners must sit next to "
+                "each other (A1, A2, B1, B2, C1, C2)."
+            )
+            continue
+
+        by_name = {e["exercise"]: e for e in entries}
+        for letter, idxs in runs:
+            members = [entries[i] for i in idxs]
+            if len(members) < 2:
+                problems.append(
+                    f"{date}: superset {letter} has only \"{members[0]['exercise']}\" in it — "
+                    "a group needs at least two exercises, or drop the slot."
+                )
+                continue
+
+            digits = [int(SLOT_RE.match(slots[i]).group(2)) for i in idxs]
+            if digits != list(range(1, len(digits) + 1)):
+                problems.append(
+                    f"{date}: superset {letter} slots are numbered {digits} — expected "
+                    f"{list(range(1, len(digits) + 1))} in order."
+                )
+
+            member_names = {e["exercise"] for e in members}
+            for e in members:
+                partner = e.get("pair_with")
+                if not partner:
+                    problems.append(
+                        f"{date}: \"{e['exercise']}\" ({e['superset']}) has no `pair_with`."
+                    )
+                elif partner == e["exercise"]:
+                    problems.append(
+                        f"{date}: \"{e['exercise']}\" is paired with itself."
+                    )
+                elif partner not in member_names:
+                    where = (
+                        f"it is in superset {by_name[partner].get('superset')}"
+                        if partner in by_name
+                        else "no such exercise in this day's workout"
+                    )
+                    problems.append(
+                        f"{date}: \"{e['exercise']}\" ({e['superset']}) pairs with "
+                        f"\"{partner}\", which is not in superset {letter} — {where}."
+                    )
+
+            # Rounds are read off the FIRST member (SupersetGroup's `rounds` prop), so a
+            # mismatch inside the group displays a round count the other exercise doesn't run.
+            set_counts = {e["exercise"]: e.get("sets") for e in members}
+            if len(set(set_counts.values())) > 1:
+                problems.append(
+                    f"{date}: superset {letter} members disagree on `sets` ({set_counts}) — "
+                    "the group header shows the first exercise's count for the whole pair."
+                )
+
+    return problems
+
+
 def validate_recovery(day_plans: list[dict]) -> list[dict]:
     """day_plans: [{dayOfWeek: int, exercises: [{name, sets}]}]"""
     violations = []
@@ -256,12 +397,13 @@ def build_correction_prompt(plan: dict, has_pull_up_bar: bool) -> str | None:
 
     missing_patterns = validate_weekly_coverage(all_exercises, has_pull_up_bar)
     recovery_violations = validate_recovery(day_plans)
+    superset_problems = validate_supersets(plan)
     redundancy_issues = []
     for dp in day_plans:
         for issue in check_same_day_redundancy([e["name"] for e in dp["exercises"]]):
             redundancy_issues.append({**issue, "day": dp["dayOfWeek"]})
 
-    if not missing_patterns and not recovery_violations and not redundancy_issues:
+    if not missing_patterns and not recovery_violations and not redundancy_issues and not superset_problems:
         return None
 
     issues: list[str] = []
@@ -278,6 +420,9 @@ def build_correction_prompt(plan: dict, has_pull_up_bar: bool) -> str | None:
 
     for v in recovery_violations:
         issues.append(f"RECOVERY CONFLICT: {v['message']}")
+
+    for p in superset_problems:
+        issues.append(f"SUPERSET METADATA: {p}")
 
     return f"""The workout plan below has structural issues. Return ONLY a corrected JSON plan in a code block, fixing exactly the issues listed. Do not change exercises that are not flagged.
 
@@ -309,7 +454,7 @@ OUTPUT RULES:
       "date": "YYYY-MM-DD",
       "name": "Push Day",
       "warmup": [{{"exercise": "...", "sets": N, "reps": "...", "description": "1-3 sentences on how to perform", "tips": ["form cue"]}}],
-      "workout": [...same shape...],
+      "workout": [...same shape, plus "superset": "A1", "pair_with": "<partner exercise>" on every entry of a superset day...],
       "cooldown": [...same shape...],
       "notes": "rationale — cite evidence e.g. 'DB Bent-Over Row 3×12 @ 25 lb avg RPE 8.3 last week — top of range, prescribing same load with tempo added'"
     }}
@@ -343,6 +488,18 @@ The week MUST include at least one working set from each pattern:
 - pull_vertical (e.g. Pull-Up, Chin-Up, Banded Pulldown) — REQUIRED if pull-up bar is in equipment inventory
 - core (e.g. Plank, Dead Bug, Slider Body Saw, Hollow Hold)
 Never place 2+ exercises sharing the same pattern AND same equipment type back-to-back within a day (e.g. DB Bent-Over Row immediately followed by DB Single-Arm Row). Break them up with a different pattern.
+
+ANTAGONIST SUPERSETS (mandatory whenever the day is programmed as pairs):
+The app renders a superset ONLY from per-exercise metadata — the day `name` and `notes` are
+display text and control nothing. On every working exercise of a superset day, set:
+- "superset": a slot — letter identifies the pair, digit the position within it ("A1", "A2",
+  "B1", "B2", "C1", "C2"). Same letter = same pair, run alternated.
+- "pair_with": the partner's EXACT `exercise` string, reciprocally (A1 names A2, A2 names A1).
+Order the `workout` array so partners are ADJACENT — A1, A2, B1, B2, C1, C2. Grouping is
+positional: a pair split across the array renders as two broken groups. Both members of a
+pair must share the same `sets` (the group header shows one round count for the pair).
+Never name a day "(supersets)" without this metadata — it renders as straight sets and the
+plan then means something different from what it displays.
 
 EQUIPMENT-CAPPED PROGRESSION (apply when user is at max DB weight):
 When an exercise has been performed at the user's equipment cap at avg RPE ≤ 8 for 2+ sessions, do NOT repeat the same prescription. Apply the progression ladder in order:
@@ -458,6 +615,7 @@ def main() -> None:
         problems = []
         problems += [f"coverage: missing {m}" for m in validate_weekly_coverage(exercises, args.has_pull_up_bar)]
         problems += [f"recovery: {v['message']}" for v in validate_recovery(day_plans)]
+        problems += [f"superset: {p}" for p in validate_supersets(plan)]
         # Redundancy is a within-day property — checking a list flattened across days
         # compares the last exercise of one day against the first of the next.
         for dp in day_plans:
@@ -474,7 +632,7 @@ def main() -> None:
             sys.exit(1)
         print(
             f"plan OK — {len(day_plans)} day(s), {len(exercises)} exercises; "
-            "coverage, recovery spacing and same-day redundancy all pass"
+            "coverage, recovery spacing, same-day redundancy and superset metadata all pass"
         )
         return
 

--- a/tests/test_weekly_plan_supersets.py
+++ b/tests/test_weekly_plan_supersets.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Tests for the superset-metadata validator in scripts/weekly_plan.py.
+
+Run: python3 -m unittest discover -s tests -v
+
+These guard a check that exists because a bad plan is SILENT — the 2026-07-27 Week 2
+rows rendered as straight sets while their name and notes described supersets. Nothing
+threw. If this validator ever stops firing, the failure mode is invisible again, so the
+validator needs its own tests more than most.
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+# weekly_plan reads CRON_SECRET and INTERNAL_APP_URL/APP_URL at import time and exits
+# without them. These are never used by the pure validators under test.
+os.environ.setdefault("CRON_SECRET", "test")
+os.environ.setdefault("INTERNAL_APP_URL", "http://localhost:3000")
+
+from weekly_plan import validate_supersets  # noqa: E402
+
+
+def ex(name, slot=None, partner=None, sets=3):
+    e = {"exercise": name, "sets": sets, "reps": "10"}
+    if slot:
+        e["superset"] = slot
+    if partner:
+        e["pair_with"] = partner
+    return e
+
+
+def day(entries, name="Week 2A - Squat + Horizontal Push/Pull (supersets)", date="2026-07-27"):
+    return {"workout_days": [{"date": date, "name": name, "workout": entries}]}
+
+
+GOOD = [
+    ex("DB Goblet Squat", "A1", "Plank"),
+    ex("Plank", "A2", "DB Goblet Squat"),
+    ex("DB Chest Press (floor)", "B1", "DB Bent-Over Row"),
+    ex("DB Bent-Over Row", "B2", "DB Chest Press (floor)"),
+    ex("DB Overhead Press", "C1", "DB Reverse Fly"),
+    ex("DB Reverse Fly", "C2", "DB Overhead Press"),
+]
+
+
+class TestValidateSupersets(unittest.TestCase):
+    def test_well_formed_plan_passes(self):
+        self.assertEqual(validate_supersets(day(GOOD)), [])
+
+    def test_the_2026_07_27_regression(self):
+        """Name claims supersets, no exercise carries a slot. The original bug."""
+        bare = [ex(e["exercise"]) for e in GOOD]
+        problems = validate_supersets(day(bare))
+        self.assertEqual(len(problems), 1)
+        self.assertIn("no exercise carries a `superset` slot", problems[0])
+
+    def test_straight_set_day_without_superset_in_name_is_exempt(self):
+        bare = [ex(e["exercise"]) for e in GOOD]
+        self.assertEqual(validate_supersets(day(bare, name="Week 1A - Full Body")), [])
+
+    def test_single_exercise_gtg_day_is_exempt(self):
+        plan = day([ex("Pull-ups (grease-the-groove)", sets=5)], name="Daily Pull-ups (GtG)")
+        self.assertEqual(validate_supersets(plan), [])
+
+    def test_partial_slotting_is_rejected(self):
+        entries = [dict(e) for e in GOOD]
+        del entries[5]["superset"]
+        problems = validate_supersets(day(entries))
+        self.assertTrue(any("5/6 working exercises" in p for p in problems))
+
+    def test_non_adjacent_pairs_are_rejected(self):
+        """Grouping is positional — A1, B1, A2, B2 renders as broken groups."""
+        entries = [GOOD[0], GOOD[2], GOOD[1], GOOD[3], GOOD[4], GOOD[5]]
+        problems = validate_supersets(day(entries))
+        self.assertTrue(any("not contiguous" in p for p in problems))
+
+    def test_malformed_slot_is_rejected(self):
+        entries = [dict(e) for e in GOOD]
+        entries[0]["superset"] = "pair-A"
+        problems = validate_supersets(day(entries))
+        self.assertTrue(any("malformed superset slot" in p for p in problems))
+
+    def test_lone_slot_is_rejected(self):
+        entries = [
+            ex("DB Goblet Squat", "A1", "Plank"),
+            ex("Plank", "B1", "DB Goblet Squat"),
+        ]
+        problems = validate_supersets(day(entries))
+        self.assertTrue(any("only" in p and "at least two" in p for p in problems))
+
+    def test_non_reciprocal_pair_with_is_rejected(self):
+        entries = [dict(e) for e in GOOD]
+        entries[1]["pair_with"] = "DB Bent-Over Row"  # points into superset B
+        problems = validate_supersets(day(entries))
+        self.assertTrue(any("not in superset A" in p for p in problems))
+
+    def test_missing_pair_with_is_rejected(self):
+        entries = [dict(e) for e in GOOD]
+        del entries[3]["pair_with"]
+        problems = validate_supersets(day(entries))
+        self.assertTrue(any("has no `pair_with`" in p for p in problems))
+
+    def test_pair_with_naming_an_absent_exercise_is_rejected(self):
+        entries = [dict(e) for e in GOOD]
+        entries[4]["pair_with"] = "DB Chest Fly (floor)"
+        problems = validate_supersets(day(entries))
+        self.assertTrue(any("no such exercise" in p for p in problems))
+
+    def test_self_pairing_is_rejected(self):
+        entries = [dict(e) for e in GOOD]
+        entries[0]["pair_with"] = "DB Goblet Squat"
+        problems = validate_supersets(day(entries))
+        self.assertTrue(any("paired with itself" in p for p in problems))
+
+    def test_out_of_order_digits_are_rejected(self):
+        entries = [dict(e) for e in GOOD]
+        entries[0]["superset"] = "A2"
+        entries[1]["superset"] = "A3"
+        problems = validate_supersets(day(entries))
+        self.assertTrue(any("numbered [2, 3]" in p for p in problems))
+
+    def test_mismatched_sets_within_a_pair_are_rejected(self):
+        entries = [dict(e) for e in GOOD]
+        entries[1]["sets"] = 2
+        problems = validate_supersets(day(entries))
+        self.assertTrue(any("disagree on `sets`" in p for p in problems))
+
+    def test_tri_set_of_three_is_accepted(self):
+        entries = [
+            ex("DB Goblet Squat", "A1", "Plank"),
+            ex("Plank", "A2", "DB Goblet Squat"),
+            ex("DB Calf Raise", "A3", "Plank"),
+            ex("DB Chest Press (floor)", "B1", "DB Bent-Over Row"),
+            ex("DB Bent-Over Row", "B2", "DB Chest Press (floor)"),
+        ]
+        self.assertEqual(validate_supersets(day(entries)), [])
+
+    def test_warmup_and_cooldown_are_not_required_to_be_slotted(self):
+        plan = day(GOOD)
+        plan["workout_days"][0]["warmup"] = [ex("Leg Swing")]
+        plan["workout_days"][0]["cooldown"] = [ex("Dead Hang")]
+        self.assertEqual(validate_supersets(plan), [])
+
+    def test_every_day_is_checked_not_just_the_first(self):
+        plan = day(GOOD)
+        plan["workout_days"].append(
+            {"date": "2026-07-29", "name": "Week 2B (supersets)",
+             "workout": [ex("DB Romanian Deadlift"), ex("DB Floor Press")]}
+        )
+        problems = validate_supersets(plan)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("2026-07-29", problems[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

A superset renders **only** from per-exercise `superset` / `pair_with` metadata. The plan `name` and `notes` are display text and control nothing.

Week 2 (`2026-07-27`, `2026-07-29`, `2026-08-01`) was written with **neither field**. Three sessions named `"… (supersets)"`, whose notes described *"Antagonist supersets: 3 pairs x 3 rounds"*, rendered as six standalone straight sets.

Nothing errored. The plan simply meant something different from what it displayed, and the only thing that caught it was noticing the UI looked wrong.

## Fix

`validate_supersets()` in `scripts/weekly_plan.py`, wired into both `validate` and `build_correction_prompt`. It fails a plan on:

| Check | Why |
|---|---|
| `"(supersets)"` in the day name but no slots | **the original bug** |
| Partial slotting | renders as a mix of groups and orphans |
| Malformed slot (not `A1`-shaped) | ungroupable |
| Non-contiguous pairs | `groupBySuperset()` walks **consecutive** same-letter entries — a split pair becomes two broken groups. Position is load-bearing |
| Lone slot in a group | a pair needs two |
| `pair_with` missing / self / non-reciprocal / outside the group | the partner link is what the UI labels |
| Out-of-order slot digits | `A2, A3` instead of `A1, A2` |
| Pair members disagreeing on `sets` | the group header shows **one** round count for both |

Days with no slots and no "superset" in the name (grease-the-groove pull-up days, straight-set days) are exempt.

`PLANNER_PROMPT` and `.claude/commands/weekly-plan.md` now document the fields, so plans get written correctly rather than only rejected afterward.

## Verification

Replaying the actual broken 7/27 row through the CLI:

```
$ python3 scripts/weekly_plan.py validate /tmp/broken.json
PLAN FAILED VALIDATION:
  - superset: 2026-07-27: name says "Week 2A - Squat + Horizontal Push/Pull (supersets)"
    but no exercise carries a `superset` slot — the UI will render 6 standalone straight
    sets. Add `superset` (A1/A2/B1/…) and `pair_with` to every working exercise, ordered
    so partners are adjacent.
```

The corrected shape passes clean. 17 unit tests, all green.

## Tests + CI

This adds `tests/` — the repo's first Python tests — and a `python-tests` workflow. Deliberately stdlib-only `unittest` with no `pip install`, so the structural validators keep running on a bare interpreter.

The reasoning: this guard protects against a *silent* failure mode. A guard that can itself silently stop firing is worth nothing, so it needs its own coverage more than most code here does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AexCfan5ogzCMJRm5ccXZc
