### PR TITLE
docs: second drift pass after the sync consolidation

### DIFF
--- a/.claude/rules/briefing.md
+++ b/.claude/rules/briefing.md
@@ -7,7 +7,10 @@ Execute in this exact order:
    ```bash
    python3 scripts/run-syncs.py
    ```
-   This runs both sync scripts (oura, google_health) in parallel and skips any source synced within the last 30 minutes.
+   Since #658 this is a thin client of the app's `/api/cron/sync` — the same endpoint the nightly
+   cron uses — so it refreshes Oura, Google Health, stocks, sports and packages in one call and
+   skips any source synced within the last 30 minutes. It therefore **requires the mr-bridge
+   container to be up**. `--force` bypasses the skip window; `--days N` (1-90) backfills.
 2. Fetch all briefing data from Supabase:
    ```bash
    python3 scripts/fetch_briefing_data.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Documentation
 
+- **Second drift pass — the first one missed three, including a rule file.**
+  `.claude/rules/briefing.md` still told the session-start protocol that `run-syncs.py` "runs both
+  sync scripts (oura, google_health) in parallel". It runs neither: it is one HTTP call that
+  refreshes five sources and needs the app container up. That file is *read by Claude at session
+  start*, so a stale instruction there is worse than a stale README.
+  `docs/fitness-tracker-setup.md` opened with "Two sync scripts pull data from fitness APIs and
+  write directly to Supabase" — the entire premise of the page.
+  `docs/architecture.d2` described the sync layer as "Python scripts · TypeScript modules".
+  **`docs/architecture.svg` is generated from that `.d2` and is now stale** — it needs a `d2`
+  regeneration, which was not available in this environment.
+
+  Lesson recorded because it cost two passes: grepping for the deleted *filenames* found the
+  obvious references. The damaging ones described the behaviour in prose without naming a file.
+
+### Documentation
+
 - **Swept the docs for drift left by #658.** Deleting the two Python syncs invalidated
   statements scattered well outside the files that changed: `README.md` still described the
   test workflow as "stdlib-only unittest run over `tests/`" (it now runs node too, and

--- a/docs/architecture.d2
+++ b/docs/architecture.d2
@@ -6,7 +6,7 @@ direction: right
 
 data_sources: "Data Sources\nOura · Fitbit · Google Fit"
 
-sync: "Sync Layer\nPython scripts · TypeScript modules\nCron (daily 6am PST) · Manual routes"
+sync: "Sync Layer\nTypeScript modules (web/src/lib/sync)\nNightly cron · scripts/run-syncs.py"
 
 supabase: "Supabase Postgres\n18 tables · RLS enforced"
 

--- a/docs/fitness-tracker-setup.md
+++ b/docs/fitness-tracker-setup.md
@@ -1,6 +1,6 @@
 # Fitness Tracker Setup
 
-Two sync scripts pull data from fitness APIs and write directly to Supabase. Run them manually before sessions to get fresh data, or let `scripts/run-syncs.py` / `/api/cron/sync` do it.
+Both fitness integrations are synced by the app, in `web/src/lib/sync/`, and reached through the `/api/cron/sync` route. The nightly cron calls it; `scripts/run-syncs.py` calls the same endpoint for an on-demand refresh before a session. The standalone Python syncs were deleted in [#658](https://github.com/Theioz/mr-bridge-assistant/pull/658) — there is one implementation now, and it needs the app container running.
 
 ---
 


### PR DESCRIPTION
## What

A second drift pass. The first (#660) grepped for the **deleted filenames**, which caught the obvious references. It missed the damaging ones — prose describing the old behaviour without naming a file.

| File | Problem |
|---|---|
| `.claude/rules/briefing.md` | Told the session-start protocol that `run-syncs.py` "runs both sync scripts (oura, google_health) in parallel". It runs **neither** — one HTTP call, five sources, and it needs the app container up. **This file is read by Claude at session start**, so a stale instruction here is worse than a stale README. |
| `docs/fitness-tracker-setup.md` | Opened with "Two sync scripts pull data from fitness APIs and write directly to Supabase" — the entire premise of the page. |
| `docs/architecture.d2` | Sync layer described as "Python scripts · TypeScript modules". |

## Known-stale, flagged not hidden

**`docs/architecture.svg` is generated from `docs/architecture.d2` and is now out of date.** No `d2` binary was available in this environment to regenerate it. Regenerate with `d2 docs/architecture.d2 docs/architecture.svg`.

## Separate finding — not fixed here

`scripts/weekly_plan.py:49` resolves `INTERNAL_APP_URL or APP_URL` — the **same fallback flaw** #659 fixed in `run-syncs.py`. On compute-core `INTERNAL_APP_URL` is absent from the live `.env` (it exists only as an exported shell variable) and `APP_URL` is the public vhost, which is **unreachable from that host**. So `weekly_plan.py` works interactively and would fail from cron or any shell without that export.

The cleanest fix is config, not code: add `INTERNAL_APP_URL=http://127.0.0.1:3000` to the live `.env`, which `.env.example` already documents. Left out of this PR because it is a live-host change, not a repo change.
