### PR TITLE
fix(run-syncs): correct the app URL default and unwrap the response envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **`run-syncs.py`: wrong app URL fallback, and a summary that printed one useless line.**
+  Two defects shipped in #658 and caught by running it end-to-end on compute-core.
+  (1) It resolved the app as `INTERNAL_APP_URL or APP_URL`. `INTERNAL_APP_URL` is exported in
+  the shell but is **not in `.env`**, and `APP_URL` is the public vhost
+  (`mr-bridge.jl-infra-lab.com`), which resolves to Surface's tailnet address and is
+  **unreachable from compute-core** — confirmed, the request returns nothing. So a missing
+  export would have turned into a confusing network failure rather than working. It now
+  defaults to `http://127.0.0.1:3000`, which is correct by construction since the script runs
+  on the app's own host, with `INTERNAL_APP_URL` as the only override and no `APP_URL` fallback.
+  (2) The endpoint answers `{"success": true, "results": {...}}`, but `_summarize()` was handed
+  the envelope, so every source collapsed into a single `results: ok {…}` line instead of one
+  line per source. It now reads the nested object and fails loudly on an unexpected shape.
+
 ### Changed
 
 - **One sync implementation instead of two.** `scripts/sync-google-health.py` (458 lines) and

--- a/scripts/run-syncs.py
+++ b/scripts/run-syncs.py
@@ -56,11 +56,16 @@ ALERTS: list[list[str]] = [
 ]
 
 
+# run-syncs.py runs on the same host as the app container, so loopback is the correct
+# default and needs no configuration. Deliberately NO fallback to APP_URL: that is the
+# public vhost (mr-bridge.jl-infra-lab.com), which resolves to Surface's tailnet address
+# and is unreachable from compute-core — verified, it returns nothing. Falling back to it
+# would turn a missing env var into a confusing network error instead of just working.
+DEFAULT_APP_URL = "http://127.0.0.1:3000"
+
+
 def _app_url() -> str:
-    url = os.environ.get("INTERNAL_APP_URL") or os.environ.get("APP_URL")
-    if not url:
-        sys.exit("[run-syncs] INTERNAL_APP_URL (or APP_URL) is not set in .env")
-    return url.rstrip("/")
+    return (os.environ.get("INTERNAL_APP_URL") or DEFAULT_APP_URL).rstrip("/")
 
 
 def _summarize(results: dict) -> None:
@@ -119,7 +124,16 @@ def run_syncs(days: int | None, force: bool) -> int:
         print("    docker compose -f ~/docker/mr-bridge/docker-compose.yml up -d mr-bridge", file=sys.stderr)
         return 1
 
-    _summarize({k: v for k, v in payload.items() if k != "ok"})
+    # The endpoint answers {"success": true, "results": {<source>: {...}}} — read the
+    # nested object, not the envelope, or every source collapses into one "results" line.
+    if not payload.get("success", True):
+        print(f"[run-syncs] endpoint reported failure: {payload}", file=sys.stderr)
+        return 1
+    results = payload.get("results")
+    if not isinstance(results, dict):
+        print(f"[run-syncs] unexpected response shape: {payload}", file=sys.stderr)
+        return 1
+    _summarize(results)
     return 0
 
 


### PR DESCRIPTION
## What

Two defects shipped in #658. Both were caught by **running the script end-to-end on compute-core** rather than trusting that green CI meant it worked — CI never executes `run-syncs.py` against a live app.

## 1. Wrong app-URL fallback (latent failure)

It resolved the app as `INTERNAL_APP_URL or APP_URL`. On compute-core:

- `INTERNAL_APP_URL` is **exported in the shell but is not in `.env`**
- `APP_URL` is `https://mr-bridge.jl-infra-lab.com` — the public vhost, which resolves to Surface's *tailnet* address and is **unreachable from compute-core**. Verified: `curl` returns HTTP 000.

So the fallback path could never have worked, and the failure would have surfaced as a confusing network error rather than a missing-config message. This is the cross-node vhost trap the homelab's own guidance warns about.

Now defaults to `http://127.0.0.1:3000` — correct by construction, since `run-syncs.py` runs on the app's own host — with `INTERNAL_APP_URL` as the only override and **no `APP_URL` fallback**.

## 2. The summary printed one useless line

The endpoint answers `{"success": true, "results": {<source>: {...}}}`, but `_summarize()` was handed the envelope. Observed output:

```
[run-syncs] success: True
[run-syncs] results: ok  {'oura': {...}, 'googleHealth': {...}, 'stocks': {...}, ...}
```

All five sources collapsed into one line — which defeats the point, since this output is what a session-start briefing reads to know whether a source failed. It now reads the nested object and fails loudly on an unexpected shape instead of degrading into a dict dump.

## Verification

Re-tested end-to-end on compute-core after deploy — see the PR thread.
