### PR TITLE
chore: drop the redundant "Recent meals" section from the meals page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Removed
 
+- **Meals page — dropped the "Recent meals" section.** It rendered inside the Today tab while
+  `PastMeals` ("Past 6 Days") renders unconditionally below the tab panels, so both were on screen
+  at the same time showing the same `pastMeals` rows — the first deduped to 10 by normalized name,
+  the second in full chronological order. Two views of one dataset, stacked. The dedupe was the only
+  thing "Recent meals" added, and it bought little: with a 6-day window most repeats are already
+  adjacent in "Past 6 Days", and the deduped list silently hid the *repeat* rows, which is exactly
+  what makes a meal worth re-logging. Removed the section, the `recentMeals` `useMemo`, the now-unused
+  `pastMeals` prop on `TodayTab`, and the `normalizeName` helper whose only caller it was. The
+  re-log path is unaffected: `MealRowDisplay`'s `onRelog` is still wired for today's meals, and
+  the Recipes tab remains the route for logging something cooked before.
+
 - **graphify — deleted the stale knowledge graph and every rule pointing at it.** `graphify-out/`
   was last regenerated **2026-05-05** and had been tracked, unchanged, for 83 days while the repo
   absorbed the self-host cutover, the Google Health port, inventory, dual units, the service-worker

--- a/web/src/components/meals/MealsClient.tsx
+++ b/web/src/components/meals/MealsClient.tsx
@@ -123,15 +123,6 @@ const MEAL_ORDER: Record<string, number> = {
 const MEAL_TYPES = ["breakfast", "lunch", "dinner", "snack"] as const;
 type MealType = (typeof MEAL_TYPES)[number];
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function normalizeName(s: string | null | undefined): string {
-  return (s ?? "")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, " ")
-    .trim();
-}
-
 // ─── Shared styles ────────────────────────────────────────────────────────────
 
 const inputStyle = {
@@ -653,13 +644,11 @@ function MealRowEdit({
 
 function TodayTab({
   todayMeals,
-  pastMeals,
   macroGoals,
   macroTotals,
   onDelete,
 }: {
   todayMeals: MealRow[];
-  pastMeals: MealRow[];
   macroGoals: MacroGoals;
   macroTotals: MacroTotals;
   onDelete: (id: string) => void;
@@ -731,17 +720,6 @@ function TodayTab({
       setReanalyzing(false);
     }
   }
-
-  const recentMeals = useMemo(() => {
-    const byKey = new Map<string, MealRow>();
-    const sorted = [...pastMeals].sort((a, b) => (a.date < b.date ? 1 : -1));
-    for (const m of sorted) {
-      const key = normalizeName(m.cooks?.name ?? m.recipes?.name ?? m.notes);
-      if (!key) continue;
-      if (!byKey.has(key)) byKey.set(key, m);
-    }
-    return Array.from(byKey.values()).slice(0, 10);
-  }, [pastMeals]);
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editFields, setEditFields] = useState<MealRowEditFields>({
@@ -1089,24 +1067,6 @@ function TodayTab({
           </div>
         )}
       </section>
-
-      {/* Recent meals (deduped past 7 days) */}
-      {recentMeals.length > 0 && (
-        <section>
-          <h2 className="db-section-label">Recent meals</h2>
-          <div>
-            {recentMeals.map((m, i) => (
-              <div key={m.id} style={i > 0 ? { borderTop: "1px solid var(--rule-soft)" } : {}}>
-                <MealRowDisplay
-                  meal={m}
-                  onClick={() => prefillLog(m)}
-                  onRelog={() => prefillLog(m)}
-                />
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
     </div>
   );
 }
@@ -2084,7 +2044,6 @@ function MealsClientInner({
       {tab === "today" && (
         <TodayTab
           todayMeals={visibleTodayMeals}
-          pastMeals={visiblePastMeals}
           macroGoals={macroGoals}
           macroTotals={displayedMacroTotals}
           onDelete={handleDelete}


### PR DESCRIPTION
## What

Removes the **Recent meals** section from the meals page.

## Why

`Recent meals` rendered inside `TodayTab`, while `PastMeals` ("Past 6 Days") renders
*unconditionally below the tab panels*. On the Today tab both were on screen at the same
time, reading the same `pastMeals` array — the first deduped to 10 by normalized name, the
second in full chronological order. Two views of one dataset, stacked.

The dedupe was the only thing the section added, and it cut against the use case it existed
for: within a 6-day window most repeats are already adjacent in "Past 6 Days", and deduping
*hid* the repeat rows — which are exactly the meals worth re-logging.

## Changes

`web/src/components/meals/MealsClient.tsx` (−41 lines):

- the `Recent meals` `<section>` in `TodayTab`
- the `recentMeals` `useMemo`
- the `pastMeals` prop on `TodayTab` (signature, type, call site) — it had no other consumer
- the `normalizeName()` helper — `recentMeals` was its only caller

`MealRowDisplay`'s `onRelog` is untouched and still wired for today's meals, so the re-log
path is unaffected. The Recipes tab remains the route for logging something cooked before.

## Verification

| Check | Result |
|---|---|
| `npm run typecheck` | pass, 0 errors |
| `npm run lint` | 0 errors, 13 warnings — all pre-existing, none in this file |
| `npm run format:check` | pass |
| `scripts/lint-tokens.sh` | all 4 guards pass |
| `npm run build` | pass, `/meals` compiled |

Compile and types are green. Not visually verified — no browser available in the authoring
environment.

## Notes

`CHANGELOG.md` updated under `[Unreleased] / Removed`. No issue to close; this came out of
a session request to reduce clutter on the meals page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Nfqj4GZ6Wr1kWvHFHft4n
