### PR TITLE
fix(weekly-plan): exclude warmups from redundancy and recovery checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **`weekly_plan.py` — warmups no longer count as programming errors.** `shape_plan()` flattened
+  `warmup + workout + cooldown` into the list feeding the recovery and same-day-redundancy checks,
+  while `_work_entries()` already excluded warmups for the superset check. The two disagreed, and
+  the consequence was that the RAMP protocol's **Potentiate** step was unrepresentable: it is a
+  ~50% ramp-up set of the day's *first lift*, and it only potentiates if it sits immediately before
+  the working sets — which the redundancy rule then read as two same-pattern exercises back-to-back
+  and rejected. Week 2 (7/27-8/01) passed only by accident, because its warmup happened to end on a
+  Band Pull-Apart rather than a squat. `day_plans` now counts the working block only, via the same
+  `_work_entries()` the superset check uses; coverage still counts every entry, since a warmup
+  movement does still demonstrate a pattern is present in the week. Verified both directions: the
+  already-executed Week 2 still validates clean (no regression) and Week 3 now validates clean.
+
+- **`log_habit.py` — the scripted habit path was broken for every call.** It upserts with
+  `on_conflict="habit_id,date"`, but the table's constraint is `user_id,habit_id,date`, so Postgres
+  rejected it with `42P10 there is no unique or exclusion constraint matching the ON CONFLICT
+  specification`. Not intermittent — it could never have succeeded.
+
+### Documented
+
+- **`EXERCISE_MUSCLE_MAP` now says out loud why grease-the-groove movements are absent from it.**
+  They are exempt from the 24h recovery rule because GtG is submaximal and daily by design; that
+  exemption was real but purely implicit (it worked only because the names were missing), so adding
+  them would have silently broken every GtG week. Same failure class as PR #650.
+
 ### Removed
 
 - **Meals page — dropped the "Recent meals" section.** It rendered inside the Today tab while

--- a/scripts/log_habit.py
+++ b/scripts/log_habit.py
@@ -67,7 +67,10 @@ def main():
         print("[log-habit] No valid habits to log.", file=sys.stderr)
         sys.exit(1)
 
-    resp = client.table("habits").upsert(rows, on_conflict="habit_id,date").execute()
+    # on_conflict must name the FULL unique constraint (user_id, habit_id, date). With just
+    # "habit_id,date" Postgres raises 42P10 "there is no unique or exclusion constraint
+    # matching the ON CONFLICT specification" — this path could never have succeeded.
+    resp = client.table("habits").upsert(rows, on_conflict="user_id,habit_id,date").execute()
     written = len(resp.data)
     log_sync(client, "log_habit", "ok", written)
     logged = [r["habit_id"] for r in resp.data]

