### PR TITLE
fix(google-health): dedup same-batch duplicates and manual rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,29 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **Google Health sync stored the same workout two and three times.** `filter_new_workouts()`
+  in `scripts/sync-google-health.py` has a ±5 min same-date overlap check, and it worked —
+  against rows already in the database. But `by_date` was built once from `existing` and never
+  updated as candidates were accepted, so two duplicates arriving in the **same** batch were
+  each measured against a database containing neither, and both passed. Google Health
+  aggregates several writers (watch, phone, connected apps) and routinely emits one activity
+  twice in a single response: once from the writer holding the HR sensor, with `hr_zones`
+  populated, and once as a coarse copy with `hr_zones` null and a wild calorie figure. On the
+  *next* run the pair is in `existing` and further copies are suppressed — which is why the
+  duplicates sat as stable pairs rather than multiplying, and why nothing looked wrong.
+  Separately, `existing` was filtered to `WORKOUT_SOURCES = ["google_health", "fitbit"]`, which
+  excludes `"manual"`, so a hand-logged session could neither suppress an auto-import nor be
+  suppressed by one. Accepted rows now join the comparison set, and reads use a new
+  `DEDUPE_SOURCES` that adds `"manual"` (`WORKOUT_SOURCES` still means "what this sync writes").
+  Observed damage: 2026-07-31 held a 13-minute walk twice at 84 and 467 kcal, and one
+  basketball game three times — 431 + 792 + 454 = 1677 kcal — inflating the day to 2963 active
+  calories against a 2500 *weekly* goal; 2026-08-02 held a phantom 295-minute "Cardio Workout"
+  worth 1867 kcal, the watch reading alcohol-elevated resting HR as five hours of exercise.
+  The affected rows were neutralised in place rather than deleted, since the 7-day lookback
+  re-imports deleted rows. Covered by `tests/test_google_health_dedupe.py`, which fails on the
+  pre-fix code. **The audit only covered 7/31 and 8/02 — other days likely carry the same
+  pairs.** Diagnostic: of a near-simultaneous pair, the phantom is the one with `hr_zones` null.
+
 - **The briefing stopped telling the coach to undo the current training rule.**
   `scripts/fetch_briefing_data.py` still printed `FLAG: effort >=8 — drop next session load 10%`
   and `FLAG: effort >=9 — cut a set next session` on every logged session. Those bands were

--- a/scripts/sync-google-health.py
+++ b/scripts/sync-google-health.py
@@ -49,6 +49,13 @@ HEALTH_API_BASE = "https://health.googleapis.com/v4"
 WORKOUT_SOURCES = ["google_health", "fitbit"]
 BODY_SOURCES = ["google_health", "fitbit_body", "google_fit"]
 
