### PR TITLE
feat: journal is one free-write surface with contextual suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- **Journal is now a single free-write surface with contextual suggestions.** The editor had two
+  inner tabs — "Reflect" (five fixed questions, each its own textarea) and "Free Write" — and
+  defaulted to Reflect on every open, with a `0 / 5` progress-dot row that filled in as questions
+  were answered. That framed journalling as a form with a completion state, and the entries show
+  what it produced: five of the six entries on record answer the prompts dutifully and briefly
+  ("Honestly not too sure", "Don't really feel gratitude for anything today"), while the single
+  entry that used Free Write is the only one with anything real in it. Removed the tabs, the five
+  `PROMPTS` fields and the progress dots; the page is now one textarea.
+
+  In their place, `web/src/lib/journal/prompts.ts` derives up to three **suggestions** from the day's
+  own data — alcohol habit rows, Oura recovery, strength sessions, habit streaks, weight swings,
+  intake vs. targets, and time since the last entry — falling back to a date-rotated evergreen pool
+  when nothing notable fires. Suggestions are tappable (they drop in as a line to write under),
+  dismissible, and never required. `buildJournalPrompts` is a pure function taking `today` on its
+  context object, so it can be exercised directly against real rows.
+
+  Deterministic rules, no model — same posture as the workout planner and the nutrition pipeline.
+  The `responses` column and its history rendering are retained so the six existing entries still
+  display, and the editor passes `initialResponses` back through the save untouched, so editing a
+  pre-2026-08 entry doesn't erase the answers it was written against. Prompts are suppressed when
+  back-dating an entry, since they describe today.
+
+### Fixed
+
+- **Grease-the-groove sessions were being classified as lifts.** Session classification tested that
+  *every* exercise name contained `grease-the-groove`, but a GtG session also carries accessory
+  movements with no such suffix (`Negative Pull-Up`, `Dead Hang`) — so real GtG sessions on 8/04,
+  8/05, 8/06 and 8/07 all failed the test and read as lifting sessions. GtG is walk work and never
+  appears inside a lift, so the correct test is *any*. Caught by running the new prompt engine
+  against live rows, where it produced a "you trained today" suggestion on a pull-up-only day. Same
+  class of bug as the GtG mis-scoring fixed in #650.
 ### Documentation
 
 - **`docs/architecture.svg` regenerated.** It is generated from `docs/architecture.d2`, which