--- a/scripts/weekly_plan.py
+++ b/scripts/weekly_plan.py
@@ -114,6 +114,13 @@ EXERCISE_PATTERN_MAP: dict[str, list[str]] = {
 REQUIRED_PATTERNS = ["squat", "hinge", "push_horizontal", "push_vertical",
                      "pull_horizontal", "pull_vertical", "core"]
 
+# Grease-the-groove movements are DELIBERATELY ABSENT from this map, and must stay absent.
+# GtG is submaximal, sub-failure and daily BY DESIGN — that is the entire protocol — so scoring it
+# on the 24h recovery rule below is a category error. It is the same mistake PR #650 fixed in
+# fetch_briefing_data.py, where GtG sessions were being graded against the 1-3 RIR lifting bands.
+# Adding "Pull-ups (grease-the-groove)" or "Chin-ups (grease-the-groove)" here would make every
+# GtG week fail recovery validation. Plain "Pull-Up"/"Chin-Up" ARE mapped, because those names mean
+# a real working set inside a lift.
 EXERCISE_MUSCLE_MAP: dict[str, list[str]] = {
     "DB Goblet Squat": ["quads", "glutes"], "Goblet Squat": ["quads", "glutes"],
     "DB Sumo Squat": ["glutes", "quads"], "DB Bulgarian Split Squat": ["quads", "glutes"],
@@ -194,6 +201,20 @@ def shape_plan(plan: dict) -> tuple[list[str], list[dict]]:
     and [{dayOfWeek, exercises: [{name, sets}]}] (recovery spacing). Keeping the
     conversion in one place is what stops `validate` and `build_correction_prompt`
     drifting apart — they disagreed before, and `validate` was the one that was wrong.
+
+    Coverage counts EVERY entry (a warmup movement still demonstrates a pattern is in
+    the week), but `day_plans` — which feeds the recovery and same-day-redundancy checks
+    — counts the WORKING BLOCK ONLY, via the same `_work_entries()` the superset check
+    uses. Both of those rules are about how the training is programmed, not about warmups:
+    the redundancy rule's own example is "DB Bent-Over Row immediately followed by DB
+    Single-Arm Row", and the recovery rule measures training volume per muscle.
+
+    2026-08-02: flattening warmups in made the RAMP protocol's Potentiate step
+    unrepresentable. That step is a ~50% ramp-up set of the day's FIRST LIFT, and it only
+    potentiates if it sits immediately before the working sets — which the redundancy
+    check then read as two same-pattern exercises back-to-back and rejected. Week 2 passed
+    only because its warmup happened to end on a Band Pull-Apart. A correct warmup should
+    not be a validation error.
     """
     all_exercises: list[str] = []
     day_plans: list[dict] = []
@@ -209,8 +230,7 @@ def shape_plan(plan: dict) -> tuple[list[str], list[dict]]:
             "date": day["date"],
             "exercises": [
                 {"name": e["exercise"], "sets": e.get("sets", 1)}
-                for e in entries
-                if e.get("exercise")
+                for e in _work_entries(day)
             ],
         })
 


### PR DESCRIPTION
## What

`shape_plan()` flattened `warmup + workout + cooldown` into the list that feeds the **recovery** and **same-day-redundancy** validators, while `_work_entries()` already excluded warmups for the **superset** check. The two disagreed — which is precisely the drift the function's own docstring warns about.

## Why it matters

It made the RAMP protocol's **Potentiate** step unrepresentable.

Potentiate is a ~50% ramp-up set of the day's *first lift*, and it only potentiates if it sits immediately before the working sets. The redundancy rule then read that as two same-pattern exercises back-to-back and rejected the week:

```
redundancy: 2026-08-03 — DB Goblet Squat then DB Goblet Squat share pattern 'squat'
redundancy: 2026-08-05 — DB Romanian Deadlift then DB Romanian Deadlift share pattern 'hinge'
redundancy: 2026-08-08 — DB Sumo Squat then DB Sumo Squat share pattern 'squat'
```

Week 2 passed only by accident: its warmup happened to end on a Band Pull-Apart rather than a squat. A correct warmup should not be a validation error.

Both rules are about how the *training* is programmed, not about warmups — the redundancy rule's own docstring example is "DB Bent-Over Row immediately followed by DB Single-Arm Row", and the recovery rule measures training volume per muscle.

## Change

`day_plans` now counts the working block only, via the same `_work_entries()` the superset check uses. Coverage still counts every entry, since a warmup movement does still demonstrate a pattern is present in the week.

Also documents why grease-the-groove movements are **deliberately absent** from `EXERCISE_MUSCLE_MAP`. GtG is submaximal, sub-failure and daily by design, so scoring it on the 24h recovery rule is a category error — the same mistake #650 fixed in `fetch_briefing_data.py`. That exemption was real but purely implicit (it worked only because the names were missing from the dict), so adding them later would have silently failed every GtG week. Now it says so.

## Verification

Ran the validator against real plan data in both directions:

| Week | Before | After |
|---|---|---|
| Week 2 (7/27–8/01, already executed) | pass | **pass** — no regression |
| Week 3 (8/03–8/09) | 3 redundancy failures | **pass** |

`python -m py_compile scripts/weekly_plan.py` clean. Note CI is path-filtered to `web/`, so a `scripts/`-only PR gets no lint or typecheck — this was compile-checked and exercised by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NvYDbSnsLb7xXDDYUs3yPG
