### PR TITLE
meals: render ingredients as a list and annotate rice in go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Recipe ingredients rendered as a raw JSON array, and rice lost its `go`.** Both were visible on
+  the same screen. `recipes.ingredients` is a free-text column holding one ingredient per line, and
+  both render sites (`PlannedMealDetail`, the `MealsClient` recipe browser) dropped it into a single
+  `<p>` with `white-space: pre-line`. That held only while every writer wrote clean newline text —
+  when a batch script JSON-encoded the array _into_ the text column, the page printed
+  `["Chicken breast, boneless skinless - 255 g", ...]` verbatim. Eight recipes were affected,
+  including four meals planned for the current week.
+
+  Ingredients now render through a shared `IngredientList` component backed by `parseIngredients`
+  (`web/src/lib/units.ts`), which recovers a JSON-array payload back into lines before display, so
+  the next bad write degrades to a correct list instead of leaking storage syntax. It emits a real
+  `<ul>` rather than a text blob — an ingredient list is a list, and screen readers announce the
+  item count. The two call sites now share one path and cannot drift apart again.
+
+  `parseIngredients` also annotates rice with **go** (合, the Japanese rice cup; 1 go = 150 g dry),
+  which is the unit Jason actually measures at the bag. The convention had been applied by hand to
+  the stored text and had drifted — 12 recipes carried it, 8 did not. Moving it to render time
+  covers every row including future ones. Cooked-weight lines are converted through per-grain yields
+  (white ~3.0×, brown ~2.75×) and are left alone when the line does not say which grain it is,
+  rather than guessing. Lines that already carry a hand-written go keep it and are not recomputed.
+
+  Rice annotation runs _before_ the imperial conversion: `annotateLine` splices `(2.8 oz)` in
+  between the number and the word after it, which would otherwise break the `<n> g dry rice` match.
+  The go is derived from the **rounded** dry weight so that the two figures shown side by side agree
+  with each other. Both behaviours are pinned by tests. `addWeightConversions` had no callers left
+  once the components moved to `parseIngredients` and was removed.
+
+  Ten tests in `web/src/__tests__/ingredients.test.ts`.
+
 ### Changed
 
 - **Journal is now a single free-write surface with contextual suggestions.** The editor had two

--- a/web/src/__tests__/ingredients.test.ts
+++ b/web/src/__tests__/ingredients.test.ts
@@ -1,0 +1,86 @@
+// Unit tests for parseIngredients (lib/units.ts).
+// Run with: node --experimental-strip-types --test src/__tests__/ingredients.test.ts
+// (from the web/ directory)
+//
+// WHY THIS EXISTS
+//
+// Two separate failures on 2026-08-08, both visible on the same screen:
+//
+//   1. Eight recipes had a JSON array written into the free-text `ingredients` column by a batch
+//      script. The UI rendered it into a `<p>` with `white-space: pre-line`, so the page printed
+//      `["Chicken breast, boneless skinless - 255 g", ...]` verbatim. The data was repaired, but a
+//      render path that leaks storage syntax when a writer misbehaves will do it again.
+//
+//   2. Rice is measured in *go* (1 go = 150 g dry) — Jason's actual unit at the bag. The convention
+//      was applied by hand and had drifted: 12 recipes carried it, 8 did not. Anything applied by
+//      hand to stored text drifts, so it moved to render time.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseIngredients } from "../lib/units.ts";
+
+test("splits plain newline text into lines", () => {
+  const out = parseIngredients("255 g chicken breast\n120 g edamame, shelled");
+  assert.equal(out.length, 2);
+  assert.match(out[0], /^255 g/);
+  assert.match(out[1], /edamame/);
+});
+
+test("recovers a JSON array written into the text column", () => {
+  const out = parseIngredients(
+    '["Chicken breast, boneless skinless - 255 g", "Edamame, shelled - 120 g"]',
+  );
+  assert.equal(out.length, 2);
+  assert.match(out[0], /Chicken breast, boneless skinless - 255 g/);
+  // The whole point: no bracket, quote or comma-separator survives into the display string.
+  assert.ok(!out.join("").includes('"'), "quotes leaked into the rendered list");
+  assert.ok(!out[0].startsWith("["), "bracket leaked into the rendered list");
+});
+
+test("text that merely starts with a bracket is not swallowed", () => {
+  const out = parseIngredients("[garnish] 15 g scallions\n200 g cabbage");
+  assert.equal(out.length, 2);
+  assert.match(out[0], /garnish/);
+});
+
+test("annotates dry rice with go", () => {
+  assert.match(parseIngredients("80 g dry brown rice")[0], /0\.53 go/);
+  assert.match(parseIngredients("150 g dry white rice")[0], /1 go/);
+});
+
+test("annotates cooked rice with both dry grams and go, by grain", () => {
+  // white cooks ~3.0x, brown ~2.75x — the yields differ, so the grain has to be named
+  assert.match(parseIngredients("150 g cooked white rice")[0], /~50 g dry = 0\.33 go/);
+  assert.match(parseIngredients("150 g cooked brown rice")[0], /~55 g dry = 0\.37 go/);
+});
+
+test("cooked rice of unnamed grain is left alone rather than guessed", () => {
+  const out = parseIngredients("150 g cooked rice")[0];
+  assert.ok(!out.includes("go"), "guessed a yield for an unspecified grain");
+});
+
+test("does not double-annotate a line that already carries its go", () => {
+  const line = "220 g cooked brown rice (~80 g dry = 0.5 go)";
+  const out = parseIngredients(line)[0];
+  assert.equal(out.match(/go/g)?.length, 1);
+  // and it keeps the hand-written figure rather than substituting a recomputed one
+  assert.match(out, /~80 g dry = 0\.5 go/);
+});
+
+test("go annotation composes with the imperial conversion", () => {
+  const out = parseIngredients("80 g dry brown rice")[0];
+  assert.match(out, /2\.8 oz/); // from annotateLine
+  assert.match(out, /0\.53 go/); // from annotateRice
+});
+
+test("gochujang does not trip the go matcher", () => {
+  const out = parseIngredients("20 g gochujang")[0];
+  assert.ok(!out.includes(" go)"), "matched 'go' inside gochujang");
+});
+
+test("empty and null input yield no rows", () => {
+  assert.deepEqual(parseIngredients(""), []);
+  assert.deepEqual(parseIngredients(null), []);
+  assert.deepEqual(parseIngredients(undefined), []);
+  assert.deepEqual(parseIngredients("\n\n  \n"), []);
+});