--- a/web/src/__tests__/journal-prompts.test.ts
+++ b/web/src/__tests__/journal-prompts.test.ts
@@ -1,0 +1,260 @@
+// Unit tests for the contextual journal prompt engine (lib/journal/prompts.ts).
+// Run with: node --experimental-strip-types --test src/__tests__/journal-prompts.test.ts
+// (from the web/ directory)
+//
+// WHY THIS EXISTS
+//
+// The journal used to be five fixed questions. It is now one free-write box with up to three
+// suggestions derived from the day's own data — so the suggestions ARE the feature, and a wrong
+// one is worse than none: it tells the user something untrue about their own day before they've
+// written a word. "You trained today" on a day they didn't train is not a cosmetic bug.
+//
+// That exact failure shipped once already and was caught only by running the engine against live
+// rows. Session classification asked whether EVERY exercise name contained "grease-the-groove".
+// A GtG walk logs this:
+//
+//   Pull-ups (grease-the-groove) | Chin-ups (grease-the-groove) | Negative Pull-Up | Dead Hang
+//
+// Two of the four carry no suffix, so `every` returned false and four consecutive pull-up-only
+// days (8/04 through 8/07) were classified as lifting sessions. GtG is deliberately kept OUT of
+// lifting sessions, so `any` is both correct and sufficient. The first test below pins that.
+//
+// The alcohol rules get the most coverage because they are the highest-stakes: they are the ones
+// that can address a real problem, and also the ones that would be most alienating if they fired
+// wrongly. The ordering rule that matters is that an unlogged day must NOT be read as a dry day.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildJournalPrompts,
+  isGreaseTheGrooveSession,
+  MAX_PROMPTS,
+  type JournalPromptContext,
+} from "../lib/journal/prompts.ts";
+
+const EMPTY: JournalPromptContext = {
+  today: "2026-08-07",
+  alcohol: [],
+  intake: [],
+  recovery: [],
+  strength: [],
+  weights: [],
+  habits: [],
+  lastEntryDate: null,
+  calorieGoal: 1800,
+  proteinGoal: 150,
+};
+
+const ctx = (over: Partial<JournalPromptContext> = {}): JournalPromptContext => ({
+  ...EMPTY,
+  ...over,
+});
+
+const ids = (c: JournalPromptContext) => buildJournalPrompts(c).map((p) => p.id);
+
+// --- session classification — the bug that shipped --------------------------
+
+test("a GtG session is recognised despite unsuffixed accessory movements", () => {
+  assert.equal(
+    isGreaseTheGrooveSession([
+      "Pull-ups (grease-the-groove)",
+      "Chin-ups (grease-the-groove)",
+      "Negative Pull-Up",
+      "Dead Hang",
+    ]),
+    true,
+  );
+});
+
+test("a lifting session is not mistaken for GtG", () => {
+  assert.equal(
+    isGreaseTheGrooveSession(["DB Goblet Squat", "Plank", "DB Chest Press (floor)"]),
+    false,
+  );
+});
+
+test("a session with no sets logged is not GtG", () => {
+  assert.equal(isGreaseTheGrooveSession([]), false);
+});
+
+test("a GtG day does not produce a training prompt", () => {
+  const c = ctx({
+    strength: [{ performed_on: "2026-08-07", perceived_effort: null, isGreaseTheGroove: true }],
+  });
+  assert.ok(!ids(c).some((id) => id.startsWith("training-")));
+});
+
+test("a real lift does produce a training prompt, and hard sessions rank higher", () => {
+  const easy = ctx({
+    strength: [{ performed_on: "2026-08-07", perceived_effort: 6, isGreaseTheGroove: false }],
+  });
+  const hard = ctx({
+    strength: [{ performed_on: "2026-08-07", perceived_effort: 9, isGreaseTheGroove: false }],
+  });
+  assert.ok(ids(easy).includes("training-session"));
+  assert.ok(ids(hard).includes("training-hard-session"));
+});
+
+// --- alcohol ---------------------------------------------------------------
+
+test("drinking today outranks everything else", () => {
+  const c = ctx({
+    alcohol: [{ date: "2026-08-07", completed: false }],
+    strength: [{ performed_on: "2026-08-07", perceived_effort: 9, isGreaseTheGroove: false }],
+  });
+  assert.equal(buildJournalPrompts(c)[0].id, "alcohol-today");
+});
+
+test("dry today after a drinking day asks what was different", () => {
+  const c = ctx({
+    alcohol: [
+      { date: "2026-08-06", completed: false },
+      { date: "2026-08-07", completed: true },
+    ],
+  });
+  assert.ok(ids(c).includes("alcohol-dry-after-heavy"));
+});
+
+test("an unlogged today is NOT treated as a dry day", () => {
+  // The habit is marked when the day is called, which is usually after journalling.
+  // Claiming "today was dry" off a missing row would be asserting something unknown.
+  const c = ctx({ alcohol: [{ date: "2026-08-06", completed: false }] });
+  const got = ids(c);
+  assert.ok(got.includes("alcohol-yesterday-only"));
+  assert.ok(!got.includes("alcohol-dry-after-heavy"));
+});
+
+test("a dry run of three or more is counted and named", () => {
+  const c = ctx({
+    alcohol: [
+      { date: "2026-08-05", completed: true },
+      { date: "2026-08-06", completed: true },
+      { date: "2026-08-07", completed: true },
+    ],
+  });
+  const prompt = buildJournalPrompts(c).find((p) => p.id === "alcohol-dry-run");
+  assert.ok(prompt, "expected a dry-run prompt");
+  assert.match(prompt.text, /^3 dry days/);
+});
+
+test("a one-day dry run is not worth remarking on", () => {
+  const c = ctx({ alcohol: [{ date: "2026-08-07", completed: true }] });
+  assert.ok(!ids(c).includes("alcohol-dry-run"));
+});
+
+// --- habit streaks ---------------------------------------------------------
+
+test("a broken streak fires only when a real streak was running", () => {
+  const rows = (dates: [string, boolean][]) =>
+    dates.map(([date, completed]) => ({ name: "Floss", date, completed }));
+
+  const broke = ctx({
+    habits: rows([
+      ["2026-08-02", true],
+      ["2026-08-03", true],
+      ["2026-08-04", true],
+      ["2026-08-05", true],
+      ["2026-08-06", false],
+    ]),
+  });
+  const prompt = buildJournalPrompts(broke).find((p) => p.id === "habit-streak-Floss");
+  assert.ok(prompt, "expected a streak-break prompt");
+  assert.match(prompt.text, /4-day streak/);
+
+  const neverKept = ctx({
+    habits: rows([
+      ["2026-08-05", true],
+      ["2026-08-06", false],
+    ]),
+  });
+  assert.ok(!ids(neverKept).includes("habit-streak-Floss"));
+});
+
+// --- recovery and weight ---------------------------------------------------
+
+test("an HRV collapse is reported against the recent baseline", () => {
+  const c = ctx({
+    recovery: [
+      { date: "2026-08-03", readiness: 80, avg_hrv: 70, resting_hr: 54, total_sleep_hrs: 8 },
+      { date: "2026-08-04", readiness: 80, avg_hrv: 70, resting_hr: 54, total_sleep_hrs: 8 },
+      { date: "2026-08-07", readiness: 60, avg_hrv: 22, resting_hr: 69, total_sleep_hrs: 7 },
+    ],
+  });
+  assert.ok(ids(c).includes("recovery-hrv-down"));
+});
+
+test("a fast weight swing is named as water, not fat", () => {
+  const c = ctx({
+    weights: [
+      { date: "2026-08-05", weight_lb: 153.0 },
+      { date: "2026-08-07", weight_lb: 155.4 },
+    ],
+  });
+  const prompt = buildJournalPrompts(c).find((p) => p.id === "weight-swing");
+  assert.ok(prompt, "expected a weight-swing prompt");
+  assert.match(prompt.text, /water, not fat/);
+});
+
+test("a weight change under the threshold is ignored", () => {
+  const c = ctx({
+    weights: [
+      { date: "2026-08-05", weight_lb: 153.9 },
+      { date: "2026-08-07", weight_lb: 154.3 },
+    ],
+  });
+  assert.ok(!ids(c).includes("weight-swing"));
+});
+
+// --- output contract -------------------------------------------------------
+
+test("never returns more than MAX_PROMPTS, highest priority first", () => {
+  const c = ctx({
+    alcohol: [
+      { date: "2026-08-06", completed: false },
+      { date: "2026-08-07", completed: true },
+    ],
+    strength: [{ performed_on: "2026-08-07", perceived_effort: 9, isGreaseTheGroove: false }],
+    weights: [
+      { date: "2026-08-05", weight_lb: 153.0 },
+      { date: "2026-08-07", weight_lb: 155.4 },
+    ],
+    lastEntryDate: "2026-07-01",
+    recovery: [
+      { date: "2026-08-06", readiness: 93, avg_hrv: 71, resting_hr: 53, total_sleep_hrs: 11.35 },
+    ],
+  });
+  const got = buildJournalPrompts(c);
+  assert.equal(got.length, MAX_PROMPTS);
+  const priorities = got.map((p) => p.priority);
+  assert.deepEqual(
+    priorities,
+    [...priorities].sort((a, b) => b - a),
+  );
+});
+
+test("an empty context still returns a full set of evergreen prompts", () => {
+  const got = buildJournalPrompts(EMPTY);
+  assert.equal(got.length, MAX_PROMPTS);
+  assert.ok(got.every((p) => p.id.startsWith("evergreen-")));
+});
+
+test("evergreen prompts are stable within a day and rotate across days", () => {
+  const a = ids(ctx({ today: "2026-08-07" }));
+  assert.deepEqual(a, ids(ctx({ today: "2026-08-07" })), "same day must be stable");
+  assert.notDeepEqual(a, ids(ctx({ today: "2026-08-08" })), "next day must differ");
+});
+
+test("prompt ids are unique within a result set", () => {
+  const got = ids(
+    ctx({
+      alcohol: [{ date: "2026-08-07", completed: false }],
+      habits: [
+        { name: "Floss", date: "2026-08-03", completed: true },
+        { name: "Floss", date: "2026-08-04", completed: true },
+        { name: "Floss", date: "2026-08-05", completed: true },
+        { name: "Floss", date: "2026-08-06", completed: false },
+      ],
+    }),
+  );
+  assert.equal(new Set(got).size, got.length);
+});

