### PR TITLE
docs: sweep drift left by the sync consolidation (#658)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Documentation
+
+- **Swept the docs for drift left by #658.** Deleting the two Python syncs invalidated
+  statements scattered well outside the files that changed: `README.md` still described the
+  test workflow as "stdlib-only unittest run over `tests/`" (it now runs node too, and
+  `web/src/__tests__` is CI-enforced for the first time) and referred to "the sync scripts"
+  falling back to `OURA_ACCESS_TOKEN`; `docs/ARCHITECTURE.md` justified `sync_log`'s missing
+  RLS policy partly on "Python scripts" that no longer exist; `docs/fitness-tracker-setup.md`
+  described the Google Health sync as having "replaced `sync-fitbit.py` and `sync-googlefit.py`",
+  naming a script that is itself now gone. Historical references inside CHANGELOG entries and
+  the deliberate "why this is a thin client" comments in `run-syncs.py` / `workout-dedupe.ts`
+  are left intact — those are the record of why, not stale instructions.
+
 ### Fixed
 
 - **`run-syncs.py`: wrong app URL fallback, and a summary that printed one useless line.**

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Skip any integrations you don't use. The app works with none, one, or all of the
 **Oura Ring:**
 1. Go to [cloud.ouraring.com/personal-access-tokens](https://cloud.ouraring.com/personal-access-tokens) and create a Personal Access Token.
 2. In your running app, go to **Settings → Integrations → Connect Oura** and paste the token. It is stored encrypted in `user_integrations`.
-3. *(Migration fallback)* If you set `OURA_ACCESS_TOKEN` in `.env` before connecting via Settings, the sync scripts will fall back to it until you connect via UI.
+3. *(Migration fallback)* If you set `OURA_ACCESS_TOKEN` in `.env` before connecting via Settings, the sync will fall back to it until you connect via UI.
 
 **Google Health** *(replaces Fitbit and Google Fit — see [#607](https://github.com/Theioz/mr-bridge-assistant/issues/607))*:
 1. Enable the [Google Health API](https://console.cloud.google.com/apis/library/health.googleapis.com) on the **same** Google Cloud project from Step 4.
@@ -573,7 +573,7 @@ mr-bridge-assistant/
 │       ├── weekly-review-nudge.yml        # Sunday 8pm ntfy.sh push (runs in cloud)
 │       ├── lint.yml                       # Token guards, eslint + prettier, typecheck, depcheck
 │       ├── smoke.yml                      # Playwright a11y + perf smokes
-│       └── python-tests.yml               # stdlib-only unittest run over tests/
+│       └── python-tests.yml               # "Unit tests": python (tests/) + node (web/src/__tests__)
 │
 ├── docs/
 │   ├── notifications-setup.md             # Android, macOS, Windows ntfy setup guide
@@ -598,6 +598,8 @@ mr-bridge-assistant/
 │
 ├── tests/                                 # Python unit tests (stdlib unittest, no deps)
 │   └── test_weekly_plan_supersets.py      # Superset-metadata validator
+│                                          # TS unit tests live in web/src/__tests__/ and
+│                                          # run in the same workflow (node --test, no deps)
 │
 └── voice/                                 # Jarvis mode (voice interface)
     ├── bridge_voice.py                    # Wake word → STT → Claude API → TTS

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -133,7 +133,7 @@ This means a user's session JWT can only read or write their own rows — no cro
 
 ### Exception: `sync_log`
 
-`sync_log` has no per-user RLS policy. It is globally readable and writable by the authenticated role. Rationale: sync operations run under the service client or Python scripts and are an infrastructure concern, not user data. The table has no PII.
+`sync_log` has no per-user RLS policy. It is globally readable and writable by the authenticated role. Rationale: sync operations run under the service client and are an infrastructure concern, not user data. The table has no PII.
 
 ---
 

--- a/docs/fitness-tracker-setup.md
+++ b/docs/fitness-tracker-setup.md
@@ -8,7 +8,7 @@ Two sync scripts pull data from fitness APIs and write directly to Supabase. Run
 
 **Implementation:** `web/src/lib/sync/google-health.ts`, reached via `/api/cron/sync`.
 
-Replaced both `sync-fitbit.py` and `sync-googlefit.py` in [#607](https://github.com/Theioz/mr-bridge-assistant/issues/607). The Fitbit Web API is turned down **September 2026** and the Google Fit REST API is deprecated; the Google Health API (`health.googleapis.com/v4`) supersedes both.
+Superseded the Fitbit and Google Fit syncs in [#607](https://github.com/Theioz/mr-bridge-assistant/issues/607); the Python implementation was later deleted in [#658](https://github.com/Theioz/mr-bridge-assistant/pull/658) when the duplicated sync implementations were collapsed into one. The Fitbit Web API is turned down **September 2026** and the Google Fit REST API is deprecated; the Google Health API (`health.googleapis.com/v4`) supersedes both.
 
 Writes:
 - `workout_sessions` — activity, duration, calories, average HR, and per-session heart-rate zones


### PR DESCRIPTION
## What

Deleting the two Python syncs in #658 invalidated statements **well outside the files that changed**. This sweeps them.

| File | Was | Now |
|---|---|---|
| `README.md` | `python-tests.yml` described as "stdlib-only unittest run over `tests/`" | It also runs node over `web/src/__tests__` — CI-enforced for the first time. Tree listing updated too. |
| `README.md` | "the **sync scripts** will fall back to `OURA_ACCESS_TOKEN`" | "the sync will fall back" — there is one implementation, and it is TypeScript |
| `docs/ARCHITECTURE.md` | `sync_log`'s missing RLS policy justified partly on "Python scripts" | Those scripts no longer exist; the rationale now rests on the service client alone |
| `docs/fitness-tracker-setup.md` | Google Health sync "replaced `sync-fitbit.py` and `sync-googlefit.py`" | Named a script that is itself now deleted. Reworded, with a pointer to #658. |

## Deliberately left alone

- **Historical CHANGELOG entries** naming the deleted scripts. Those are the record of what happened, not instructions.
- The **"why this is a thin client"** comments in `scripts/run-syncs.py` and `web/src/lib/sync/workout-dedupe.ts`, which name the deleted files on purpose — they exist so nobody reintroduces a second implementation without first reading why there was one.

## Verified separately

`.env.example` already documents both `CRON_SECRET` and `INTERNAL_APP_URL`, so no change was needed there. Worth noting though: `INTERNAL_APP_URL` is present in `.env.example` but **absent from the live `.env` on compute-core** — it currently only exists as an exported shell variable. #659 made that harmless by defaulting to `http://127.0.0.1:3000`, but `scripts/weekly_plan.py` also reads it, so the live file is still worth reconciling.
