### PR TITLE
fix(google-health): apply the dedup fix to the app-side sync too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **The app-side Google Health sync had the same duplicate bug — and it is the one that runs
+  nightly.** The previous entry fixed `scripts/sync-google-health.py`, but that path is only
+  reached by a manual `run-syncs.py`. The daily 14:00 cron calls `/api/cron/sync`, which runs
+  `syncGoogleHealth()` in `web/src/lib/sync/google-health.ts` — a parallel TypeScript
+  implementation carrying **both** identical defects. Its overlap check was a `.filter()` over
+  `existingList`, which structurally cannot accumulate: `dateIndex` was built once from stored
+  rows and never saw a row accepted earlier in the same pass, so same-batch duplicates all
+  survived. Its `WORKOUT_SOURCES` likewise omitted `"manual"`. Rewritten as an accumulating loop
+  that pushes each accepted row into `dateIndex`, and reads now use a matching `DEDUPE_SOURCES`.
+  Both files now carry cross-references, because the real hazard here is that a fix to one reads
+  as a fix to the system. **Anyone touching dedup must change both.**
+
 - **Google Health sync stored the same workout two and three times.** `filter_new_workouts()`
   in `scripts/sync-google-health.py` has a ±5 min same-date overlap check, and it worked —
   against rows already in the database. But `by_date` was built once from `existing` and never

--- a/web/src/lib/sync/google-health.ts
+++ b/web/src/lib/sync/google-health.ts
@@ -13,6 +13,14 @@ const SYNC_DAYS = 7;
 const WORKOUT_SOURCES = ["google_health", "fitbit"];
 const BODY_SOURCES = ["google_health", "fitbit_body", "google_fit"];
 
+// Rows the dedup must compare AGAINST — a superset of the ones this sync writes.
+// "manual" belongs here because a session logged by hand is the same real-world workout
+// the watch also reports; leaving it out meant a manual row could neither suppress an
+// auto-import nor be suppressed by one. One 2026-07-31 basketball game landed three
+// times that way (manual 454 kcal + two auto-imports) and was counted at 1677 kcal.
+// Mirrors DEDUPE_SOURCES in scripts/sync-google-health.py.
+const DEDUPE_SOURCES = [...WORKOUT_SOURCES, "manual"];
+
 // ---------------------------------------------------------------------------
 // Google Health v4 response shapes (only the fields this sync consumes).
 // Verified against the v4 discovery doc, rev 20260713.
@@ -368,7 +376,7 @@ export async function syncGoogleHealth(
       .from("workout_sessions")
       .select("id,date,start_time,activity,avg_hr,duration_mins,source")
       .eq("user_id", userId)
-      .in("source", WORKOUT_SOURCES);
+      .in("source", DEDUPE_SOURCES);
 
     const existingList = (existingWorkouts ?? []) as {
       id: string;
@@ -388,19 +396,48 @@ export async function syncGoogleHealth(
     // overlapping row is never replaced: the pre-existing row is the same workout
     // already stored under the old source, so re-inserting or swapping it would churn
     // history for no gain.
+    //
+    // The window is checked against previously-stored rows AND against rows already
+    // accepted in this same batch. Google Health aggregates several writers (watch,
+    // phone, connected apps) and commonly emits one activity twice per response — once
+    // from the writer holding the HR sensor, with hr_zones populated, and once as a
+    // coarse copy with hr_zones null and a wild calorie figure. Both arrive together, so
+    // neither is stored yet when the other is judged: a plain .filter() over
+    // `existingList` lets both through. The next run does suppress further copies, which
+    // is why duplicates sat as stable pairs rather than multiplying, and why this went
+    // unnoticed. Mirrors filter_new_workouts() in scripts/sync-google-health.py.
     const OVERLAP_MINS = 5;
     const dateIndex = new Map<string, typeof existingList>();
     for (const r of existingList) dateIndex.set(r.date, [...(dateIndex.get(r.date) ?? []), r]);
 
-    const toInsert = exactNew.filter((newRow) => {
+    const toInsert: typeof exactNew = [];
+    for (const newRow of exactNew) {
       const newMins = timeToMins(newRow.start_time as string | null);
-      for (const ex of dateIndex.get(newRow.date as string) ?? []) {
+      const date = newRow.date as string;
+      let overlapped = false;
+      for (const ex of dateIndex.get(date) ?? []) {
         const exMins = timeToMins(ex.start_time);
         if (newMins == null || exMins == null) continue;
-        if (Math.abs(newMins - exMins) <= OVERLAP_MINS) return false;
+        if (Math.abs(newMins - exMins) <= OVERLAP_MINS) {
+          overlapped = true;
+          break;
+        }
       }
-      return true;
-    });
+      if (overlapped) continue;
+      toInsert.push(newRow);
+      // The accepted row joins the comparison set for the rest of this batch.
+      dateIndex.set(date, [
+        ...(dateIndex.get(date) ?? []),
+        {
+          id: "",
+          date,
+          start_time: newRow.start_time as string | null,
+          activity: newRow.activity as string,
+          avg_hr: null,
+          duration_mins: null,
+        },
+      ]);
+    }
 
     const newWorkouts = toInsert.map(({ _key, ...rest }) => ({ ...rest, user_id: userId }));
     if (newWorkouts.length) {


### PR DESCRIPTION
## Why this exists

#656 fixed `scripts/sync-google-health.py`. **That was half the job.**

That path is only reached by a manual `run-syncs.py`. The **daily 14:00 cron** on compute-core calls `/api/cron/sync`, which runs `syncGoogleHealth()` in `web/src/lib/sync/google-health.ts` — a parallel TypeScript implementation carrying **both** of the same defects. The nightly sync was still producing duplicates after #656 merged.

## The two defects, in the TS copy

**1. The overlap check structurally could not accumulate.**

```ts
const dateIndex = new Map<string, typeof existingList>();
for (const r of existingList) dateIndex.set(r.date, [...]);   // stored rows only

const toInsert = exactNew.filter((newRow) => { ... });         // .filter() cannot push
```

`dateIndex` was built once and never saw a row accepted earlier in the same pass, so every same-batch duplicate survived. Rewritten as an explicit loop that pushes each accepted row into `dateIndex`.

**2. `WORKOUT_SOURCES` omitted `"manual"`**, so a hand-logged session could neither suppress an auto-import nor be suppressed by one. Reads now use `DEDUPE_SOURCES`, matching the Python side.

## Verification

`prettier --check`, `tsc --noEmit`, and `eslint` all clean. Pre-commit token guards passed.

No unit test here: the Python side is covered by `tests/test_google_health_dedupe.py` (which fails on pre-fix code), and this file has no existing test harness — `syncGoogleHealth()` takes a live Supabase client and does network I/O, so testing it properly means a fixture layer that does not exist yet. Worth building; out of scope for a fix that should ship tonight.

## The real lesson

Two implementations of one dedup rule drifted apart silently, and fixing one read as fixing the system. Both files now cross-reference each other by name, and both changelog entries say so. **Anyone touching dedup must change both.**

Consolidating them behind one implementation is the durable answer and is not attempted here.