--- a/web/src/app/(protected)/journal/page.tsx
+++ b/web/src/app/(protected)/journal/page.tsx
@@ -10,7 +10,12 @@ export const metadata: Metadata = {
   description: "Guided journal entries and history.",
 };
 import type { JournalEntry, JournalResponses } from "@/lib/types";
-import { todayString } from "@/lib/timezone";
+import { todayString, daysAgoString } from "@/lib/timezone";
+import {
+  buildJournalPrompts,
+  isGreaseTheGrooveSession,
+  type JournalPromptContext,
+} from "@/lib/journal/prompts";
 
 async function saveJournalEntry(
   date: string,
@@ -37,6 +42,93 @@ async function saveJournalEntry(
   return {};
 }
 
+/**
+ * Gathers the day's signals and turns them into free-write suggestions.
+ *
+ * Every query is RLS-scoped and best-effort: a failed or empty source narrows the
+ * rule set rather than breaking the page, and `buildJournalPrompts` always returns
+ * evergreen prompts when nothing notable fires.
+ */
+async function loadPrompts(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  today: string,
+  lastEntryDate: string | null,
+) {
+  const since = daysAgoString(21);
+
+  const [habitRows, registryRows, mealRows, recoveryRows, strengthRows, weightRows, profileRows] =
+    await Promise.all([
+      supabase.from("habits").select("habit_id,date,completed").gte("date", since),
+      // Retired habits keep their rows but must not drive suggestions.
+      supabase.from("habit_registry").select("id,name").eq("active", true),
+      supabase.from("meal_log").select("date,calories,protein_g").gte("date", since),
+      supabase
+        .from("recovery_metrics")
+        .select("date,readiness,avg_hrv,resting_hr,total_sleep_hrs")
+        .gte("date", since)
+        .gt("total_sleep_hrs", 0)
+        .order("date", { ascending: true }),
+      supabase
+        .from("strength_sessions")
+        .select("performed_on,perceived_effort,strength_session_sets(exercise_name)")
+        .gte("performed_on", since),
+      supabase.from("fitness_log").select("date,weight_lb").gte("date", since),
+      supabase.from("profile").select("key,value").in("key", ["calorie_goal", "protein_goal"]),
+    ]);
+
+  const nameById = new Map<string, string>(
+    (registryRows.data ?? []).map((r) => [r.id as string, r.name as string]),
+  );
+  const named = (habitRows.data ?? []).map((h) => ({
+    name: nameById.get(h.habit_id as string) ?? "",
+    date: h.date as string,
+    completed: !!h.completed,
+  }));
+
+  // Intake arrives one row per component; the rules want one row per day.
+  const intakeByDate = new Map<string, { date: string; calories: number; protein_g: number }>();
+  for (const m of mealRows.data ?? []) {
+    const day = intakeByDate.get(m.date as string) ?? {
+      date: m.date as string,
+      calories: 0,
+      protein_g: 0,
+    };
+    day.calories += (m.calories as number) ?? 0;
+    day.protein_g += (m.protein_g as number) ?? 0;
+    intakeByDate.set(day.date, day);
+  }
+
+  const goal = (key: string): number | null => {
+    const raw = (profileRows.data ?? []).find((p) => p.key === key)?.value;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  };
+
+  const ctx: JournalPromptContext = {
+    today,
+    alcohol: named.filter((h) => h.name === "No Alcohol"),
+    habits: named.filter((h) => h.name && h.name !== "No Alcohol"),
+    intake: [...intakeByDate.values()],
+    recovery: (recoveryRows.data ?? []) as JournalPromptContext["recovery"],
+    strength: (strengthRows.data ?? []).map((s) => {
+      const sets = (s.strength_session_sets ?? []) as { exercise_name: string }[];
+      return {
+        performed_on: s.performed_on as string,
+        perceived_effort: (s.perceived_effort as number | null) ?? null,
+        isGreaseTheGroove: isGreaseTheGrooveSession(sets.map((set) => set.exercise_name)),
+      };
+    }),
+    weights: (weightRows.data ?? [])
+      .filter((w) => w.weight_lb != null)
+      .map((w) => ({ date: w.date as string, weight_lb: w.weight_lb as number })),
+    lastEntryDate,
+    calorieGoal: goal("calorie_goal"),
+    proteinGoal: goal("protein_goal"),
+  };
+
+  return buildJournalPrompts(ctx);
+}
+
 export default async function JournalPage() {
   const supabase = await createClient();
   const today = todayString();
@@ -48,6 +140,8 @@ export default async function JournalPage() {
 
   const todayEntry = todayResult.data as JournalEntry | null;
   const allEntries = (allResult.data ?? []) as JournalEntry[];
+  const lastEntryDate = allEntries.find((e) => e.date < today)?.date ?? null;
+  const prompts = await loadPrompts(supabase, today, lastEntryDate);
 
   const dateLabel = new Date(today + "T00:00:00").toLocaleDateString("en-US", {
     weekday: "long",
@@ -86,6 +180,7 @@ export default async function JournalPage() {
         initialResponses={todayEntry?.responses ?? {}}
         initialFreeWrite={todayEntry?.free_write ?? ""}
         allEntries={allEntries}
+        prompts={prompts}
         saveAction={saveJournalEntry}
       />
     </div>

--- a/web/src/components/journal/journal-editor.tsx
+++ b/web/src/components/journal/journal-editor.tsx
@@ -2,46 +2,20 @@
 
 import { useState, useTransition, useRef, useEffect, useCallback } from "react";
 import type { JournalResponses } from "@/lib/types";
+import type { JournalPrompt } from "@/lib/journal/prompts";
 
-const PROMPTS: {
-  slug: keyof JournalResponses;
-  question: string;
-  placeholder: string;
-}[] = [
-  {
-    slug: "best_moment",
-    question: "Best moment",
-    placeholder: "A win, interaction, or memory that stood out...",
-  },
-  {
-    slug: "challenge",
-    question: "Biggest challenge",
-    placeholder: "What was hard — and how did you handle it...",
-  },
-  {
-    slug: "small_gratitude",
-    question: "Small gratitude",
-    placeholder: "Something simple you might usually overlook...",
-  },
-  {
-    slug: "energy_check",
-    question: "Energy & drain",
-    placeholder: "What gave you energy / what drained you...",
-  },
-  {
-    slug: "tomorrow_focus",
-    question: "Tomorrow's focus",
-    placeholder: "One clear intention for tomorrow...",
-  },
-];
-
-type Tab = "reflect" | "freewrite";
 type SaveStatus = "idle" | "saving" | "saved";
 
 interface Props {
   date: string;
+  /**
+   * Legacy sectioned answers. Nothing writes these any more — they are carried
+   * through the save untouched so editing a pre-2026-08 entry doesn't erase the
+   * prompts it was originally written against.
+   */
   initialResponses: JournalResponses;
   initialFreeWrite: string;
+  prompts: JournalPrompt[];
   saveAction: (
     date: string,
     responses: JournalResponses,
@@ -54,55 +28,66 @@ export default function JournalEditor({
   date,
   initialResponses,
   initialFreeWrite,
+  prompts,
   saveAction,
   onSubmit,
 }: Props) {
-  const [tab, setTab] = useState<Tab>("reflect");
-  const [responses, setResponses] = useState<JournalResponses>(initialResponses);
   const [freeWrite, setFreeWrite] = useState(initialFreeWrite);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
+  const [showPrompts, setShowPrompts] = useState(true);
   const [, startTransition] = useTransition();
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const filledCount = PROMPTS.filter((p) => responses[p.slug]?.trim()).length;
   const wordCount = freeWrite.trim().split(/\s+/).filter(Boolean).length;
-  const isEmpty = Object.values(responses).every((v) => !v?.trim()) && !freeWrite.trim();
+  const isEmpty = !freeWrite.trim();
 
   const triggerSave = useCallback(
-    (r: JournalResponses, fw: string) => {
+    (fw: string) => {
       startTransition(async () => {
         setSaveStatus("saving");
-        await saveAction(date, r, fw);
+        await saveAction(date, initialResponses, fw);
         setSaveStatus("saved");
         setTimeout(() => setSaveStatus("idle"), 2000);
       });
     },
-    [date, saveAction],
+    [date, initialResponses, saveAction],
   );
 
-  function scheduleAutoSave(r: JournalResponses, fw: string) {
+  function scheduleAutoSave(fw: string) {
     if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => triggerSave(r, fw), 1500);
-  }
-
-  function handleResponseChange(slug: keyof JournalResponses, value: string) {
-    const next = { ...responses, [slug]: value };
-    setResponses(next);
-    scheduleAutoSave(next, freeWrite);
+    debounceRef.current = setTimeout(() => triggerSave(fw), 1500);
   }
 
   function handleFreeWriteChange(value: string) {
     setFreeWrite(value);
-    scheduleAutoSave(responses, value);
+    scheduleAutoSave(value);
+  }
+
+  /**
+   * A tapped prompt is dropped in as a line to write under, not as a field.
+   * The caret lands after it so typing continues straight into the answer.
+   */
+  function insertPrompt(text: string) {
+    const trimmed = freeWrite.replace(/\s+$/, "");
+    const next = trimmed ? `${trimmed}\n\n${text}\n` : `${text}\n`;
+    setFreeWrite(next);
+    scheduleAutoSave(next);
+    requestAnimationFrame(() => {
+      const el = textareaRef.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(next.length, next.length);
+      el.scrollTop = el.scrollHeight;
+    });
   }
 
   async function handleSubmit() {
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = null;
     setSaveStatus("saving");
-    await saveAction(date, responses, freeWrite);
+    await saveAction(date, initialResponses, freeWrite);
     setSaveStatus("saved");
-    setResponses({});
     setFreeWrite("");
     onSubmit?.();
   }
@@ -116,64 +101,18 @@ export default function JournalEditor({
 
   return (
     <div data-print-flat="">
-      {/* Inner tab bar — hairline rule with amber underline on active; save status on the right */}
+      {/* Save status — sits alone now that the mode tabs are gone */}
       <div
         className="flex print:hidden"
         style={{
-          alignItems: "flex-end",
-          justifyContent: "space-between",
-          borderBottom: "1px solid var(--rule-soft)",
-          marginBottom: "var(--space-5)",
+          justifyContent: "flex-end",
+          minHeight: 20,
+          marginBottom: "var(--space-3)",
         }}
       >
-        <div
-          role="tablist"
-          aria-label="Journal mode"
-          style={{ display: "flex", gap: "var(--space-5)" }}
-        >
-          {(
-            [
-              ["reflect", "Reflect"],
-              ["freewrite", "Free Write"],
-            ] as [Tab, string][]
-          ).map(([t, label]) => {
-            const isActive = tab === t;
-            return (
-              <button
-                key={t}
-                role="tab"
-                aria-selected={isActive}
-                onClick={() => setTab(t)}
-                className="transition-colors"
-                style={{
-                  minHeight: 44,
-                  padding: "var(--space-2) var(--space-1)",
-                  fontFamily: "var(--font-display), system-ui, sans-serif",
-                  fontSize: "var(--t-micro)",
-                  fontWeight: 600,
-                  letterSpacing: "0.12em",
-                  textTransform: "uppercase",
-                  color: isActive ? "var(--accent-text)" : "var(--color-text-faint)",
-                  background: "transparent",
-                  border: "none",
-                  borderBottom: isActive ? "2px solid var(--accent)" : "2px solid transparent",
-                  marginBottom: -1,
-                  transitionDuration: "var(--motion-fast)",
-                  transitionTimingFunction: "var(--ease-out-quart)",
-                  cursor: "pointer",
-                }}
-              >
-                {label}
-              </button>
-            );
-          })}
-        </div>
-
-        {/* Save status */}
         <span
           className="tnum transition-opacity"
           style={{
-            paddingBottom: "var(--space-2)",
             fontSize: "var(--t-micro)",
             letterSpacing: "0.04em",
             color: saveStatus === "saved" ? "var(--color-positive)" : "var(--color-text-faint)",
@@ -186,97 +125,123 @@ export default function JournalEditor({
         </span>
       </div>
 
-      {/* Reflect tab */}
-      {tab === "reflect" && (
-        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-6)" }}>
-          {/* Progress row — accent dots + tabular count */}
+      {/* Suggestions — inspiration, not fields. Dismissible, never required. */}
+      {showPrompts && prompts.length > 0 && (
+        <div
+          className="print:hidden"
+          style={{
+            marginBottom: "var(--space-5)",
+            paddingBottom: "var(--space-4)",
+            borderBottom: "1px solid var(--rule-soft)",
+          }}
+        >
           <div
-            className="flex print:hidden"
-            style={{ alignItems: "center", gap: "var(--space-2)" }}
+            className="flex"
+            style={{
+              alignItems: "baseline",
+              justifyContent: "space-between",
+              marginBottom: "var(--space-3)",
+            }}
           >
-            {PROMPTS.map((p) => (
-              <span
-                key={p.slug}
-                className="transition-colors"
+            <span className="db-section-label" style={{ color: "var(--color-text-muted)" }}>
+              Could write about
+            </span>
+            <button
+              type="button"
+              onClick={() => setShowPrompts(false)}
+              className="hover-text-brighten transition-colors"
+              style={{
+                fontSize: "var(--t-micro)",
+                color: "var(--color-text-faint)",
+                background: "transparent",
+                border: "none",
+                padding: "var(--space-1)",
+                cursor: "pointer",
+                transitionDuration: "var(--motion-fast)",
+                transitionTimingFunction: "var(--ease-out-quart)",
+              }}
+            >
+              Hide
+            </button>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            {prompts.map((p) => (
+              <button
+                key={p.id}
+                type="button"
+                onClick={() => insertPrompt(p.text)}
+                className="hover-text-brighten transition-colors"
                 style={{
-                  width: 6,
-                  height: 6,
-                  borderRadius: "9999px",
-                  background: responses[p.slug]?.trim() ? "var(--accent)" : "var(--rule)",
+                  minHeight: 44,
+                  display: "flex",
+                  alignItems: "center",
+                  textAlign: "left",
+                  padding: "var(--space-2) var(--space-3)",
+                  borderRadius: "var(--r-2)",
+                  border: "1px solid var(--rule-soft)",
+                  background: "transparent",
+                  color: "var(--color-text-muted)",
+                  fontSize: "var(--t-meta)",
+                  lineHeight: 1.45,
+                  cursor: "pointer",
                   transitionDuration: "var(--motion-fast)",
                   transitionTimingFunction: "var(--ease-out-quart)",
                 }}
-              />
-            ))}
-            <span
-              className="tnum"
-              style={{
-                marginLeft: "var(--space-2)",
-                fontSize: "var(--t-micro)",
-                color: "var(--color-text-muted)",
-              }}
-            >
-              {filledCount} / {PROMPTS.length}
-            </span>
-          </div>
-
-          {/* Prompts — each as a quiet section header + flat textarea; hairlines between */}
-          {PROMPTS.map((p, i) => (
-            <div
-              key={p.slug}
-              style={{
-                paddingTop: i > 0 ? "var(--space-5)" : 0,
-                borderTop: i > 0 ? "1px solid var(--rule-soft)" : "none",
-              }}
-            >
-              <label
-                htmlFor={`journal-${p.slug}`}
-                className="db-section-label"
-                style={{
-                  display: "block",
-                  margin: "0 0 var(--space-2)",
-                  color: "var(--color-text-muted)",
-                }}
               >
-                {p.question}
-              </label>
-              <textarea
-                id={`journal-${p.slug}`}
-                value={responses[p.slug] ?? ""}
-                onChange={(e) => handleResponseChange(p.slug, e.target.value)}
-                placeholder={p.placeholder}
-                rows={3}
-                className="journal-field"
-              />
-            </div>
-          ))}
+                {p.text}
+              </button>
+            ))}
+          </div>
         </div>
       )}
 
-      {/* Free Write tab */}
-      {tab === "freewrite" && (
-        <div>
-          <textarea
-            value={freeWrite}
-            onChange={(e) => handleFreeWriteChange(e.target.value)}
-            placeholder="Write anything on your mind — no structure, no prompts. Just you and the page."
-            rows={18}
-            className="journal-field"
-            style={{ fontSize: "var(--t-body)", lineHeight: 1.75 }}
-          />
-          <p
-            className="tnum"
+      <textarea
+        ref={textareaRef}
+        value={freeWrite}
+        onChange={(e) => handleFreeWriteChange(e.target.value)}
+        placeholder="Whatever's on your mind."
+        rows={18}
+        aria-label="Journal entry"
+        className="journal-field"
+        style={{ fontSize: "var(--t-body)", lineHeight: 1.75 }}
+      />
+
+      <div
+        className="flex print:hidden"
+        style={{
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginTop: "var(--space-2)",
+        }}
+      >
+        {!showPrompts && prompts.length > 0 ? (
+          <button
+            type="button"
+            onClick={() => setShowPrompts(true)}
+            className="hover-text-brighten transition-colors"
             style={{
-              marginTop: "var(--space-2)",
-              textAlign: "right",
               fontSize: "var(--t-micro)",
-              color: "var(--color-text-muted)",
+              color: "var(--color-text-faint)",
+              background: "transparent",
+              border: "none",
+              padding: 0,
+              cursor: "pointer",
+              transitionDuration: "var(--motion-fast)",
+              transitionTimingFunction: "var(--ease-out-quart)",
             }}
           >
-            {wordCount} {wordCount === 1 ? "word" : "words"}
-          </p>
-        </div>
-      )}
+            Show suggestions
+          </button>
+        ) : (
+          <span />
+        )}
+        <p
+          className="tnum"
+          style={{ fontSize: "var(--t-micro)", color: "var(--color-text-muted)" }}
+        >
+          {wordCount} {wordCount === 1 ? "word" : "words"}
+        </p>
+      </div>
 
       {/* Submit button — filled accent CTA, 44px min-height */}
       <div className="print:hidden" style={{ marginTop: "var(--space-6)" }}>

--- a/web/src/components/journal/journal-tabs.tsx
+++ b/web/src/components/journal/journal-tabs.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import JournalEditor from "./journal-editor";
 import JournalHistory from "./journal-history";
 import type { JournalEntry, JournalResponses } from "@/lib/types";
+import type { JournalPrompt } from "@/lib/journal/prompts";
 
 type OuterTab = "write" | "history";
 
@@ -12,6 +13,7 @@ interface Props {
   initialResponses: JournalResponses;
   initialFreeWrite: string;
   allEntries: JournalEntry[];
+  prompts: JournalPrompt[];
   saveAction: (
     date: string,
     responses: JournalResponses,
@@ -24,6 +26,7 @@ export default function JournalTabs({
   initialResponses,
   initialFreeWrite,
   allEntries,
+  prompts,
   saveAction,
 }: Props) {
   const [tab, setTab] = useState<OuterTab>("write");
@@ -138,6 +141,8 @@ export default function JournalTabs({
             date={editorDate}
             initialResponses={editorResponses}
             initialFreeWrite={editorFreeWrite}
+            /* Prompts describe today; they'd be misleading on a back-dated entry. */
+            prompts={isEditingPast ? [] : prompts}
             saveAction={saveAction}
             onSubmit={handleSubmit}
           />

--- a/web/src/lib/journal/prompts.ts
+++ b/web/src/lib/journal/prompts.ts
@@ -1,0 +1,285 @@
+/**
+ * Contextual journal prompts — deterministic, no model.
+ *
+ * The journal is a free-write surface; these are *suggestions* of what might be
+ * worth writing about today, derived from what actually happened. Same posture as
+ * the workout planner and the nutrition pipeline: rules over a model, so the same
+ * inputs always produce the same prompts and nothing is invented.
+ *
+ * `buildJournalPrompts` is pure — every input arrives on `JournalPromptContext`,
+ * including today's date, so it can be exercised directly against real rows.
+ */
+
+export interface JournalPromptContext {
+  /** YYYY-MM-DD in the user's timezone. */
+  today: string;
+  /** "No Alcohol" habit rows. `completed: true` means a dry day. */
+  alcohol: { date: string; completed: boolean }[];
+  /** Per-day intake totals, already summed across meals. */
+  intake: { date: string; calories: number; protein_g: number }[];
+  /** Oura rows, junk (total_sleep_hrs = 0) already filtered out. */
+  recovery: {
+    date: string;
+    readiness: number | null;
+    avg_hrv: number | null;
+    resting_hr: number | null;
+    total_sleep_hrs: number | null;
+  }[];
+  strength: {
+    performed_on: string;
+    perceived_effort: number | null;
+    /** True when ANY exercise is grease-the-groove — it never sits inside a lift. */
+    isGreaseTheGroove: boolean;
+  }[];
+  weights: { date: string; weight_lb: number }[];
+  /** Habits other than "No Alcohol", for streak-break detection. */
+  habits: { name: string; date: string; completed: boolean }[];
+  /** Most recent journal entry strictly before today, if any. */
+  lastEntryDate: string | null;
+  calorieGoal: number | null;
+  proteinGoal: number | null;
+}
+
+export interface JournalPrompt {
+  /** Stable rule identifier — used as a React key and for debugging. */
+  id: string;
+  text: string;
+  /** Higher wins when more rules fire than there are slots. */
+  priority: number;
+}
+
+/** How many suggestions the editor shows at once. */
+export const MAX_PROMPTS = 3;
+
+/**
+ * Shown when nothing notable fires. Rotated by date so the set is stable for a
+ * whole day rather than reshuffling on every render.
+ */
+const EVERGREEN: string[] = [
+  "What took up the most space in your head today?",
+  "What did you avoid today, and what was underneath it?",
+  "Something that went better than you expected.",
+  "What would make tomorrow feel worth it?",
+  "What are you tired of?",
+  "Who did you think about today that you didn't talk to?",
+  "What did you do today that was only for you?",
+  "What is the thing you keep not writing down?",
+];
+
+/**
+ * A session is grease-the-groove if **any** movement is GtG work.
+ *
+ * Not `every`: a GtG walk also carries accessory movements whose names have no
+ * suffix — `Negative Pull-Up`, `Dead Hang` — so requiring all of them silently
+ * reclassified real GtG sessions as lifts. GtG is deliberately kept out of
+ * lifting sessions, so a single GtG movement is sufficient evidence.
+ */
+export function isGreaseTheGrooveSession(exerciseNames: string[]): boolean {
+  return exerciseNames.some((name) => name.toLowerCase().includes("grease-the-groove"));
+}
+
+function shiftDate(date: string, days: number): string {
+  const d = new Date(date + "T00:00:00Z");
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+function daysBetween(from: string, to: string): number {
+  const a = new Date(from + "T00:00:00Z").getTime();
+  const b = new Date(to + "T00:00:00Z").getTime();
+  return Math.round((b - a) / 86_400_000);
+}
+
+function mean(values: number[]): number | null {
+  if (values.length === 0) return null;
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+/**
+ * Counts back from `before` to find the streak that was running immediately
+ * prior — used to tell a broken 5-day streak apart from a habit never kept.
+ */
+function streakEndingBefore(rows: { date: string; completed: boolean }[], before: string): number {
+  const byDate = new Map(rows.map((r) => [r.date, r.completed]));
+  let length = 0;
+  let cursor = shiftDate(before, -1);
+  while (byDate.get(cursor) === true) {
+    length += 1;
+    cursor = shiftDate(cursor, -1);
+  }
+  return length;
+}
+
+export function buildJournalPrompts(ctx: JournalPromptContext): JournalPrompt[] {
+  const { today } = ctx;
+  const yesterday = shiftDate(today, -1);
+  const out: JournalPrompt[] = [];
+
+  const alcoholByDate = new Map(ctx.alcohol.map((r) => [r.date, r.completed]));
+  const drankToday = alcoholByDate.get(today) === false;
+  const dryToday = alcoholByDate.get(today) === true;
+  const drankYesterday = alcoholByDate.get(yesterday) === false;
+
+  // --- Alcohol: the highest-signal thing this journal can ask about ----------
+  if (drankToday) {
+    out.push({
+      id: "alcohol-today",
+      text: "What was happening in the hour before the first drink?",
+      priority: 100,
+    });
+  } else if (dryToday && drankYesterday) {
+    out.push({
+      id: "alcohol-dry-after-heavy",
+      text: "Yesterday wasn't dry and today was. What was different about the afternoon?",
+      priority: 98,
+    });
+  } else if (dryToday) {
+    const dryRun = streakEndingBefore(ctx.alcohol, today) + 1;
+    if (dryRun >= 3) {
+      out.push({
+        id: "alcohol-dry-run",
+        text: `${dryRun} dry days. What's actually filling that time now?`,
+        priority: 82,
+      });
+    }
+  } else if (drankYesterday) {
+    // Today is unlogged — the habit is usually marked when the day is called,
+    // which is after journaling. Ask without asserting how today went.
+    out.push({
+      id: "alcohol-yesterday-only",
+      text: "Yesterday wasn't dry. How has today gone by comparison?",
+      priority: 90,
+    });
+  }
+
+  // --- Recovery: read HRV and RHR directly, not the readiness headline -------
+  const recoveryByDate = new Map(ctx.recovery.map((r) => [r.date, r]));
+  const latestRecovery = recoveryByDate.get(today) ?? recoveryByDate.get(yesterday) ?? null;
+  if (latestRecovery) {
+    const priorHrv = ctx.recovery
+      .filter((r) => r.date < latestRecovery.date && r.avg_hrv != null)
+      .slice(-7)
+      .map((r) => r.avg_hrv as number);
+    const baseline = mean(priorHrv);
+    if (latestRecovery.avg_hrv != null && baseline != null && baseline > 0) {
+      const ratio = latestRecovery.avg_hrv / baseline;
+      if (ratio <= 0.7) {
+        out.push({
+          id: "recovery-hrv-down",
+          text: `HRV is ${Math.round((1 - ratio) * 100)}% below your recent average. Does your body feel like the number?`,
+          priority: 76,
+        });
+      } else if (ratio >= 1.3) {
+        out.push({
+          id: "recovery-hrv-up",
+          text: "Recovery came back sharply overnight. What did you do differently yesterday?",
+          priority: 58,
+        });
+      }
+    }
+    if ((latestRecovery.total_sleep_hrs ?? 0) >= 10) {
+      out.push({
+        id: "recovery-long-sleep",
+        text: `${latestRecovery.total_sleep_hrs?.toFixed(1)} hours of sleep. Catching up, or hiding?`,
+        priority: 52,
+      });
+    }
+  }
+
+  // --- Training -------------------------------------------------------------
+  const lifted = ctx.strength.find((s) => s.performed_on === today && !s.isGreaseTheGroove);
+  if (lifted) {
+    if (lifted.perceived_effort != null && lifted.perceived_effort >= 8) {
+      out.push({
+        id: "training-hard-session",
+        text: "That session was a hard one. What did it take to finish it?",
+        priority: 72,
+      });
+    } else {
+      out.push({
+        id: "training-session",
+        text: "You trained today. How did it actually feel, past the numbers?",
+        priority: 46,
+      });
+    }
+  }
+
+  // --- Habit streaks: only interesting when something real was running -------
+  const habitNames = [...new Set(ctx.habits.map((h) => h.name))];
+  for (const name of habitNames) {
+    const rows = ctx.habits.filter((h) => h.name === name);
+    const brokeOn = rows.find((r) => r.date === yesterday && !r.completed);
+    if (!brokeOn) continue;
+    const priorStreak = streakEndingBefore(rows, yesterday);
+    if (priorStreak >= 3) {
+      out.push({
+        id: `habit-streak-${name}`,
+        text: `${name} broke a ${priorStreak}-day streak yesterday. What got in the way?`,
+        priority: 68,
+      });
+    }
+  }
+
+  // --- Weight: a swing this fast is water, and worth saying so --------------
+  const sortedWeights = [...ctx.weights].sort((a, b) => a.date.localeCompare(b.date));
+  const latestWeight = sortedWeights.at(-1);
+  if (latestWeight) {
+    const priorWindow = sortedWeights.filter(
+      (w) => w.date < latestWeight.date && daysBetween(w.date, latestWeight.date) <= 3,
+    );
+    const earliest = priorWindow[0];
+    if (earliest) {
+      const delta = latestWeight.weight_lb - earliest.weight_lb;
+      if (Math.abs(delta) >= 1.5) {
+        out.push({
+          id: "weight-swing",
+          text: `${delta > 0 ? "+" : ""}${delta.toFixed(1)} lb in ${daysBetween(earliest.date, latestWeight.date)} days — that's water, not fat. Does the scale still get to you?`,
+          priority: 60,
+        });
+      }
+    }
+  }
+
+  // --- Intake ---------------------------------------------------------------
+  const todayIntake = ctx.intake.find((i) => i.date === today);
+  if (todayIntake && ctx.calorieGoal && todayIntake.calories >= ctx.calorieGoal * 1.5) {
+    out.push({
+      id: "intake-high",
+      text: "Today ran well over target. What were you actually after when you reached for it?",
+      priority: 64,
+    });
+  }
+  if (
+    todayIntake &&
+    ctx.proteinGoal &&
+    todayIntake.calories > 0 &&
+    todayIntake.protein_g <= ctx.proteinGoal * 0.6
+  ) {
+    out.push({
+      id: "intake-protein-short",
+      text: "Protein landed short today. Was that a planning problem or an appetite one?",
+      priority: 40,
+    });
+  }
+
+  // --- Coming back after a gap ---------------------------------------------
+  if (ctx.lastEntryDate) {
+    const gap = daysBetween(ctx.lastEntryDate, today);
+    if (gap >= 7) {
+      out.push({
+        id: "journal-gap",
+        text: `First entry in ${gap} days. What's happened since you last wrote?`,
+        priority: 66,
+      });
+    }
+  }
+
+  // --- Evergreen fill -------------------------------------------------------
+  const rotation = Math.abs(daysBetween("2026-01-01", today));
+  for (let i = 0; out.length < MAX_PROMPTS && i < EVERGREEN.length; i++) {
+    const text = EVERGREEN[(rotation + i) % EVERGREEN.length];
+    out.push({ id: `evergreen-${(rotation + i) % EVERGREEN.length}`, text, priority: 10 });
+  }
+
+  return out.sort((a, b) => b.priority - a.priority).slice(0, MAX_PROMPTS);
+}


### PR DESCRIPTION
## Why

The journal editor had two inner tabs — **Reflect** (five fixed questions, each its own
textarea) and **Free Write** — and defaulted to Reflect on every open, with a `0 / 5`
progress-dot row that filled in as questions were answered.

That framed journalling as a form with a completion state, and the six entries on record show
what it produced. Five answer the prompts dutifully and briefly:

> *"Honestly not too sure but let's just say I'm glad I'm still more or less healthy."*
> *"Don't really feel gratitude for anything today."*

The one entry that used the buried Free Write tab is the only one with anything real in it.

## What changed

- **One surface.** Removed the inner tabs, the five `PROMPTS` fields and the progress dots.
  The page is a single textarea.
- **Contextual suggestions** (`web/src/lib/journal/prompts.ts`) derive up to three prompts from
  the day's own data — alcohol habit rows, Oura recovery, strength sessions, habit streaks,
  weight swings, intake vs. targets, days since the last entry — with a date-rotated evergreen
  pool when nothing notable fires. Tapping one drops it in as a line to write under. They can be
  hidden, and are never required.
- **Deterministic, no model** — same posture as the workout planner and the nutrition pipeline.
  `buildJournalPrompts` is pure and takes `today` on its context object, so it runs directly
  against live rows.

## Bug found by running it against live data

Session classification tested that **every** exercise name contained `grease-the-groove`. A GtG
session also carries accessory movements with no such suffix (`Negative Pull-Up`, `Dead Hang`),
so real GtG sessions on 8/04, 8/05, 8/06 and 8/07 all failed the test and read as **lifting
sessions** — the engine offered a "you trained today" prompt on a pull-up-only day.

GtG is walk work and never appears inside a lift, so the correct test is **any**. Same class of
bug as the GtG mis-scoring fixed in #650.

## Backwards compatibility

- The `responses` column and its rendering in `journal-history.tsx` are retained, so the six
  existing entries still display.
- The editor passes `initialResponses` back through the save **untouched**, so editing a
  pre-2026-08 entry doesn't erase the answers it was written against.
- Prompts are suppressed when back-dating an entry, since they describe today.
- `habit_registry` is now queried with `active = true`, so retired habits keep their rows but
  stop driving suggestions.

## Verification

- `tsc --noEmit` clean, `eslint` clean on all touched paths, `prettier --check .` clean.
- `buildJournalPrompts` exercised against live rows across five scenarios — today as-is, today
  unlogged, a drinking day, a quiet day, and an empty context. Output:

```
### TODAY 2026-08-07 (real data)
  [ 98] alcohol-dry-after-heavy   Yesterday wasn't dry and today was. What was different about the afternoon?
  [ 58] recovery-hrv-up           Recovery came back sharply overnight. What did you do differently yesterday?
  [ 52] recovery-long-sleep       11.3 hours of sleep. Catching up, or hiding?

### if today were still unlogged
  [ 90] alcohol-yesterday-only    Yesterday wasn't dry. How has today gone by comparison?

### if he had drunk today
  [100] alcohol-today             What was happening in the hour before the first drink?

### quiet day / empty context
  [ 10] evergreen-*               (date-rotated fallback)
```

**Not browser-verified** — there is no browser in this environment and no unit-test runner in the
repo, only Playwright smoke. The prompt engine is proven against real data; the editor layout is
proven only by typecheck and lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jnk9QfN8r5fCSycti1HNfa