--- a/web/src/components/meals/IngredientList.tsx
+++ b/web/src/components/meals/IngredientList.tsx
@@ -1,0 +1,43 @@
+import { parseIngredients } from "@/lib/units";
+
+/**
+ * A recipe's ingredients, one per line.
+ *
+ * Both places that show ingredients (the planned-meal detail and the recipe browser) used to render
+ * the raw column into a single `<p>` with `white-space: pre-line`. That worked only as long as the
+ * column held clean newline text — when a batch script wrote a JSON array into it, the page printed
+ * the JSON. Parsing lives in `parseIngredients`, which also annotates units and rice `go`; this
+ * component is the shared shell so the two call sites cannot drift apart again.
+ *
+ * A real `<ul>` rather than a text blob: an ingredient list IS a list, and screen readers announce
+ * the item count, which a pre-line paragraph does not.
+ */
+export function IngredientList({
+  text,
+  tone = "default",
+}: {
+  text: string | null | undefined;
+  tone?: "default" | "muted";
+}) {
+  const items = parseIngredients(text);
+  if (!items.length) return null;
+
+  return (
+    <ul
+      style={{
+        fontSize: "var(--t-meta)",
+        color: tone === "muted" ? "var(--color-text-muted)" : "var(--color-text)",
+        lineHeight: 1.6,
+        listStyle: "disc outside",
+        paddingLeft: "1.1em",
+        margin: 0,
+      }}
+    >
+      {items.map((line, i) => (
+        <li key={i} style={{ marginBottom: "0.15em" }}>
+          {line}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/src/components/meals/MealsClient.tsx
+++ b/web/src/components/meals/MealsClient.tsx
@@ -18,7 +18,7 @@ import { compressImage } from "@/lib/meal-photo";
 import { ChartFrame, TrendLine } from "@/components/charts/primitives";
 import { formatDate } from "@/lib/chart-utils";
 import { todayString } from "@/lib/timezone";
-import { addWeightConversions } from "@/lib/units";
+import { IngredientList } from "./IngredientList";
 
 const FoodPhotoAnalyzer = dynamic(() => import("@/app/(protected)/meals/FoodPhotoAnalyzer"), {
   ssr: false,
@@ -1222,17 +1222,9 @@ function RecipesTab({ recipes }: { recipes: RecipeRow[] }) {
                     }}
                   >
                     {r.ingredients && (
-                      <p
-                        style={{
-                          fontSize: "var(--t-meta)",
-                          color: "var(--color-text-muted)",
-                          lineHeight: 1.6,
-                          marginBottom: "var(--space-3)",
-                          whiteSpace: "pre-line",
-                        }}
-                      >
-                        {addWeightConversions(r.ingredients)}
-                      </p>
+                      <div style={{ marginBottom: "var(--space-3)" }}>
+                        <IngredientList text={r.ingredients} tone="muted" />
+                      </div>
                     )}
 
                     {r.instructions && (

--- a/web/src/components/meals/PlannedMealDetail.tsx
+++ b/web/src/components/meals/PlannedMealDetail.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import type { KitchenPlannedMeal } from "./KitchenPanel";
-import { addWeightConversions } from "@/lib/units";
+import { IngredientList } from "./IngredientList";
 
 /**
  * The click-in view for a planned meal: what's in it, and what it costs you.
@@ -64,7 +64,7 @@ export function PlannedMealDetail({ meal }: { meal: KitchenPlannedMeal }) {
         {recipe.ingredients ? (
           <div style={{ marginBottom: "var(--space-3)" }}>
             <p style={sectionLabelStyle}>Ingredients</p>
-            <p style={ingredientsStyle}>{addWeightConversions(recipe.ingredients)}</p>
+            <IngredientList text={recipe.ingredients} />
           </div>
         ) : (
           <p style={mutedStyle}>No ingredients recorded for this recipe yet.</p>

--- a/web/src/lib/units.ts
+++ b/web/src/lib/units.ts
@@ -32,8 +32,8 @@ function round(n: number, decimals: number): number {
 // ── Ingredient-text weight conversions ──────────────────────────────────────────
 // Recipes are written in grams (USDA); the fridge is stocked in lb/oz. Showing a gram amount
 // without its imperial equivalent forces a mental conversion that is easy to get wrong ("we have
-// 1.25 lb of chicken but the recipe says 200 g"). `addWeightConversions` annotates each weight in
-// a free-text ingredient list with its other units, leaving the stored text unchanged.
+// 1.25 lb of chicken but the recipe says 200 g"). `annotateLine` annotates each weight with its
+// other units, leaving the stored text unchanged. Reached via `parseIngredients` below.
 
 const GRAMS_PER: Record<string, number> = {
   g: 1,
@@ -75,7 +75,65 @@ function annotateLine(line: string): string {
   return `${line.slice(0, end)} (${alts.join(" · ")})${line.slice(end)}`;
 }
 
-/** Annotate each line of a free-text ingredient list with imperial/metric equivalents. */
-export function addWeightConversions(text: string): string {
-  return text.split("\n").map(annotateLine).join("\n");
+// ── Rice: grams ↔ go ────────────────────────────────────────────────────────────
+// Jason scoops rice in *go* (合), the Japanese rice cup — 1 go = 150 g of DRY rice. Recipes are
+// written in grams because USDA is, and a cooked-weight line hides the number he actually measures
+// at the bag. Annotating at render time rather than in the stored text means every rice line gets
+// it, including rows written by a future script that forgets the convention.
+const GRAMS_PER_GO = 150;
+
+// Cooked yield differs by grain, so a cooked line is only convertible when it says which it is.
+const COOKED_YIELD: Record<string, number> = { white: 3.0, brown: 2.75 };
+
+const RICE_DRY = /(\d+(?:\.\d+)?)\s*g\s+dry\s+(?:\w+\s+)?rice\b/i;
+const RICE_COOKED = /(\d+(?:\.\d+)?)\s*g\s+cooked\s+(white|brown)\s+rice\b/i;
+
+function annotateRice(line: string): string {
+  if (/\bgo\b/i.test(line)) return line; // already carries its go — don't double-annotate
+
+  const dry = line.match(RICE_DRY);
+  if (dry) return `${line} (${round(parseFloat(dry[1]) / GRAMS_PER_GO, 2)} go)`;
+
+  const cooked = line.match(RICE_COOKED);
+  if (cooked) {
+    // Derive the go from the ROUNDED dry weight, not the raw one: both numbers are shown side by
+    // side, and a reader who divides the printed grams by 150 has to land on the printed go.
+    const dryGrams = Math.round(parseFloat(cooked[1]) / COOKED_YIELD[cooked[2].toLowerCase()]);
+    return `${line} (~${dryGrams} g dry = ${round(dryGrams / GRAMS_PER_GO, 2)} go)`;
+  }
+  return line;
+}
+
+// ── Ingredient lists ────────────────────────────────────────────────────────────
+// `recipes.ingredients` is a free-text column holding one ingredient per line. A batch script in
+// August 2026 wrote eight rows as a JSON-encoded array *into* that text column, so the UI rendered
+// the literal `["Chicken breast - 255 g", ...]` — the page was faithfully printing what was stored.
+// The rows were repaired, but parsing the array back out here means the next bad write degrades to
+// a correct list instead of leaking syntax at Jason.
+
+/** Split a stored ingredient list into display lines, annotated with unit and go conversions. */
+export function parseIngredients(text: string | null | undefined): string[] {
+  const trimmed = (text ?? "").trim();
+  if (!trimmed) return [];
+
+  let lines: string[];
+  if (trimmed.startsWith("[")) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      parsed = null; // not valid JSON after all — fall back to line splitting
+    }
+    lines =
+      Array.isArray(parsed) && parsed.every((x) => typeof x === "string")
+        ? (parsed as string[])
+        : trimmed.split("\n");
+  } else {
+    lines = trimmed.split("\n");
+  }
+
+  // Rice first: `annotateLine` splices "(2.8 oz)" in between the number and the word that follows
+  // it, which would break the "<n> g dry rice" match. Going rice-first also parks the go at the end
+  // of the line, where it reads as a note rather than interrupting the amount.
+  return lines.map((l) => annotateLine(annotateRice(l.trim()))).filter(Boolean);
 }


### PR DESCRIPTION
## What

Recipe ingredients rendered as a raw JSON array, and rice lost its `go`. Both were visible on the same screen.

`recipes.ingredients` is a free-text column holding one ingredient per line, and both render sites dropped it into a single `<p>` with `white-space: pre-line`. That held only while every writer wrote clean newline text — a batch script JSON-encoded the array *into* the column, so the page printed this verbatim:

```
["Chicken breast, boneless skinless - 255 g", "Sweet baby broccoli (broccolini) - 133 g", ...]
```

Eight recipes were affected, four of them meals planned for the current week. The rows have been repaired in the database separately; this PR makes the render path stop leaking storage syntax when a writer misbehaves again.

## How

- **`parseIngredients` (`web/src/lib/units.ts`)** — recovers a JSON-array payload back into lines before display, falling through to newline splitting for everything else (including text that merely *starts* with a bracket). Replaces `addWeightConversions`, which had no callers left afterwards and was removed.
- **`IngredientList` (new, shared)** — both call sites (`PlannedMealDetail`, the `MealsClient` recipe browser) now go through one component, so they cannot drift apart again. Emits a real `<ul>` instead of a text blob: an ingredient list is a list, and screen readers announce the item count, which `pre-line` does not.
- **Rice in `go`** — 1 go = 150 g dry, the unit actually measured at the bag. The convention had been applied by hand to stored text and had drifted: 12 recipes carried it, 8 did not. Moving it to render time covers every row including future ones. Cooked-weight lines convert through per-grain yields (white ~3.0×, brown ~2.75×) and are **left alone when the grain is not named** rather than guessed. Lines already carrying a hand-written go keep it.

Two ordering details, both pinned by tests:

1. Rice runs **before** the imperial conversion — `annotateLine` splices `(2.8 oz)` in between the number and the word after it, which breaks the `<n> g dry rice` match. Caught by a failing test, not by review.
2. The go is derived from the **rounded** dry weight, so the two figures printed side by side agree (`~55 g dry = 0.37 go`, not `0.36`).

## Verification

- `node --test src/__tests__/ingredients.test.ts` — **10 new tests, pass**. Full suite (6 files) green.
- `tsc --noEmit` clean; `eslint .` 0 errors, no findings in changed files; `prettier --check .` from `web/` clean.
- `next build` succeeds.
- Not viewed in a browser — there is no browser in this environment. The parsing and annotation logic is fully unit-tested; the component itself is presentational.

## Notes

- `CHANGELOG.md` is additive only. It already fails root-level `prettier --check` on `main` (pre-existing; CI runs prettier from `web/`, which is clean), so it was deliberately **not** reformatted — doing so churns unrelated entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfJaVnfvNE68BThwysaPjf