+# Rows the dedup must compare AGAINST — a superset of the ones this sync writes.
+# "manual" belongs here because a session logged by hand is the same real-world workout
+# the watch also reports; leaving it out meant a manual row could neither suppress an
+# auto-import nor be suppressed by one. One 2026-07-31 basketball game landed three
+# times that way (manual 454 kcal + two auto-imports) and was counted at 1677 kcal.
+DEDUPE_SOURCES = WORKOUT_SOURCES + ["manual"]
+
 # Fitbit returned display strings ("Walking"); Google returns an exerciseType enum
 # across 182 values. Alias the ones that had canonical names, title-case the rest.
 ACTIVITY_ALIASES = {
@@ -321,10 +328,17 @@ def filter_new_workouts(client, user_id: str, rows: list[dict]) -> list[dict]:
     Unlike the Fitbit sync, an overlapping row is never replaced: the existing row is
     the same workout already stored under the old source label, so swapping it would
     churn history for no gain.
+
+    The overlap window is checked against previously-stored rows AND against rows already
+    accepted earlier in this same batch. Google Health aggregates several writers (watch,
+    phone, connected apps) and commonly emits the same activity twice — once from the
+    writer holding the HR sensor, with `hr_zones` populated, and once as a coarse copy with
+    `hr_zones` null and a wild calorie figure. Both arrive in one response, so neither is in
+    the database yet when the other is judged.
     """
     existing = (client.table("workout_sessions")
                 .select("id,date,start_time,activity,avg_hr,duration_mins,source")
-                .eq("user_id", user_id).in_("source", WORKOUT_SOURCES).execute().data)
+                .eq("user_id", user_id).in_("source", DEDUPE_SOURCES).execute().data)
 
     existing_keys = {f"{r['date']}|{r['start_time']}|{r['activity']}" for r in existing}
     candidates = [r for r in rows if r["_key"] not in existing_keys]
@@ -347,6 +361,15 @@ def filter_new_workouts(client, user_id: str, rows: list[dict]) -> list[dict]:
                 break
         if not overlapped:
             new_rows.append(row)
+            # An accepted row joins the comparison set. Without this, `by_date` holds only
+            # what was already in the database, so two duplicates arriving in the same
+            # batch are each measured against a database containing neither — and both
+            # pass. That is exactly how 2026-07-31 stored Basketball at 13:12:00 and
+            # 13:13:05 (65 s apart) and two Walks 3 min apart, both pairs well inside
+            # OVERLAP_MINS. The next run does suppress further copies, since by then the
+            # pair is in `existing` — which is why duplicates sit as stable pairs rather
+            # than multiplying, and why this went unnoticed.
+            by_date.setdefault(row["date"], []).append(row)
     return new_rows
 
 

--- a/tests/test_google_health_dedupe.py
+++ b/tests/test_google_health_dedupe.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Tests for workout dedup in scripts/sync-google-health.py.
+
+Run: python3 -m unittest discover -s tests -v
+
+These guard a bug whose failure mode is SILENT and cumulative. Google Health aggregates
+several writers (watch, phone, connected apps) and routinely reports one activity twice in
+a single response: once from the writer holding the HR sensor, with `hr_zones` populated,
+and once as a coarse copy with `hr_zones` null and a wild calorie figure.
+
+Before 2026-08-05 the +/-5 min overlap check compared each incoming row only against rows
+already in the database, never against rows accepted earlier in the same batch — so for a
+same-batch pair, neither copy was stored yet when the other was judged, and both passed.
+Nothing errored; active-calorie totals just drifted upward. 2026-07-31 stored one walk
+twice (84 and 467 kcal for 13 minutes) and one basketball game three times (1677 kcal
+total); 2026-08-02 stored a phantom 295-minute "Cardio Workout" worth 1867 kcal.
+
+If this regresses nothing throws and the numbers quietly inflate again, so it needs a test.
+"""
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+
+def _load_sync_module():
+    """Import sync-google-health.py on a bare interpreter.
+
+    Two obstacles, both deliberate. The CI job installs no dependencies on purpose (see
+    .github/workflows/python-tests.yml), and the filename is hyphenated, so it is not a
+    legal module name for a plain import. Stub the non-stdlib imports, then load by path.
+    `filter_new_workouts` is pure apart from a single Supabase read, which the fake client
+    below supplies.
+    """
+    dotenv = types.ModuleType("dotenv")
+    dotenv.load_dotenv = lambda *a, **k: None
+    sys.modules.setdefault("dotenv", dotenv)
+
+    for name, attrs in (
+        ("_supabase", ("get_client", "get_owner_user_id", "upsert")),
+        ("_sync_log", ("log_sync", "urlopen_with_retry")),
+        ("_integrations", ("load_integration",)),
+    ):
+        stub = types.ModuleType(name)
+        for attr in attrs:
+            setattr(stub, attr, lambda *a, **k: None)
+        sys.modules.setdefault(name, stub)
+
+    spec = importlib.util.spec_from_file_location(
+        "sync_google_health", SCRIPTS / "sync-google-health.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+sync = _load_sync_module()
+
+USER = "test-user"
+
+
+class _FakeQuery:
+    """Mimics only the postgrest chain filter_new_workouts actually calls."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def select(self, *a, **k):
+        return self
+
+    def eq(self, *a, **k):
+        return self
+
+    def in_(self, column, values):
+        self._rows = [r for r in self._rows if r.get(column) in values]
+        return self
+
+    def execute(self):
+        return types.SimpleNamespace(data=self._rows)
+
+
+class FakeClient:
+    def __init__(self, stored):
+        self.stored = stored
+
+    def table(self, _name):
+        return _FakeQuery([dict(r) for r in self.stored])
+
+
+def stored(date, start, activity, source="google_health"):
+    return {
+        "id": f"{date}-{start}-{activity}",
+        "date": date,
+        "start_time": start,
+        "activity": activity,
+        "avg_hr": None,
+        "duration_mins": 30,
+        "source": source,
+    }
+
+
+def incoming(date, start, activity, **extra):
+    row = {
+        "date": date,
+        "start_time": start,
+        "activity": activity,
+        "_key": f"{date}|{start}|{activity}",
+    }
+    row.update(extra)
+    return row
+
+
+def names(rows):
+    return [(r["start_time"], r["activity"]) for r in rows]
+
+
+class SameBatchDuplicates(unittest.TestCase):
+    """The regression: both copies arrive together, so neither is in the DB yet."""
+
+    def test_basketball_pair_65_seconds_apart_keeps_one(self):
+        # The real 2026-07-31 rows: 13:12:00 (no HR zones) and 13:13:05 (Peak 41m).
+        rows = [
+            incoming("2026-07-31", "13:12:00", "Basketball", calories=431),
+            incoming("2026-07-31", "13:13:05", "Basketball", calories=792),
+        ]
+        kept = sync.filter_new_workouts(FakeClient([]), USER, rows)
+        self.assertEqual(len(kept), 1, f"expected 1 row, got {names(kept)}")
+        self.assertEqual(kept[0]["start_time"], "13:12:00")
+
+    def test_walk_pair_three_minutes_apart_keeps_one(self):
+        # 2026-07-31 again: 13 min of walking stored as 84 kcal and 467 kcal.
+        rows = [
+            incoming("2026-07-31", "12:59:54", "Walk", calories=84),
+            incoming("2026-07-31", "13:03:00", "Walk", calories=467),
+        ]
+        kept = sync.filter_new_workouts(FakeClient([]), USER, rows)
+        self.assertEqual(len(kept), 1, f"expected 1 row, got {names(kept)}")
+
+    def test_three_copies_collapse_to_one(self):
+        rows = [
+            incoming("2026-07-31", "13:12:00", "Basketball"),
+            incoming("2026-07-31", "13:13:05", "Basketball"),
+            incoming("2026-07-31", "13:14:10", "Basketball"),
+        ]
+        kept = sync.filter_new_workouts(FakeClient([]), USER, rows)
+        self.assertEqual(len(kept), 1, f"expected 1 row, got {names(kept)}")
+
+    def test_genuinely_separate_sessions_both_survive(self):
+        # Outside OVERLAP_MINS: two real sessions on one day must not be collapsed.
+        rows = [
+            incoming("2026-07-31", "09:54:31", "Cardio Workout"),
+            incoming("2026-07-31", "15:36:22", "Cardio Workout"),
+        ]
+        kept = sync.filter_new_workouts(FakeClient([]), USER, rows)
+        self.assertEqual(len(kept), 2, f"expected 2 rows, got {names(kept)}")
+
+    def test_same_clock_time_on_different_dates_both_survive(self):
+        rows = [
+            incoming("2026-07-30", "13:12:00", "Basketball"),
+            incoming("2026-07-31", "13:12:00", "Basketball"),
+        ]
+        kept = sync.filter_new_workouts(FakeClient([]), USER, rows)
+        self.assertEqual(len(kept), 2, f"expected 2 rows, got {names(kept)}")
+
+
+class ManualRowsParticipateInDedup(unittest.TestCase):
+    """A hand-logged session is the same real workout the watch also reports."""
+
+    def test_manual_row_suppresses_the_auto_import(self):
+        db = [stored("2026-07-31", "13:13:05", "Basketball", source="manual")]
+        rows = [incoming("2026-07-31", "13:12:00", "Basketball")]
+        kept = sync.filter_new_workouts(FakeClient(db), USER, rows)
+        self.assertEqual(kept, [], f"manual row should have suppressed it, got {names(kept)}")
+
+    def test_manual_is_in_the_dedup_source_list(self):
+        self.assertIn("manual", sync.DEDUPE_SOURCES)
+        # ...but is not something this sync claims to write.
+        self.assertNotIn("manual", sync.WORKOUT_SOURCES)
+
+    def test_unrelated_source_does_not_suppress(self):
+        db = [stored("2026-07-31", "13:13:05", "Basketball", source="strava")]
+        rows = [incoming("2026-07-31", "13:12:00", "Basketball")]
+        kept = sync.filter_new_workouts(FakeClient(db), USER, rows)
+        self.assertEqual(len(kept), 1, "a source outside DEDUPE_SOURCES must not suppress")
+
+
+class PreExistingBehaviourPreserved(unittest.TestCase):
+    """The original guarantees must survive the fix."""
+
+    def test_exact_key_match_is_dropped(self):
+        db = [stored("2026-07-31", "13:13:05", "Basketball")]
+        rows = [incoming("2026-07-31", "13:13:05", "Basketball")]
+        self.assertEqual(sync.filter_new_workouts(FakeClient(db), USER, rows), [])
+
+    def test_stored_row_suppresses_a_near_neighbour(self):
+        db = [stored("2026-07-31", "13:13:05", "Basketball")]
+        rows = [incoming("2026-07-31", "13:12:00", "Basketball")]
+        self.assertEqual(sync.filter_new_workouts(FakeClient(db), USER, rows), [])
+
+    def test_null_start_time_is_not_treated_as_overlapping(self):
+        # time_to_mins returns None for a missing start_time; those rows are skipped by
+        # the comparison rather than silently matching everything.
+        rows = [
+            incoming("2026-07-31", None, "Basketball"),
+            incoming("2026-07-31", "13:12:00", "Basketball"),
+        ]
+        kept = sync.filter_new_workouts(FakeClient([]), USER, rows)
+        self.assertEqual(len(kept), 2, f"expected both kept, got {names(kept)}")
+
+    def test_empty_batch(self):
+        self.assertEqual(sync.filter_new_workouts(FakeClient([]), USER, []), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`filter_new_workouts()` in `scripts/sync-google-health.py` stored the same workout two and three times. Two independent defects.

**1. The overlap check was blind within a single batch.** There is a ±5 min same-date check and it works — against rows already in the database. But `by_date` was built once from `existing` and never updated as candidates were accepted, so two duplicates arriving in the *same* response were each measured against a database containing neither, and both passed.

Google Health aggregates several writers (watch, phone, connected apps) and routinely emits one activity twice per response: once from the writer holding the HR sensor, with `hr_zones` populated, and once as a coarse copy with `hr_zones` null and a wild calorie figure. On the *next* run the pair is in `existing`, so further copies are suppressed — which is why duplicates sat as stable **pairs** rather than multiplying, and why nothing ever looked broken.

**2. Manual rows were invisible to the dedup.** `existing` was filtered to `WORKOUT_SOURCES = ["google_health", "fitbit"]`, which omits `"manual"`. A hand-logged session could neither suppress an auto-import nor be suppressed by one.

## Observed damage

| Date | Rows | Effect |
|---|---|---|
| 2026-07-31 | `Walk` 12:59:54 (84 kcal) + 13:03:00 (**467 kcal**), 3 min apart | 13-minute walk counted twice; 467 kcal is ~6x plausible |
| 2026-07-31 | `Basketball` 13:13:05 (792 kcal, avg HR 172) + 13:12:00 (431 kcal, no zones) + a `manual` row (454 kcal) | one game counted at **1677 kcal** |
| 2026-08-02 | phantom `Cardio Workout`, 295 min / **1867 kcal** | watch read alcohol-elevated resting HR as five hours of exercise |

7/31 totalled 2963 active calories against a **weekly** goal of 2500. Inflated active calories make a surplus look like a deficit, which is the number the coaching loop reads.

## Fix

- Accepted rows now join `by_date`, so same-batch duplicates are compared against each other.
- Reads use a new `DEDUPE_SOURCES = WORKOUT_SOURCES + ["manual"]`. `WORKOUT_SOURCES` keeps its documented meaning of "sources this sync writes".

## Tests

`tests/test_google_health_dedupe.py` — 14 cases over both defects, built from the real 7/31 rows. Verified to **fail on the pre-fix code** (4 failures + 1 error) and pass after. It stubs the non-stdlib imports and loads the hyphenated filename by path, so it runs in the existing `python-tests` job, which deliberately installs nothing.

Negative cases included: sessions >5 min apart, same clock time on different dates, null `start_time`, and a source outside `DEDUPE_SOURCES` — none of which should be collapsed.

## Data already repaired

The affected rows were **neutralised in place** (`calories`/`duration_mins` zeroed, originals preserved in `notes`) rather than deleted: the 7-day lookback re-imports deleted rows, but an existing row is never replaced, so an edit is the only durable repair.

## Not covered

Only 7/31 and 8/02 were audited. **Other days very likely carry the same pairs** — a full sweep is still owed. Diagnostic: same date + activity, start times within ~5 min, one row with `metadata->>'hr_zones'` null.
