### PR TITLE
meals: recipes become structured data, and the model leaves the macro path

### DIFF
--- a/supabase/migrations/20260812000000_structured_recipes.sql
+++ b/supabase/migrations/20260812000000_structured_recipes.sql
@@ -1,0 +1,67 @@
+-- Recipes become structured data: an ingredient is a row, a step is a step.
+--
+-- WHY THIS IS NOT A FORMATTING CHANGE
+--
+-- `recipes.ingredients` is free text, and it is the INPUT TO THE MACRO PIPELINE. Today
+-- resolveRecipeMacros() hands that prose to a local 7B model (parseFoodText) to be split into
+-- {query, qty, unit} before USDA ever sees it. web/src/lib/nutrition/parse.ts documents why that
+-- is a liability in its own words: the model called a large egg 105 g (real ~50 g) and a cup of
+-- cooked rice 284 g (real ~158 g) — both ~2x heavy. The codebase already works around this by
+-- re-lexing every quantity out of the source fragment in quantity.ts, "because the model
+-- demonstrably alters numbers it is asked to repeat".
+--
+-- All of that machinery exists to recover structure that was thrown away at write time. When the
+-- quantity is a number in a column, there is nothing to parse, nothing to re-lex, and nothing to
+-- mangle. The model step is skipped outright for a structured recipe.
+--
+-- fdc_id closes the other half. USDA's top hit for "chicken breast, cooked" is "Chicken breast
+-- tenders, breaded, cooked, microwaved" — 252 kcal and 17.6 g carbs against ~165/0 for the plain
+-- cut. Pinning the FDC id per ingredient makes re-resolution deterministic: the same recipe
+-- resolves to the same numbers next month, which is the whole point of tracking a trend.
+--
+-- ADDITIVE, NOT A CUTOVER
+--
+-- ~65 recipes hold prose or newline text today, four of them on the current week's plan. The text
+-- columns stay and remain the fallback: readers prefer `ingredients_json` when present and drop
+-- back to `ingredients` otherwise, so a half-finished backfill renders correctly throughout.
+-- parseIngredients() (added in #665, after a batch script JSON-encoded an array into the text
+-- column and the page printed the JSON at Jason) keeps covering the legacy path.
+--
+-- Shape mirrors workout_plans.warmup/workout/cooldown, which have stored arrays of typed objects
+-- since the initial schema. Meals were the odd one out; now they are not.
+
+alter table recipes
+  -- Array of ingredient objects. See RecipeIngredient in web/src/lib/types.ts.
+  --   { item, quantity, unit, prep?, group?, optional?, note?, fdc_id? }
+  -- `quantity`/`unit` null is legitimate — "salt, to taste" is a real ingredient with no amount.
+  -- Such a row renders fine and is simply skipped by the macro resolver, exactly as an
+  -- unquantified line is today.
+  add column if not exists ingredients_json jsonb
+    constraint recipes_ingredients_json_is_array
+    check (ingredients_json is null or jsonb_typeof(ingredients_json) = 'array'),
+
+  -- Array of step objects. See RecipeStep in web/src/lib/types.ts.
+  --   { step, text, tips?, duration_mins? }
+  add column if not exists steps_json jsonb
+    constraint recipes_steps_json_is_array
+    check (steps_json is null or jsonb_typeof(steps_json) = 'array');
+
+comment on column recipes.ingredients_json is
+  'Structured ingredients: [{item, quantity, unit, prep, group, optional, note, fdc_id}]. '
+  'Preferred over the legacy `ingredients` text column when present; readers fall back to it. '
+  'When a row carries quantity+unit the macro resolver skips the local model entirely and goes '
+  'straight to USDA; when it also carries fdc_id, USDA search and model selection are both '
+  'skipped. Null quantity is valid (e.g. "salt, to taste") and is ignored for macros.';
+
+comment on column recipes.steps_json is
+  'Structured method: [{step, text, tips, duration_mins}]. Preferred over the legacy '
+  '`instructions` text column when present. Display only — nothing in the macro path reads it.';
+
+comment on column recipes.ingredients is
+  'LEGACY free text, one ingredient per line. Retained as the fallback while ingredients_json is '
+  'backfilled. Do not write new recipes here — write ingredients_json. Still parsed for display '
+  'by parseIngredients(), which also recovers a JSON-array payload written into this column.';
+
+comment on column recipes.instructions is
+  'LEGACY free text. Retained as the fallback while steps_json is backfilled. Do not write new '
+  'recipes here — write steps_json.';

--- a/web/scripts/backfill-structured-recipes.ts
+++ b/web/scripts/backfill-structured-recipes.ts
@@ -1,0 +1,166 @@
+/**
+ * Backfill `recipes.ingredients_json` / `steps_json` from the legacy free-text columns.
+ *
+ * Run from web/:
+ *   node --experimental-strip-types scripts/backfill-structured-recipes.ts          # dry run
+ *   node --experimental-strip-types scripts/backfill-structured-recipes.ts --write  # apply
+ *
+ * Needs SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in the environment.
+ *
+ * WHY A SCRIPT AND NOT A SQL MIGRATION
+ *
+ * The conversion needs the same quantity lexer the macro pipeline uses (`lexQuantity`), so that a
+ * backfilled amount is read exactly the way a logged amount is. Reimplementing that in PL/pgSQL
+ * would create a second parser that silently drifts from the first.
+ *
+ * THE SAFETY RULE: ALL-OR-NOTHING PER RECIPE
+ *
+ * A row with `quantity: null` is EXCLUDED from the macro total by design — that is what makes
+ * "salt, to taste" behave. It also means a line whose amount we failed to read would silently
+ * delete a real ingredient from a real total. The text path at least invents an amount and flags
+ * the recipe low-confidence; converting it badly would look cleaner and be worse.
+ *
+ * So a recipe is converted only when EVERY line either yields an amount or is recognisably a
+ * seasoning. Anything else leaves the whole recipe on the text path and is printed for a human to
+ * fix in the editor. Measured on the live library at time of writing: 67 of 72 convert, and the 5
+ * that don't genuinely have no amount written down anywhere ("Pasta, corn, spinach, green beans").
+ *
+ * MACROS ARE NOT RE-RESOLVED HERE.
+ *
+ * Existing totals were computed from the same ingredients and stay correct; re-resolving 67 recipes
+ * would fire hundreds of USDA calls and change stored numbers in bulk with no one watching. The
+ * structured path takes over the next time a recipe is edited or explicitly re-resolved.
+ */
+import { createClient } from "@supabase/supabase-js";
+import { lexQuantity } from "../src/lib/nutrition/quantity.ts";
+import { splitIngredientLines } from "../src/lib/units.ts";
+import type { RecipeIngredient, RecipeStep } from "../src/lib/types.ts";
+
+/** Lines that legitimately carry no amount. Kept narrow — see the safety rule above. */
+const TRULY_AMOUNTLESS =
+  /\b(to taste|to garnish|for garnish|to serve|zero[- ]cal|as needed|optional)\b/i;
+const SEASONING = /\b(salt|pepper|powder|cumin|seasoning|spice|paprika|herbs?)\b/i;
+
+/**
+ * "kimchi 120 g", "Ribeye 0.78 lb (354g)" — the amount TRAILS the food.
+ *
+ * `lexQuantity` reads only a LEADING amount, deliberately: a trailing number in meal text is more
+ * often a temperature or a year. Handling the trailing form here keeps that lexer untouched, and it
+ * matters because rows written in August 2026 used exactly this shape.
+ */
+const TRAILING =
+  /^(.*?)[\s,(]*(\d+(?:\.\d+)?)\s*(g|kg|ml|l|oz|lb|tbsp|tsp|cup|clove|can|slice)s?\b/i;
+
+export function ingredientRowsFrom(text: string): {
+  rows: RecipeIngredient[];
+  unresolved: string[];
+} {
+  let lines = splitIngredientLines(text);
+  // Semicolon prose, e.g. "cod 227 g; kimchi 120 g; 2 large eggs".
+  if (lines.length === 1 && lines[0].includes(";")) {
+    lines = lines[0]
+      .split(";")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+
+  const rows: RecipeIngredient[] = [];
+  const unresolved: string[] = [];
+
+  for (let raw of lines) {
+    raw = raw
+      .replace(/^PER SERVING \([^)]*\)\.\s*/i, "")
+      .replace(/\.$/, "")
+      .trim();
+    if (!raw) continue;
+
+    const lead = lexQuantity(raw);
+    if (lead) {
+      const at = raw.indexOf(lead.source);
+      const item = (at < 0 ? raw : raw.slice(at + lead.source.length))
+        .trim()
+        .replace(/^(of\s+|[,\-–—]\s*)/i, "");
+      rows.push({ item: item || raw, quantity: lead.qty, unit: lead.unit });
+      continue;
+    }
+
+    const tail = TRAILING.exec(raw);
+    if (tail && tail[1].trim()) {
+      const rest = raw
+        .slice(tail[0].length)
+        .trim()
+        .replace(/^[),\s]+/, "");
+      rows.push({
+        item: tail[1].trim().replace(/[,(]$/, "").trim(),
+        quantity: parseFloat(tail[2]),
+        unit: tail[3].toLowerCase(),
+        note: rest || null,
+      });
+      continue;
+    }
+
+    rows.push({ item: raw, quantity: null, unit: null });
+    if (!TRULY_AMOUNTLESS.test(raw) && !SEASONING.test(raw)) unresolved.push(raw);
+  }
+  return { rows, unresolved };
+}
+
+/** Numbered or newline-separated instructions -> steps. Blank-line groups win over single lines. */
+export function stepRowsFrom(text: string | null): RecipeStep[] | null {
+  const t = (text ?? "").trim();
+  if (!t) return null;
+  const chunks = (t.includes("\n\n") ? t.split(/\n{2,}/) : t.split("\n"))
+    .map((c) => c.trim().replace(/^\d+[.)]\s*/, ""))
+    .filter(Boolean);
+  return chunks.length ? chunks.map((text, i) => ({ step: i + 1, text })) : null;
+}
+
+async function main() {
+  const write = process.argv.includes("--write");
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required");
+  const db = createClient(url, key);
+
+  const { data, error } = await db
+    .from("recipes")
+    .select("id, name, ingredients, instructions, ingredients_json")
+    .order("name");
+  if (error) throw new Error(error.message);
+
+  let converted = 0;
+  const blocked: { name: string; unresolved: string[] }[] = [];
+
+  for (const r of data ?? []) {
+    if (Array.isArray(r.ingredients_json) && r.ingredients_json.length) continue; // already done
+    const text = (r.ingredients as string | null)?.trim();
+    if (!text) continue;
+
+    const { rows, unresolved } = ingredientRowsFrom(text);
+    if (unresolved.length) {
+      blocked.push({ name: r.name as string, unresolved });
+      continue;
+    }
+
+    converted++;
+    if (write) {
+      const { error: e } = await db
+        .from("recipes")
+        .update({ ingredients_json: rows, steps_json: stepRowsFrom(r.instructions as string) })
+        .eq("id", r.id);
+      if (e) throw new Error(`${r.name}: ${e.message}`);
+    } else {
+      console.log(`${r.name}\n   ${JSON.stringify(rows)}`);
+    }
+  }
+
+  console.log(`\n${write ? "converted" : "would convert"}: ${converted}`);
+  console.log(`left on the text path (need an amount written down): ${blocked.length}`);
+  for (const b of blocked) console.log(`   ${b.name}\n      - ${b.unresolved.join("\n      - ")}`);
+  if (!write) console.log("\nDry run. Re-run with --write to apply.");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/web/src/__tests__/structured-recipes.test.ts
+++ b/web/src/__tests__/structured-recipes.test.ts
@@ -1,0 +1,194 @@
+// Unit tests for the structured recipe columns (lib/units.ts, lib/nutrition/recipe-structured.ts).
+// Run with: node --experimental-strip-types --test src/__tests__/structured-recipes.test.ts
+// (from the web/ directory)
+//
+// WHY THIS EXISTS
+//
+// `ingredients_json` is not a presentation change — it is the INPUT TO THE MACRO PIPELINE, and it
+// removes the local model from that path entirely. Two properties have to hold or the numbers get
+// quietly worse rather than better:
+//
+//   1. A structured row must render exactly like the text line it replaces. The imperial and rice
+//      `go` annotations from #665 live in the text path; if the structured path skipped them, half
+//      the library would silently lose its unit hints mid-backfill.
+//
+//   2. `quantity: null` must survive validation as a distinct state. The resolver EXCLUDES those
+//      rows from the total on purpose ("salt, to taste" has no mass). If validation coerced null to
+//      0 — or rejected the row — a real ingredient would either vanish from a real plate or block a
+//      save. Both were live failure modes in the prose path this replaces.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { formatIngredient, groupIngredients, splitIngredientLines } from "../lib/units.ts";
+import {
+  RecipeShapeError,
+  parseIngredientRows,
+  parseStepRows,
+} from "../lib/nutrition/recipe-structured.ts";
+
+// ── formatIngredient ────────────────────────────────────────────────────────────
+
+test("structured row picks up the same imperial annotation as a text line", () => {
+  const out = formatIngredient({ item: "ground beef, 93/7", quantity: 454, unit: "g" });
+  assert.match(out, /^454 g/);
+  assert.match(out, /16 oz/); // the annotation the text path would have added
+  assert.match(out, /ground beef/);
+});
+
+test("small amounts skip the ounce annotation, as in the text path", () => {
+  // Below 15 g an ounce figure is noise ("5 g of oil -> 0.2 oz").
+  const out = formatIngredient({ item: "avocado oil", quantity: 5, unit: "g" });
+  assert.equal(out, "5 g avocado oil");
+});
+
+test("rice carries its go conversion", () => {
+  const out = formatIngredient({ item: "dry white rice", quantity: 300, unit: "g" });
+  assert.match(out, /2 go/);
+});
+
+test("prep is folded into the line, not dropped", () => {
+  const out = formatIngredient({
+    item: "chicken breast",
+    quantity: 302,
+    unit: "g",
+    prep: "raw",
+  });
+  assert.match(out, /chicken breast, raw/);
+});
+
+test("an amount-less ingredient renders without a leading number", () => {
+  const out = formatIngredient({ item: "salt", quantity: null, unit: null });
+  assert.equal(out, "salt");
+});
+
+test("note and optional are appended after annotation, so a note cannot suppress it", () => {
+  // `annotateRice` bails on any line already containing a bare "go". A note is free text and could
+  // contain one, so notes must be appended AFTER the annotators run.
+  const out = formatIngredient({
+    item: "dry white rice",
+    quantity: 300,
+    unit: "g",
+    note: "let it go 12 min",
+  });
+  assert.match(out, /2 go/, "rice annotation survived a note containing the word 'go'");
+  assert.match(out, /— let it go 12 min$/);
+});
+
+test("optional is marked", () => {
+  const out = formatIngredient({ item: "parmesan", quantity: 5, unit: "g", optional: true });
+  assert.match(out, /\(optional\)/);
+});
+
+// ── groupIngredients ────────────────────────────────────────────────────────────
+
+test("ungrouped rows collapse to a single null bucket in original order", () => {
+  const groups = groupIngredients([
+    { item: "a", quantity: null, unit: null },
+    { item: "b", quantity: null, unit: null },
+  ]);
+  assert.equal(groups.length, 1);
+  assert.equal(groups[0].group, null);
+  assert.deepEqual(
+    groups[0].items.map((i) => i.item),
+    ["a", "b"],
+  );
+});
+
+test("groups keep first-seen order and re-collect non-adjacent rows", () => {
+  const groups = groupIngredients([
+    { item: "beef", quantity: null, unit: null, group: "Chili" },
+    { item: "basil", quantity: null, unit: null, group: "Sauce" },
+    { item: "cumin", quantity: null, unit: null, group: "Chili" },
+  ]);
+  assert.deepEqual(
+    groups.map((g) => g.group),
+    ["Chili", "Sauce"],
+  );
+  assert.deepEqual(
+    groups[0].items.map((i) => i.item),
+    ["beef", "cumin"],
+  );
+});
+
+// ── splitIngredientLines ────────────────────────────────────────────────────────
+
+test("raw split does NOT annotate — the editor must see what was typed", () => {
+  // parseIngredients would return "200 g (7.1 oz) beef"; feeding that back into the amount lexer
+  // gives it two numbers to choose between.
+  assert.deepEqual(splitIngredientLines("200 g beef"), ["200 g beef"]);
+});
+
+test("raw split still recovers a JSON array written into the text column", () => {
+  assert.deepEqual(splitIngredientLines('["255 g chicken", "120 g edamame"]'), [
+    "255 g chicken",
+    "120 g edamame",
+  ]);
+});
+
+// ── validation ──────────────────────────────────────────────────────────────────
+
+test("quantity null is valid and is preserved, not coerced to 0", () => {
+  const rows = parseIngredientRows([{ item: "salt", quantity: null }]);
+  assert.equal(rows![0].quantity, null);
+  assert.equal(rows![0].unit, null);
+});
+
+test("a quantity with no unit is rejected", () => {
+  // A bare number cannot be converted to grams, so USDA would fall back to an assumed portion —
+  // an amount that looks stated but is not.
+  assert.throws(() => parseIngredientRows([{ item: "beef", quantity: 200 }]), RecipeShapeError);
+});
+
+test("a string quantity is rejected rather than coerced", () => {
+  // "200g" as a string resolves to nothing downstream and silently drops the ingredient.
+  assert.throws(
+    () => parseIngredientRows([{ item: "beef", quantity: "200", unit: "g" }]),
+    RecipeShapeError,
+  );
+});
+
+test("an empty item is rejected", () => {
+  assert.throws(() => parseIngredientRows([{ item: "   ", quantity: null }]), RecipeShapeError);
+});
+
+test("a non-integer fdc_id is rejected", () => {
+  assert.throws(
+    () => parseIngredientRows([{ item: "beef", quantity: 1, unit: "g", fdc_id: 1.5 }]),
+    RecipeShapeError,
+  );
+});
+
+test("a valid fdc_id survives", () => {
+  const rows = parseIngredientRows([
+    { item: "chicken breast", quantity: 302, unit: "g", fdc_id: 171477 },
+  ]);
+  assert.equal(rows![0].fdc_id, 171477);
+});
+
+test("null input means 'not provided', not 'empty list'", () => {
+  // The PATCH route distinguishes these: absent leaves the column alone, [] clears it.
+  assert.equal(parseIngredientRows(null), null);
+  assert.deepEqual(parseIngredientRows([]), []);
+});
+
+test("steps default their number to array position", () => {
+  const steps = parseStepRows([{ text: "Brown the beef" }, { text: "Add tomatoes" }]);
+  assert.deepEqual(
+    steps!.map((s) => s.step),
+    [1, 2],
+  );
+});
+
+test("an explicit step number wins over position", () => {
+  const steps = parseStepRows([{ step: 4, text: "Simmer" }]);
+  assert.equal(steps![0].step, 4);
+});
+
+test("blank tips are dropped rather than stored as empty strings", () => {
+  const steps = parseStepRows([{ text: "Simmer", tips: ["  ", "Stir occasionally"] }]);
+  assert.deepEqual(steps![0].tips, ["Stir occasionally"]);
+});
+
+test("a non-array payload is rejected", () => {
+  assert.throws(() => parseIngredientRows({ item: "beef" }), RecipeShapeError);
+});

--- a/web/src/app/(protected)/meals/page.tsx
+++ b/web/src/app/(protected)/meals/page.tsx
@@ -57,7 +57,9 @@ export default async function MealsPage() {
     userId
       ? supabase
           .from("recipes")
-          .select("id, name, cuisine, tags, ingredients, instructions")
+          .select(
+            "id, name, cuisine, tags, ingredients, instructions, ingredients_json, steps_json",
+          )
           .eq("user_id", userId)
           .order("name")
       : Promise.resolve({ data: [] }),
@@ -79,7 +81,8 @@ export default async function MealsPage() {
           .from("meal_plans")
           .select(
             "id, date, meal_type, portions, status, name, " +
-              "recipes(id, name, ingredients, instructions, calories, protein_g, carbs_g, fat_g, fiber_g, " +
+              "recipes(id, name, ingredients, instructions, ingredients_json, steps_json, " +
+              "calories, protein_g, carbs_g, fat_g, fiber_g, " +
               "typical_portions, macros_confidence, macros_computed_at), " +
               "cooks(id, name, portions, portions_remaining, calories, protein_g, carbs_g, fat_g, fiber_g)",
           )

--- a/web/src/app/api/recipes/[id]/route.ts
+++ b/web/src/app/api/recipes/[id]/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { resolveRecipeMacros } from "@/lib/nutrition/recipe-macros";
+import {
+  RecipeShapeError,
+  parseIngredientRows,
+  parseStepRows,
+} from "@/lib/nutrition/recipe-structured";
+
+/**
+ * Edit a recipe — the write side of the structured editor.
+ *
+ * Only the fields present in the body are touched, so the editor can save an ingredient list
+ * without having to round-trip (and risk clobbering) the name, tags or macros.
+ *
+ * Editing ingredients invalidates the macros by definition: the stored totals describe the OLD
+ * list. Leaving them in place would leave a plate of food wearing yesterday's numbers, which is
+ * the exact failure the macro audit trail exists to prevent — so a change to either ingredient
+ * column triggers a re-resolve, and if that fails the macros are cleared rather than left stale.
+ */
+export async function PATCH(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  let body: {
+    name?: string;
+    cuisine?: string | null;
+    ingredients?: string | null;
+    instructions?: string | null;
+    ingredients_json?: unknown;
+    steps_json?: unknown;
+    tags?: string[] | null;
+    typical_portions?: number | null;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const patch: Record<string, unknown> = {};
+  let touchedIngredients = false;
+
+  if ("name" in body) {
+    const name = body.name?.trim();
+    if (!name) return NextResponse.json({ error: "name cannot be empty" }, { status: 400 });
+    patch.name = name;
+  }
+  if ("cuisine" in body) patch.cuisine = body.cuisine?.trim() || null;
+  if ("tags" in body) patch.tags = body.tags ?? null;
+  if ("instructions" in body) patch.instructions = body.instructions?.trim() || null;
+  if ("typical_portions" in body) {
+    const tp = body.typical_portions;
+    if (tp != null && (!Number.isInteger(tp) || tp < 1))
+      return NextResponse.json(
+        { error: "typical_portions must be a positive integer or null" },
+        { status: 400 },
+      );
+    patch.typical_portions = tp ?? null;
+  }
+
+  try {
+    if ("ingredients_json" in body) {
+      patch.ingredients_json = parseIngredientRows(body.ingredients_json);
+      touchedIngredients = true;
+    }
+    if ("steps_json" in body) patch.steps_json = parseStepRows(body.steps_json);
+  } catch (e) {
+    if (e instanceof RecipeShapeError)
+      return NextResponse.json({ error: e.message }, { status: 400 });
+    throw e;
+  }
+  if ("ingredients" in body) {
+    patch.ingredients = body.ingredients?.trim() || null;
+    touchedIngredients = true;
+  }
+
+  if (!Object.keys(patch).length)
+    return NextResponse.json({ error: "nothing to update" }, { status: 400 });
+
+  try {
+    const db = createServiceClient();
+    const { data: recipe, error } = await db
+      .from("recipes")
+      .update(patch)
+      .eq("id", id)
+      .eq("user_id", user.id)
+      .select("id, name")
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    if (!recipe) return NextResponse.json({ error: "Recipe not found" }, { status: 404 });
+
+    let macrosResolved = false;
+    let macrosError: string | null = null;
+    if (touchedIngredients) {
+      try {
+        const resolved = await resolveRecipeMacros(db, user.id, id);
+        macrosResolved = resolved !== null;
+      } catch (e) {
+        macrosError = e instanceof Error ? e.message : "Could not resolve macros";
+        // Stale macros are worse than absent ones: absent shows "not resolved yet", stale shows a
+        // confident number for food that is no longer the recipe.
+        await db
+          .from("recipes")
+          .update({ macros_confidence: null, macros_computed_at: null })
+          .eq("id", id)
+          .eq("user_id", user.id);
+      }
+    }
+
+    return NextResponse.json({ recipe, macrosResolved, macrosError });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Failed to update recipe";
+    console.error("[PATCH /api/recipes/[id]]", err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/web/src/app/api/recipes/route.ts
+++ b/web/src/app/api/recipes/route.ts
@@ -2,6 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { createServiceClient } from "@/lib/supabase/service";
 import { resolveRecipeMacros } from "@/lib/nutrition/recipe-macros";
+import {
+  RecipeShapeError,
+  parseIngredientRows,
+  parseStepRows,
+} from "@/lib/nutrition/recipe-structured";
 
 /**
  * Create a recipe — and, when asked, resolve its macros and adopt a planned meal in one call.
@@ -27,6 +32,8 @@ export async function POST(req: NextRequest) {
     name?: string;
     ingredients?: string;
     instructions?: string;
+    ingredients_json?: unknown;
+    steps_json?: unknown;
     tags?: string[];
     resolve?: boolean;
     link_plan_id?: string;
@@ -41,6 +48,20 @@ export async function POST(req: NextRequest) {
   if (!name) return NextResponse.json({ error: "name is required" }, { status: 400 });
   const ingredients = body.ingredients?.trim() || null;
 
+  // Validated before the insert so a malformed payload is a 400 rather than a stored row that
+  // silently drops ingredients out of a macro total later.
+  let ingredientsJson, stepsJson;
+  try {
+    ingredientsJson = parseIngredientRows(body.ingredients_json);
+    stepsJson = parseStepRows(body.steps_json);
+  } catch (e) {
+    if (e instanceof RecipeShapeError)
+      return NextResponse.json({ error: e.message }, { status: 400 });
+    throw e;
+  }
+  // Structured counts as having something to resolve, same as ingredient text.
+  const resolvable = !!ingredientsJson?.length || !!ingredients;
+
   try {
     const db = createServiceClient();
     const { data: recipe, error } = await db
@@ -50,6 +71,8 @@ export async function POST(req: NextRequest) {
         name,
         ingredients,
         instructions: body.instructions?.trim() || null,
+        ingredients_json: ingredientsJson,
+        steps_json: stepsJson,
         tags: body.tags ?? null,
       })
       .select("id, name")
@@ -60,7 +83,7 @@ export async function POST(req: NextRequest) {
     // the recipe intact (text saved, macros null) rather than losing the user's input.
     let macrosResolved = false;
     let macrosError: string | null = null;
-    if (body.resolve && ingredients) {
+    if (body.resolve && resolvable) {
       try {
         await resolveRecipeMacros(db, user.id, recipe.id);
         macrosResolved = true;

--- a/web/src/components/meals/IngredientList.tsx
+++ b/web/src/components/meals/IngredientList.tsx
@@ -1,43 +1,86 @@
-import { parseIngredients } from "@/lib/units";
+import { formatIngredient, groupIngredients, parseIngredients } from "@/lib/units";
+import type { RecipeIngredient } from "@/lib/types";
 
 /**
- * A recipe's ingredients, one per line.
+ * A recipe's ingredients.
  *
- * Both places that show ingredients (the planned-meal detail and the recipe browser) used to render
- * the raw column into a single `<p>` with `white-space: pre-line`. That worked only as long as the
- * column held clean newline text — when a batch script wrote a JSON array into it, the page printed
- * the JSON. Parsing lives in `parseIngredients`, which also annotates units and rice `go`; this
- * component is the shared shell so the two call sites cannot drift apart again.
+ * Two storage shapes reach this component and it renders them identically:
+ *
+ *   `items`  structured `recipes.ingredients_json` — the one to write going forward.
+ *   `text`   legacy `recipes.ingredients` free text, one ingredient per line.
+ *
+ * Structured wins when present; text is the fallback while the backfill runs, so a half-converted
+ * library renders correctly throughout. Both paths go through the same annotators in units.ts
+ * (imperial equivalents, rice `go`), which is why a converted recipe looks the same as it did
+ * before conversion rather than quietly losing its unit hints.
+ *
+ * Text parsing lives in `parseIngredients`, which also recovers a JSON array written into the text
+ * column — a batch script did exactly that in August 2026 and the page printed the raw JSON at
+ * Jason. Keeping that recovery here means the next bad write still degrades to a correct list.
  *
  * A real `<ul>` rather than a text blob: an ingredient list IS a list, and screen readers announce
  * the item count, which a pre-line paragraph does not.
  */
 export function IngredientList({
+  items,
   text,
   tone = "default",
 }: {
-  text: string | null | undefined;
+  items?: RecipeIngredient[] | null;
+  text?: string | null;
   tone?: "default" | "muted";
 }) {
-  const items = parseIngredients(text);
-  if (!items.length) return null;
+  const color = tone === "muted" ? "var(--color-text-muted)" : "var(--color-text)";
 
+  if (items?.length) {
+    const groups = groupIngredients(items);
+    // A single ungrouped bucket is the common case — render a bare list with no heading rather
+    // than wrapping every flat recipe in a pointless section.
+    const flat = groups.length === 1 && groups[0].group === null;
+    return (
+      <div>
+        {groups.map((g, gi) => (
+          <div key={gi} style={{ marginTop: flat || gi === 0 ? 0 : "var(--space-2)" }}>
+            {g.group && <p style={groupHeadingStyle}>{g.group}</p>}
+            <ul style={{ ...listStyle, color }}>
+              {g.items.map((ing, i) => (
+                <li key={i} style={itemStyle}>
+                  {formatIngredient(ing)}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  const lines = parseIngredients(text);
+  if (!lines.length) return null;
   return (
-    <ul
-      style={{
-        fontSize: "var(--t-meta)",
-        color: tone === "muted" ? "var(--color-text-muted)" : "var(--color-text)",
-        lineHeight: 1.6,
-        listStyle: "disc outside",
-        paddingLeft: "1.1em",
-        margin: 0,
-      }}
-    >
-      {items.map((line, i) => (
-        <li key={i} style={{ marginBottom: "0.15em" }}>
+    <ul style={{ ...listStyle, color }}>
+      {lines.map((line, i) => (
+        <li key={i} style={itemStyle}>
           {line}
         </li>
       ))}
     </ul>
   );
 }
+
+const listStyle: React.CSSProperties = {
+  fontSize: "var(--t-meta)",
+  lineHeight: 1.6,
+  listStyle: "disc outside",
+  paddingLeft: "1.1em",
+  margin: 0,
+};
+
+const itemStyle: React.CSSProperties = { marginBottom: "0.15em" };
+
+const groupHeadingStyle: React.CSSProperties = {
+  fontSize: "var(--t-meta)",
+  fontWeight: 600,
+  color: "var(--color-text)",
+  margin: "0 0 0.2em",
+};

--- a/web/src/components/meals/KitchenPanel.tsx
+++ b/web/src/components/meals/KitchenPanel.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { PlannedMealDetail } from "./PlannedMealDetail";
+import type { RecipeIngredient, RecipeStep } from "@/lib/types";
 
 /**
  * The kitchen: what's planned today, and what's already in the fridge.
@@ -42,6 +43,8 @@ export interface KitchenPlannedMeal {
     name: string;
     ingredients: string | null;
     instructions: string | null;
+    ingredients_json: RecipeIngredient[] | null;
+    steps_json: RecipeStep[] | null;
     calories: number | null;
     protein_g: number | null;
     carbs_g: number | null;

--- a/web/src/components/meals/MealsClient.tsx
+++ b/web/src/components/meals/MealsClient.tsx
@@ -19,6 +19,7 @@ import { ChartFrame, TrendLine } from "@/components/charts/primitives";
 import { formatDate } from "@/lib/chart-utils";
 import { todayString } from "@/lib/timezone";
 import { IngredientList } from "./IngredientList";
+import type { RecipeIngredient, RecipeStep } from "@/lib/types";
 
 const FoodPhotoAnalyzer = dynamic(() => import("@/app/(protected)/meals/FoodPhotoAnalyzer"), {
   ssr: false,
@@ -51,6 +52,8 @@ export interface RecipeRow {
   tags: string[] | null;
   ingredients: string | null;
   instructions: string | null;
+  ingredients_json: RecipeIngredient[] | null;
+  steps_json: RecipeStep[] | null;
 }
 
 export interface MacroGoals {
@@ -1223,7 +1226,11 @@ function RecipesTab({ recipes }: { recipes: RecipeRow[] }) {
                   >
                     {r.ingredients && (
                       <div style={{ marginBottom: "var(--space-3)" }}>
-                        <IngredientList text={r.ingredients} tone="muted" />
+                        <IngredientList
+                          items={r.ingredients_json}
+                          text={r.ingredients}
+                          tone="muted"
+                        />
                       </div>
                     )}
 

--- a/web/src/components/meals/PlannedMealDetail.tsx
+++ b/web/src/components/meals/PlannedMealDetail.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import type { KitchenPlannedMeal } from "./KitchenPanel";
 import { IngredientList } from "./IngredientList";
+import { StepList } from "./StepList";
+import { RecipeEditor } from "./RecipeEditor";
 
 /**
  * The click-in view for a planned meal: what's in it, and what it costs you.
@@ -52,6 +54,7 @@ function MacroLine({ m, label, portions }: { m: Macros; label: string; portions?
 
 export function PlannedMealDetail({ meal }: { meal: KitchenPlannedMeal }) {
   const router = useRouter();
+  const [editing, setEditing] = useState(false);
   const recipe = meal.recipes;
   const cook = meal.cooks;
 
@@ -59,20 +62,34 @@ export function PlannedMealDetail({ meal }: { meal: KitchenPlannedMeal }) {
   if (recipe) {
     const hasMacros = !!recipe.macros_computed_at;
     const typ = recipe.typical_portions ?? null;
+    if (editing) {
+      return (
+        <RecipeEditor
+          recipe={recipe}
+          onCancel={() => setEditing(false)}
+          onSaved={() => {
+            setEditing(false);
+            // Macros are re-resolved server-side on save, so the numbers on screen are stale
+            // until the server components refetch.
+            router.refresh();
+          }}
+        />
+      );
+    }
     return (
       <div style={detailBoxStyle}>
-        {recipe.ingredients ? (
+        {recipe.ingredients_json?.length || recipe.ingredients ? (
           <div style={{ marginBottom: "var(--space-3)" }}>
             <p style={sectionLabelStyle}>Ingredients</p>
-            <IngredientList text={recipe.ingredients} />
+            <IngredientList items={recipe.ingredients_json} text={recipe.ingredients} />
           </div>
         ) : (
           <p style={mutedStyle}>No ingredients recorded for this recipe yet.</p>
         )}
-        {recipe.instructions && (
+        {(recipe.steps_json?.length || recipe.instructions) && (
           <div style={{ marginBottom: hasMacros ? "var(--space-3)" : 0 }}>
             <p style={sectionLabelStyle}>How to make it</p>
-            <p style={ingredientsStyle}>{recipe.instructions}</p>
+            <StepList steps={recipe.steps_json} text={recipe.instructions} />
           </div>
         )}
         {hasMacros ? (
@@ -88,6 +105,9 @@ export function PlannedMealDetail({ meal }: { meal: KitchenPlannedMeal }) {
         ) : (
           <p style={mutedStyle}>Macros not resolved yet for this recipe.</p>
         )}
+        <button type="button" onClick={() => setEditing(true)} style={editLinkStyle}>
+          {recipe.ingredients_json?.length ? "Edit recipe" : "Edit — add amounts"}
+        </button>
       </div>
     );
   }
@@ -284,3 +304,15 @@ function saveButtonStyle(pending: boolean): React.CSSProperties {
     opacity: pending ? 0.5 : 1,
   };
 }
+
+const editLinkStyle: React.CSSProperties = {
+  display: "inline-block",
+  marginTop: "var(--space-3)",
+  fontSize: "var(--t-meta)",
+  color: "var(--color-text-muted)",
+  background: "transparent",
+  border: "none",
+  padding: 0,
+  textDecoration: "underline",
+  cursor: "pointer",
+};

--- a/web/src/components/meals/RecipeEditor.tsx
+++ b/web/src/components/meals/RecipeEditor.tsx
@@ -320,8 +320,8 @@ const inputStyle: React.CSSProperties = {
   fontSize: "var(--t-meta)",
   padding: "0.35em 0.5em",
   border: "1px solid var(--rule-soft)",
-  borderRadius: "var(--radius-sm, 4px)",
-  background: "var(--color-surface, transparent)",
+  borderRadius: "var(--r-1)",
+  background: "var(--color-surface)",
   color: "var(--color-text)",
 };
 
@@ -331,7 +331,7 @@ const iconBtnStyle: React.CSSProperties = {
   justifyContent: "center",
   padding: "0.3em",
   border: "1px solid var(--rule-soft)",
-  borderRadius: "var(--radius-sm, 4px)",
+  borderRadius: "var(--r-1)",
   background: "transparent",
   color: "var(--color-text-muted)",
   cursor: "pointer",
@@ -357,7 +357,7 @@ const stepNumStyle: React.CSSProperties = {
 
 const errorStyle: React.CSSProperties = {
   fontSize: "var(--t-meta)",
-  color: "var(--color-danger, #c0392b)",
+  color: "var(--color-danger)",
   marginTop: "var(--space-2)",
 };
 
@@ -371,7 +371,7 @@ const warnStyle: React.CSSProperties = {
 const saveStyle = (busy: boolean): React.CSSProperties => ({
   fontSize: "var(--t-meta)",
   padding: "0.45em 0.9em",
-  borderRadius: "var(--radius-sm, 4px)",
+  borderRadius: "var(--r-1)",
   border: "1px solid var(--rule-soft)",
   background: "var(--color-text)",
   color: "var(--color-bg)",
@@ -382,7 +382,7 @@ const saveStyle = (busy: boolean): React.CSSProperties => ({
 const cancelStyle: React.CSSProperties = {
   fontSize: "var(--t-meta)",
   padding: "0.45em 0.9em",
-  borderRadius: "var(--radius-sm, 4px)",
+  borderRadius: "var(--r-1)",
   border: "1px solid var(--rule-soft)",
   background: "transparent",
   color: "var(--color-text-muted)",

--- a/web/src/components/meals/RecipeEditor.tsx
+++ b/web/src/components/meals/RecipeEditor.tsx
@@ -1,0 +1,390 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronUp, Plus, X } from "lucide-react";
+import type { RecipeIngredient, RecipeStep } from "@/lib/types";
+import { splitIngredientLines } from "@/lib/units";
+import { lexQuantity } from "@/lib/nutrition/quantity";
+
+/**
+ * Row-based editor for a recipe's ingredients and method.
+ *
+ * WHY ROWS AND NOT A TEXTAREA
+ *
+ * The amount is the whole point. Prose ingredients get routed through a local model to recover
+ * {food, amount} pairs, and that model measurably alters the numbers it is asked to repeat — a
+ * large egg came back as 105 g against a real ~50 g. Typing 105 into a number input cannot be
+ * misread. Everything downstream (`estimateFromStructured`) then skips the model entirely.
+ *
+ * SEEDING FROM LEGACY TEXT
+ *
+ * ~65 recipes hold free text. Opening the editor on one runs each line through `lexQuantity` — the
+ * same lexer the macro pipeline already trusts — to split "255 g chicken breast" into 255 / g /
+ * "chicken breast". Lines it cannot read keep the whole line as the item with a null amount, which
+ * renders as an explicit "no amount" warning rather than a silent zero. This matters: a row saved
+ * with `quantity: null` is EXCLUDED from macros by design, so a bad seed that looked fine would
+ * quietly delete an ingredient from the total.
+ *
+ * REORDERING IS BUTTONS, NOT DRAG
+ *
+ * No drag-and-drop dependency exists in this project and hand-rolled DnD is not keyboard
+ * operable. Up/down controls reorder from the keyboard, work on touch without a long-press, and
+ * cost nothing to maintain. Step numbers are renumbered on save so `step` always matches order.
+ */
+export function RecipeEditor({
+  recipe,
+  onSaved,
+  onCancel,
+}: {
+  recipe: {
+    id: string;
+    name: string;
+    ingredients: string | null;
+    instructions: string | null;
+    ingredients_json: RecipeIngredient[] | null;
+    steps_json: RecipeStep[] | null;
+  };
+  onSaved?: () => void;
+  onCancel?: () => void;
+}) {
+  const [rows, setRows] = useState<RecipeIngredient[]>(() =>
+    recipe.ingredients_json?.length ? recipe.ingredients_json : seedRows(recipe.ingredients),
+  );
+  const [steps, setSteps] = useState<RecipeStep[]>(() =>
+    recipe.steps_json?.length ? recipe.steps_json : seedSteps(recipe.instructions),
+  );
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [warn, setWarn] = useState<string | null>(null);
+
+  const missingAmounts = rows.filter((r) => r.item.trim() && r.quantity == null).length;
+
+  function patchRow(i: number, patch: Partial<RecipeIngredient>) {
+    setRows((rs) => rs.map((r, j) => (j === i ? { ...r, ...patch } : r)));
+  }
+  function move<T>(list: T[], i: number, dir: -1 | 1): T[] {
+    const j = i + dir;
+    if (j < 0 || j >= list.length) return list;
+    const next = [...list];
+    [next[i], next[j]] = [next[j], next[i]];
+    return next;
+  }
+
+  async function save() {
+    setBusy(true);
+    setError(null);
+    setWarn(null);
+    // Blank rows are dropped rather than rejected — an empty trailing row is how people leave a
+    // form, not an error worth blocking a save over.
+    const cleanRows = rows
+      .filter((r) => r.item.trim())
+      .map((r) => ({
+        ...r,
+        item: r.item.trim(),
+        // The API rejects a quantity with no unit, because grams cannot be derived from a bare
+        // number. Default to grams rather than bounce the user back for the common case.
+        unit: r.quantity != null ? r.unit?.trim() || "g" : null,
+      }));
+    const cleanSteps = steps
+      .filter((s) => s.text.trim())
+      .map((s, i) => ({ ...s, step: i + 1, text: s.text.trim() }));
+
+    try {
+      const res = await fetch(`/api/recipes/${recipe.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ingredients_json: cleanRows,
+          steps_json: cleanSteps.length ? cleanSteps : null,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json.error ?? "Couldn't save");
+        return;
+      }
+      if (json.macrosError) setWarn(`Saved, but macros didn't resolve: ${json.macrosError}`);
+      onSaved?.();
+    } catch {
+      setError("Couldn't save");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div style={boxStyle}>
+      <p style={labelStyle}>Ingredients</p>
+      {rows.map((r, i) => (
+        <div key={i} style={rowStyle}>
+          <input
+            aria-label={`Amount for ingredient ${i + 1}`}
+            value={r.quantity ?? ""}
+            onChange={(e) =>
+              patchRow(i, {
+                quantity: e.target.value === "" ? null : Number(e.target.value),
+              })
+            }
+            inputMode="decimal"
+            type="number"
+            min="0"
+            step="any"
+            placeholder="qty"
+            style={{ ...inputStyle, width: "4.5rem" }}
+          />
+          <input
+            aria-label={`Unit for ingredient ${i + 1}`}
+            value={r.unit ?? ""}
+            onChange={(e) => patchRow(i, { unit: e.target.value || null })}
+            placeholder="g"
+            style={{ ...inputStyle, width: "3.5rem" }}
+          />
+          <input
+            aria-label={`Ingredient ${i + 1}`}
+            value={r.item}
+            onChange={(e) => patchRow(i, { item: e.target.value })}
+            placeholder="ground beef, 93/7"
+            style={{ ...inputStyle, flex: 1, minWidth: "7rem" }}
+          />
+          <input
+            aria-label={`Prep for ingredient ${i + 1}`}
+            value={r.prep ?? ""}
+            onChange={(e) => patchRow(i, { prep: e.target.value || null })}
+            placeholder="raw / cooked"
+            style={{ ...inputStyle, width: "6.5rem" }}
+          />
+          <input
+            aria-label={`USDA id for ingredient ${i + 1}`}
+            value={r.fdc_id ?? ""}
+            onChange={(e) =>
+              patchRow(i, { fdc_id: e.target.value === "" ? null : Number(e.target.value) })
+            }
+            type="number"
+            placeholder="fdc id"
+            title="Pin the USDA FoodData Central record so re-resolving can't drift"
+            style={{ ...inputStyle, width: "5.5rem" }}
+          />
+          <IconBtn label="Move up" onClick={() => setRows((rs) => move(rs, i, -1))}>
+            <ChevronUp size={13} />
+          </IconBtn>
+          <IconBtn label="Move down" onClick={() => setRows((rs) => move(rs, i, 1))}>
+            <ChevronDown size={13} />
+          </IconBtn>
+          <IconBtn
+            label={`Remove ingredient ${i + 1}`}
+            onClick={() => setRows((rs) => rs.filter((_, j) => j !== i))}
+          >
+            <X size={13} />
+          </IconBtn>
+        </div>
+      ))}
+      <button
+        type="button"
+        style={addBtnStyle}
+        onClick={() => setRows((rs) => [...rs, { item: "", quantity: null, unit: "g" }])}
+      >
+        <Plus size={12} /> Add ingredient
+      </button>
+
+      {missingAmounts > 0 && (
+        <p style={warnStyle}>
+          {missingAmounts} ingredient{missingAmounts === 1 ? "" : "s"} with no amount. Those are
+          treated as &ldquo;to taste&rdquo; and left out of the macros — fill the amount in if that
+          isn&rsquo;t what you meant.
+        </p>
+      )}
+
+      <p style={{ ...labelStyle, marginTop: "var(--space-4)" }}>How to make it</p>
+      {steps.map((s, i) => (
+        <div key={i} style={rowStyle}>
+          <span style={stepNumStyle}>{i + 1}.</span>
+          <textarea
+            aria-label={`Step ${i + 1}`}
+            value={s.text}
+            onChange={(e) =>
+              setSteps((ss) => ss.map((x, j) => (j === i ? { ...x, text: e.target.value } : x)))
+            }
+            rows={2}
+            placeholder="Brown the beef, then add the aromatics."
+            style={{ ...inputStyle, flex: 1, resize: "vertical", fontFamily: "inherit" }}
+          />
+          <IconBtn label="Move up" onClick={() => setSteps((ss) => move(ss, i, -1))}>
+            <ChevronUp size={13} />
+          </IconBtn>
+          <IconBtn label="Move down" onClick={() => setSteps((ss) => move(ss, i, 1))}>
+            <ChevronDown size={13} />
+          </IconBtn>
+          <IconBtn
+            label={`Remove step ${i + 1}`}
+            onClick={() => setSteps((ss) => ss.filter((_, j) => j !== i))}
+          >
+            <X size={13} />
+          </IconBtn>
+        </div>
+      ))}
+      <button
+        type="button"
+        style={addBtnStyle}
+        onClick={() => setSteps((ss) => [...ss, { step: ss.length + 1, text: "" }])}
+      >
+        <Plus size={12} /> Add step
+      </button>
+
+      {error && <p style={errorStyle}>{error}</p>}
+      {warn && <p style={warnStyle}>{warn}</p>}
+      <div style={{ display: "flex", gap: "var(--space-2)", marginTop: "var(--space-3)" }}>
+        <button type="button" onClick={save} disabled={busy} style={saveStyle(busy)}>
+          {busy ? "Saving…" : "Save & re-resolve macros"}
+        </button>
+        {onCancel && (
+          <button type="button" onClick={onCancel} style={cancelStyle}>
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Legacy text -> editable rows, using the same lexer the macro pipeline uses.
+ *
+ * A line the lexer cannot read keeps its full text as the item and a null amount, which surfaces
+ * in the "no amount" warning above. That is deliberate: silently inventing an amount here would
+ * write a number Jason never typed into a column the resolver treats as authoritative.
+ */
+function seedRows(text: string | null): RecipeIngredient[] {
+  const lines = splitIngredientLines(text);
+  if (!lines.length) return [{ item: "", quantity: null, unit: "g" }];
+  return lines.map((line) => {
+    const lexed = lexQuantity(line);
+    if (!lexed) return { item: line, quantity: null, unit: null };
+    const at = line.indexOf(lexed.source);
+    const rest = (at < 0 ? line : line.slice(at + lexed.source.length))
+      .trim()
+      .replace(/^(of\s+|[,\-–—]\s*)/i, "");
+    return { item: rest || line, quantity: lexed.qty, unit: lexed.unit };
+  });
+}
+
+/** Legacy instructions -> steps. Split on blank lines first, then newlines. */
+function seedSteps(text: string | null): RecipeStep[] {
+  const t = (text ?? "").trim();
+  if (!t) return [];
+  const chunks = (t.includes("\n\n") ? t.split(/\n{2,}/) : t.split("\n"))
+    .map((c) => c.trim().replace(/^\d+[.)]\s*/, ""))
+    .filter(Boolean);
+  return chunks.map((text, i) => ({ step: i + 1, text }));
+}
+
+function IconBtn({
+  label,
+  onClick,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button type="button" aria-label={label} title={label} onClick={onClick} style={iconBtnStyle}>
+      {children}
+    </button>
+  );
+}
+
+const boxStyle: React.CSSProperties = {
+  padding: "var(--space-3) 0",
+  borderTop: "1px solid var(--rule-soft)",
+};
+
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: "var(--t-micro)",
+  fontWeight: 600,
+  color: "var(--color-text-muted)",
+  textTransform: "uppercase",
+  letterSpacing: "0.04em",
+  marginBottom: "var(--space-2)",
+};
+
+const rowStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  flexWrap: "wrap",
+  gap: "var(--space-1)",
+  marginBottom: "var(--space-1)",
+};
+
+const inputStyle: React.CSSProperties = {
+  fontSize: "var(--t-meta)",
+  padding: "0.35em 0.5em",
+  border: "1px solid var(--rule-soft)",
+  borderRadius: "var(--radius-sm, 4px)",
+  background: "var(--color-surface, transparent)",
+  color: "var(--color-text)",
+};
+
+const iconBtnStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "0.3em",
+  border: "1px solid var(--rule-soft)",
+  borderRadius: "var(--radius-sm, 4px)",
+  background: "transparent",
+  color: "var(--color-text-muted)",
+  cursor: "pointer",
+};
+
+const addBtnStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "0.3em",
+  fontSize: "var(--t-meta)",
+  color: "var(--color-text-muted)",
+  background: "transparent",
+  border: "none",
+  cursor: "pointer",
+  padding: "var(--space-1) 0",
+};
+
+const stepNumStyle: React.CSSProperties = {
+  fontSize: "var(--t-meta)",
+  color: "var(--color-text-muted)",
+  width: "1.2rem",
+};
+
+const errorStyle: React.CSSProperties = {
+  fontSize: "var(--t-meta)",
+  color: "var(--color-danger, #c0392b)",
+  marginTop: "var(--space-2)",
+};
+
+const warnStyle: React.CSSProperties = {
+  fontSize: "var(--t-meta)",
+  color: "var(--color-text-muted)",
+  marginTop: "var(--space-2)",
+  lineHeight: 1.5,
+};
+
+const saveStyle = (busy: boolean): React.CSSProperties => ({
+  fontSize: "var(--t-meta)",
+  padding: "0.45em 0.9em",
+  borderRadius: "var(--radius-sm, 4px)",
+  border: "1px solid var(--rule-soft)",
+  background: "var(--color-text)",
+  color: "var(--color-bg)",
+  opacity: busy ? 0.6 : 1,
+  cursor: busy ? "default" : "pointer",
+});
+
+const cancelStyle: React.CSSProperties = {
+  fontSize: "var(--t-meta)",
+  padding: "0.45em 0.9em",
+  borderRadius: "var(--radius-sm, 4px)",
+  border: "1px solid var(--rule-soft)",
+  background: "transparent",
+  color: "var(--color-text-muted)",
+  cursor: "pointer",
+};

--- a/web/src/components/meals/StepList.tsx
+++ b/web/src/components/meals/StepList.tsx
@@ -1,0 +1,66 @@
+import type { RecipeStep } from "@/lib/types";
+
+/**
+ * A recipe's method, as numbered steps.
+ *
+ * The counterpart to IngredientList and the same contract: structured `steps_json` wins, the legacy
+ * `instructions` free-text column is the fallback while the backfill runs.
+ *
+ * Numbering comes from `step`, not array position. A stored order that disagrees with the array is
+ * a data bug worth seeing rather than papering over — and it means a caller can hand this component
+ * a filtered subset without the numbers silently renumbering themselves.
+ *
+ * `tips` render under their step in muted text, mirroring how WorkoutExercise.tips already read on
+ * the fitness side, so the two planners look like one product.
+ */
+export function StepList({ steps, text }: { steps?: RecipeStep[] | null; text?: string | null }) {
+  if (steps?.length) {
+    const ordered = [...steps].sort((a, b) => a.step - b.step);
+    return (
+      <ol style={listStyle}>
+        {ordered.map((s, i) => (
+          <li key={i} value={s.step} style={{ marginBottom: "0.35em" }}>
+            <span>{s.text}</span>
+            {s.duration_mins != null && <span style={durationStyle}> · {s.duration_mins} min</span>}
+            {s.tips?.length ? (
+              <ul style={tipsStyle}>
+                {s.tips.map((t, ti) => (
+                  <li key={ti}>{t}</li>
+                ))}
+              </ul>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    );
+  }
+
+  const trimmed = (text ?? "").trim();
+  if (!trimmed) return null;
+  return <p style={legacyStyle}>{trimmed}</p>;
+}
+
+const listStyle: React.CSSProperties = {
+  fontSize: "var(--t-meta)",
+  color: "var(--color-text)",
+  lineHeight: 1.6,
+  paddingLeft: "1.3em",
+  margin: 0,
+};
+
+const durationStyle: React.CSSProperties = { color: "var(--color-text-muted)" };
+
+const tipsStyle: React.CSSProperties = {
+  listStyle: "disc outside",
+  paddingLeft: "1.1em",
+  margin: "0.2em 0 0",
+  color: "var(--color-text-muted)",
+};
+
+const legacyStyle: React.CSSProperties = {
+  fontSize: "var(--t-meta)",
+  color: "var(--color-text)",
+  lineHeight: 1.6,
+  whiteSpace: "pre-line",
+  margin: 0,
+};

--- a/web/src/lib/nutrition/estimate.ts
+++ b/web/src/lib/nutrition/estimate.ts
@@ -70,18 +70,6 @@ function isNutritionallyEmpty(m: {
 }
 
 async function estimateOne(food: ParsedFood, context?: string): Promise<EstimatedItem | null> {
-  const searched = await searchFoods(food.query, 5);
-
-  // Drop candidates that are not plausibly the food we asked for. USDA's search sometimes
-  // returns nothing relevant, and the model then picks the least-bad of a bad set — "salt"
-  // became "Syrups, table blends, pancake", which puts 20g of SYRUP into a zero-calorie
-  // ingredient. No prompt fixes that: the right answer was never in the list.
-  //
-  // Matching NOTHING is a better outcome than matching syrup. Salt genuinely has no macros;
-  // a bogus match invents some. The caller reports what went unmatched.
-  const candidates = searched.filter((c) => isPlausibleMatch(food.query, c.description));
-  if (candidates.length === 0) return null;
-
   // THE QUANTITY COMES FROM THE TEXT, NOT THE MODEL.
   //
   // The model is asked to echo the fragment it read (`source`) and we lex the number out of
@@ -93,10 +81,51 @@ async function estimateOne(food: ParsedFood, context?: string): Promise<Estimate
   // When the source states nothing ("Green beans"), the model's qty/unit is an invention.
   // We still estimate — a rough total beats no total — but the item is flagged unquantified
   // and the confidence below is capped accordingly.
-  const lexed = food.source ? lexQuantity(food.source) : null;
+  //
+  // A STRUCTURED ingredient never went through the model at all: its qty/unit were read
+  // straight out of `recipes.ingredients_json`. There is no prose to lex and nothing to
+  // second-guess, so it is quantified by construction.
+  const lexed = !food.structured && food.source ? lexQuantity(food.source) : null;
   const qty = lexed ? lexed.qty : food.qty;
   const unit = lexed ? lexed.unit : food.unit;
-  const quantified = lexed !== null;
+  const quantified = lexed !== null || food.structured === true;
+
+  // Pinned record: skip the search AND the model's pick. Deliberately before searchFoods so a
+  // pinned ingredient costs one USDA fetch and zero model calls.
+  if (food.fdcId != null) {
+    const pinned = await getFood(food.fdcId).catch(() => null);
+    if (pinned && !isNutritionallyEmpty(pinned.per100g)) {
+      const { grams, exact, basis } = gramsFor(qty, unit, pinned.portions);
+      return {
+        input: (food.source ?? `${qty} ${unit} ${food.query}`).trim(),
+        matched: pinned.description,
+        fdcId: pinned.fdcId,
+        qty,
+        unit,
+        grams: Math.round(grams),
+        exactPortion: exact,
+        quantified,
+        basis: quantified
+          ? `${basis} — pinned fdcId`
+          : `${basis} — NO QUANTITY STATED, amount is a guess`,
+        macros: macrosForGrams(pinned.per100g, grams),
+      };
+    }
+    // A pinned id that 404s or carries no nutrition falls through to the normal search rather
+    // than failing the ingredient — a stale pin should degrade, not break the recipe.
+  }
+
+  const searched = await searchFoods(food.query, 5);
+
+  // Drop candidates that are not plausibly the food we asked for. USDA's search sometimes
+  // returns nothing relevant, and the model then picks the least-bad of a bad set — "salt"
+  // became "Syrups, table blends, pancake", which puts 20g of SYRUP into a zero-calorie
+  // ingredient. No prompt fixes that: the right answer was never in the list.
+  //
+  // Matching NOTHING is a better outcome than matching syrup. Salt genuinely has no macros;
+  // a bogus match invents some. The caller reports what went unmatched.
+  const candidates = searched.filter((c) => isPlausibleMatch(food.query, c.description));
+  if (candidates.length === 0) return null;
 
   // Never blind-trust candidates[0] — USDA's top hit for "chicken breast, cooked"
   // is breaded microwaved tenders (252 kcal vs ~165 for plain).
@@ -204,6 +233,34 @@ export async function estimateFromText(
     .filter((_, i) => settled[i] === null)
     .map((f) => f.source?.trim() || f.query);
   return assemble(items, label?.trim() || text.trim(), unmatched);
+}
+
+/**
+ * Structured ingredients — the model-free path.
+ *
+ * `estimateFromText` exists to recover {food, amount} pairs from prose, and everything downstream
+ * of it is damage control for a model that alters numbers (see parse.ts: a large egg read as 105 g
+ * against a real ~50 g). `recipes.ingredients_json` already holds those pairs as data, so this
+ * skips `parseFoodText` outright: no Ollama call, no lexer, no chance of a rounded amount.
+ *
+ * Rows with no quantity ("salt, to taste") are dropped rather than guessed at. In the prose path an
+ * amount-less ingredient still gets an invented serving and caps the confidence; here the author
+ * has explicitly said there is no amount, which is a statement, not an omission. Returning them as
+ * `unmatched` would also be wrong — they matched fine, they just have no mass. They are reported
+ * separately by the caller.
+ */
+export async function estimateFromStructured(
+  foods: ParsedFood[],
+  label: string,
+): Promise<MealEstimate> {
+  // No `context` argument: it exists to help the model disambiguate a USDA pick, and a structured
+  // row either pins its record or carries a prep-qualified name that already does that job.
+  const settled = await Promise.all(foods.map((f) => estimateOne(f).catch(() => null)));
+  const items = settled.filter((i): i is EstimatedItem => i !== null);
+  const unmatched = foods
+    .filter((_, i) => settled[i] === null)
+    .map((f) => f.source?.trim() || f.query);
+  return assemble(items, label.trim(), unmatched);
 }
 
 /**

--- a/web/src/lib/nutrition/parse.ts
+++ b/web/src/lib/nutrition/parse.ts
@@ -33,6 +33,20 @@ export type ParsedFood = {
    * not the model's recollection of it.
    */
   source?: string;
+  /**
+   * Set when `qty`/`unit` came from structured data (`recipes.ingredients_json`) rather than from
+   * prose. The whole lexer exists to recover a number the model may have altered; when the number
+   * was never routed through a model there is nothing to recover, so the lexer is skipped and the
+   * amount counts as quantified rather than guessed.
+   */
+  structured?: boolean;
+  /**
+   * A pinned USDA FoodData Central id. Present only on structured ingredients. Skips BOTH the
+   * search and the model's selection step, which is what makes re-resolution deterministic —
+   * USDA's top hit for "chicken breast, cooked" is breaded microwaved tenders (252 kcal vs ~165),
+   * so leaving that choice to a search means the same recipe can drift month to month.
+   */
+  fdcId?: number | null;
 };
 
 function ollamaUrl(): string {

--- a/web/src/lib/nutrition/recipe-macros.ts
+++ b/web/src/lib/nutrition/recipe-macros.ts
@@ -1,5 +1,49 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { estimateFromText } from "./estimate";
+import { estimateFromStructured, estimateFromText } from "./estimate";
+import type { ParsedFood } from "./parse";
+import type { RecipeIngredient } from "../types";
+
+/**
+ * Narrow whatever came back from the jsonb column into ingredient rows.
+ *
+ * The column is checked to be a JSON array at the database level but nothing constrains its
+ * ELEMENTS, and this value feeds the macro pipeline — so a malformed row must be dropped here
+ * rather than reaching USDA as `undefined`. Anything without a usable `item` string is discarded.
+ */
+function asIngredientRows(raw: unknown): RecipeIngredient[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((r): r is RecipeIngredient => {
+    if (!r || typeof r !== "object") return false;
+    const item = (r as RecipeIngredient).item;
+    return typeof item === "string" && item.trim().length > 0;
+  });
+}
+
+/**
+ * Structured rows -> the shape estimateOne consumes.
+ *
+ * Rows with no quantity are dropped, not guessed at: "salt, to taste" is an author stating there
+ * is no amount, which is different from prose that merely failed to mention one. Feeding it
+ * forward would invent a serving and drag the confidence down for an ingredient that genuinely
+ * contributes nothing.
+ *
+ * `prep` is folded into the query because it changes which USDA record is correct — "cooked" vs
+ * "raw" chicken is a ~40% difference in calories per 100 g, and a pinned fdc_id is the only other
+ * way to express that.
+ */
+function toParsedFoods(rows: RecipeIngredient[]): ParsedFood[] {
+  return rows
+    .filter((r) => typeof r.quantity === "number" && Number.isFinite(r.quantity) && r.quantity > 0)
+    .map((r) => ({
+      query: r.prep ? `${r.item}, ${r.prep}` : r.item,
+      qty: r.quantity as number,
+      unit: r.unit?.trim() || "g",
+      // The audit trail should read like the plate, not like a database row.
+      source: `${r.quantity} ${r.unit ?? ""} ${r.item}`.replace(/\s+/g, " ").trim(),
+      structured: true,
+      fdcId: r.fdc_id ?? null,
+    }));
+}
 
 /**
  * Resolve a recipe's ingredient list into measured macros.
@@ -78,7 +122,7 @@ export async function resolveRecipeMacros(
 ): Promise<RecipeMacros | null> {
   const { data: recipe, error } = await db
     .from("recipes")
-    .select("id, name, ingredients, typical_portions")
+    .select("id, name, ingredients, ingredients_json, typical_portions")
     .eq("id", recipeId)
     .eq("user_id", userId)
     .maybeSingle();
@@ -86,16 +130,27 @@ export async function resolveRecipeMacros(
   if (error) throw new Error(`recipe load failed: ${error.message}`);
   if (!recipe) throw new Error("Recipe not found");
 
+  const structured = asIngredientRows(recipe.ingredients_json);
   const ingredients = (recipe.ingredients as string | null)?.trim();
-  if (!ingredients) return null;
+  if (!structured.length && !ingredients) return null;
 
-  // The recipe NAME is passed as the label, not as food to parse — naming the dish helps
-  // the identifier disambiguate ("Greek Salmon" -> salmon, not a generic fish), while the
-  // ingredient list remains the only thing quantities are read from.
-  // "recipe" mode, NOT the meal prompt. A recipe's ingredients are raw and dry; the meal
-  // prompt's examples all say "cooked", and fed a recipe it rewrote "2 cups dry brown rice"
-  // to cooked rice — ~90g of carbs instead of ~280g, reported as HIGH confidence.
-  const estimate = await estimateFromText(ingredients, recipe.name as string, "recipe");
+  // STRUCTURED FIRST — and it is not merely a nicer input format.
+  //
+  // The prose path spends a model call recovering {food, amount} pairs out of a sentence, then
+  // re-lexes every number back out of the source fragment because the model alters the ones it is
+  // asked to repeat (parse.ts: a large egg read as 105 g against a real ~50 g). ingredients_json
+  // already holds those pairs, so none of that machinery runs: no Ollama, no lexer, no rounding.
+  // With fdc_id pinned, USDA search and the model's record selection are skipped too, which is
+  // what makes a re-resolve next month return the same numbers as today.
+  const estimate = structured.length
+    ? await estimateFromStructured(toParsedFoods(structured), recipe.name as string)
+    : // The recipe NAME is passed as the label, not as food to parse — naming the dish helps
+      // the identifier disambiguate ("Greek Salmon" -> salmon, not a generic fish), while the
+      // ingredient list remains the only thing quantities are read from.
+      // "recipe" mode, NOT the meal prompt. A recipe's ingredients are raw and dry; the meal
+      // prompt's examples all say "cooked", and fed a recipe it rewrote "2 cups dry brown rice"
+      // to cooked rice — ~90g of carbs instead of ~280g, reported as HIGH confidence.
+      await estimateFromText(ingredients as string, recipe.name as string, "recipe");
 
   const total: RecipeMacroTotals = {
     calories: Math.round(estimate.totals.calories),
@@ -134,6 +189,23 @@ export async function resolveRecipeMacros(
   const incomplete = unquantified.length > 0 || estimate.unmatched.length > 0;
   if (incomplete) total.confidence = "low";
 
+  // DELIBERATELY AMOUNT-LESS ROWS ARE NOT "UNQUANTIFIED", and conflating the two would be a
+  // regression in both directions.
+  //
+  //   unquantified — an amount was needed, none was found, so one was INVENTED. The total is soft
+  //                  and confidence must drop.
+  //   amountless   — the author wrote `quantity: null`. "Salt, to taste" has no mass to add and
+  //                  contributes nothing; excluding it leaves the total exactly right.
+  //
+  // Capping confidence on the second would make every recipe containing salt read "low" and train
+  // Jason to ignore the badge. Dropping them without a trace would hide a genuinely forgotten
+  // amount. So: persisted for audit, no effect on confidence.
+  const amountless = structured
+    .filter(
+      (r) => typeof r.quantity !== "number" || !Number.isFinite(r.quantity) || r.quantity <= 0,
+    )
+    .map((r) => (r.prep ? `${r.item}, ${r.prep}` : r.item));
+
   const { error: writeErr } = await db
     .from("recipes")
     .update({
@@ -151,6 +223,11 @@ export async function resolveRecipeMacros(
         macro_notes: total.notes,
         macro_unmatched: estimate.unmatched,
         macro_unquantified: unquantified,
+        // Structured rows the author marked as having no amount. Empty on the prose path.
+        macro_amountless: amountless,
+        // Which path produced these numbers, so a re-resolve that changes a total can be
+        // attributed rather than guessed at.
+        macro_source: structured.length ? "structured" : "text",
       },
     })
     .eq("id", recipeId)

--- a/web/src/lib/nutrition/recipe-structured.ts
+++ b/web/src/lib/nutrition/recipe-structured.ts
@@ -1,0 +1,127 @@
+import type { RecipeIngredient, RecipeStep } from "../types";
+
+/**
+ * Validation for the structured recipe columns.
+ *
+ * The database checks only that `ingredients_json` is a JSON *array*; nothing constrains its
+ * elements. That is deliberate — Postgres is the wrong place to encode a shape this fiddly — but it
+ * means the API is the last line of defence, and this value feeds the macro pipeline. A row that
+ * reaches USDA with `quantity: "200g"` (a string) resolves to nothing and silently drops a real
+ * ingredient out of a real total, which is precisely the failure mode #665 and the macro-audit work
+ * were about.
+ *
+ * So: reject, don't coerce. A malformed payload is a bug in the caller, and quietly repairing it
+ * would hide that bug and store something the author never wrote.
+ */
+
+export class RecipeShapeError extends Error {}
+
+function fail(path: string, why: string): never {
+  throw new RecipeShapeError(`${path}: ${why}`);
+}
+
+function optionalString(v: unknown, path: string): string | null {
+  if (v == null) return null;
+  if (typeof v !== "string") fail(path, "must be a string or null");
+  const t = v.trim();
+  return t.length ? t : null;
+}
+
+/**
+ * Normalize one ingredient row.
+ *
+ * `quantity: null` is explicitly VALID and is not the same as a missing amount — "salt, to taste"
+ * is an author stating there is no mass. The resolver excludes such rows from the total without
+ * capping confidence, so the distinction has to survive validation rather than be normalized away.
+ */
+export function parseIngredientRow(raw: unknown, path: string): RecipeIngredient {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) fail(path, "must be an object");
+  const r = raw as Record<string, unknown>;
+
+  const item = typeof r.item === "string" ? r.item.trim() : "";
+  if (!item) fail(`${path}.item`, "is required and must be a non-empty string");
+
+  let quantity: number | null = null;
+  if (r.quantity != null) {
+    if (typeof r.quantity !== "number" || !Number.isFinite(r.quantity))
+      fail(`${path}.quantity`, "must be a finite number or null");
+    if (r.quantity < 0) fail(`${path}.quantity`, "must not be negative");
+    quantity = r.quantity;
+  }
+
+  const unit = optionalString(r.unit, `${path}.unit`);
+  // A bare number with no unit cannot be converted to grams, so USDA would fall back to an assumed
+  // portion — an amount that looks stated but isn't. Catch it at write time.
+  if (quantity != null && !unit) fail(`${path}.unit`, "is required when quantity is set");
+
+  let fdcId: number | null = null;
+  if (r.fdc_id != null) {
+    if (typeof r.fdc_id !== "number" || !Number.isInteger(r.fdc_id) || r.fdc_id <= 0)
+      fail(`${path}.fdc_id`, "must be a positive integer USDA FoodData Central id");
+    fdcId = r.fdc_id;
+  }
+
+  if (r.optional != null && typeof r.optional !== "boolean")
+    fail(`${path}.optional`, "must be a boolean");
+
+  return {
+    item,
+    quantity,
+    unit,
+    prep: optionalString(r.prep, `${path}.prep`),
+    group: optionalString(r.group, `${path}.group`),
+    optional: r.optional === true ? true : undefined,
+    note: optionalString(r.note, `${path}.note`),
+    fdc_id: fdcId,
+  };
+}
+
+export function parseIngredientRows(raw: unknown): RecipeIngredient[] | null {
+  if (raw == null) return null;
+  if (!Array.isArray(raw)) throw new RecipeShapeError("ingredients_json: must be an array");
+  return raw.map((r, i) => parseIngredientRow(r, `ingredients_json[${i}]`));
+}
+
+export function parseStepRow(raw: unknown, path: string, fallbackStep: number): RecipeStep {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) fail(path, "must be an object");
+  const r = raw as Record<string, unknown>;
+
+  const text = typeof r.text === "string" ? r.text.trim() : "";
+  if (!text) fail(`${path}.text`, "is required and must be a non-empty string");
+
+  // Step numbers are authoritative for render order, but authoring UIs routinely omit them and
+  // rely on array position. Defaulting to position is safe; a NON-INTEGER step is not.
+  let step = fallbackStep;
+  if (r.step != null) {
+    if (typeof r.step !== "number" || !Number.isInteger(r.step) || r.step < 1)
+      fail(`${path}.step`, "must be a positive integer");
+    step = r.step;
+  }
+
+  let tips: string[] | null = null;
+  if (r.tips != null) {
+    if (!Array.isArray(r.tips) || r.tips.some((t) => typeof t !== "string"))
+      fail(`${path}.tips`, "must be an array of strings");
+    const cleaned = (r.tips as string[]).map((t) => t.trim()).filter(Boolean);
+    tips = cleaned.length ? cleaned : null;
+  }
+
+  let duration: number | null = null;
+  if (r.duration_mins != null) {
+    if (
+      typeof r.duration_mins !== "number" ||
+      !Number.isFinite(r.duration_mins) ||
+      r.duration_mins < 0
+    )
+      fail(`${path}.duration_mins`, "must be a non-negative number");
+    duration = r.duration_mins;
+  }
+
+  return { step, text, tips, duration_mins: duration };
+}
+
+export function parseStepRows(raw: unknown): RecipeStep[] | null {
+  if (raw == null) return null;
+  if (!Array.isArray(raw)) throw new RecipeShapeError("steps_json: must be an array");
+  return raw.map((r, i) => parseStepRow(r, `steps_json[${i}]`, i + 1));
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -113,12 +113,60 @@ export interface Profile {
   updated_at: string;
 }
 
+/**
+ * One line of a recipe's ingredient list.
+ *
+ * The fields exist so the macro resolver never has to re-derive them from prose. A structured row
+ * with `quantity` + `unit` skips `parseFoodText()` (the local model) entirely; one that also
+ * carries `fdc_id` skips USDA search and model selection too. See the 20260812 migration for why
+ * that matters — in short, the model is measurably ~2x heavy on portion weights and the codebase
+ * already re-lexes every number to work around it.
+ */
+export interface RecipeIngredient {
+  /** The food, as close to a USDA name as is still readable: "ground beef, 93/7". */
+  item: string;
+  /** Null is legitimate — "salt, to taste" is a real ingredient. Ignored for macros. */
+  quantity: number | null;
+  /** "g", "ml", "tbsp", "clove", "can"… Null whenever `quantity` is. */
+  unit: string | null;
+  /** State at the time it goes in: "diced", "raw", "cooked", "drained". Affects USDA choice. */
+  prep?: string | null;
+  /** Section heading, e.g. "Sauce" / "For the tray". Ungrouped rows render as one list. */
+  group?: string | null;
+  optional?: boolean;
+  /** Free note shown after the amount — provenance, substitutions, error bars. */
+  note?: string | null;
+  /**
+   * USDA FoodData Central id. Pinning it makes re-resolution deterministic: USDA's top hit for
+   * "chicken breast, cooked" is breaded microwaved tenders (252 kcal vs ~165), so leaving the
+   * choice to a search means the same recipe can resolve differently month to month.
+   */
+  fdc_id?: number | null;
+}
+
+/** One step of the method. Display only — nothing in the macro path reads these. */
+export interface RecipeStep {
+  /** 1-based, and authoritative: render order comes from here, not array position. */
+  step: number;
+  text: string;
+  /** Short asides that would clutter the step itself, mirroring WorkoutExercise.tips. */
+  tips?: string[] | null;
+  duration_mins?: number | null;
+}
+
 export interface Recipe {
   id: string;
   name: string;
   cuisine: string | null;
+  /**
+   * LEGACY free text, one ingredient per line. Still the fallback while `ingredients_json` is
+   * backfilled; prefer the structured column for anything new.
+   */
   ingredients: string | null;
+  /** LEGACY free text. Fallback for `steps_json`. */
   instructions: string | null;
+  ingredients_json: RecipeIngredient[] | null;
+  steps_json: RecipeStep[] | null;
   tags: string[] | null;
   metadata: Record<string, unknown>;
   created_at: string;

--- a/web/src/lib/units.ts
+++ b/web/src/lib/units.ts
@@ -1,3 +1,5 @@
+import type { RecipeIngredient } from "./types";
+
 export type WeightUnit = "kg" | "lb";
 
 const LB_PER_KG = 2.2046226218;
@@ -111,8 +113,14 @@ function annotateRice(line: string): string {
 // The rows were repaired, but parsing the array back out here means the next bad write degrades to
 // a correct list instead of leaking syntax at Jason.
 
-/** Split a stored ingredient list into display lines, annotated with unit and go conversions. */
-export function parseIngredients(text: string | null | undefined): string[] {
+/**
+ * Split a stored ingredient list into raw lines — no annotation.
+ *
+ * Separate from `parseIngredients` because the structured-recipe editor seeds its rows from this
+ * and must see the text the author actually wrote. Annotated text would feed "200 g (7.1 oz) beef"
+ * back into the amount lexer, which then has two numbers to choose between.
+ */
+export function splitIngredientLines(text: string | null | undefined): string[] {
   const trimmed = (text ?? "").trim();
   if (!trimmed) return [];
 
@@ -131,9 +139,61 @@ export function parseIngredients(text: string | null | undefined): string[] {
   } else {
     lines = trimmed.split("\n");
   }
+  return lines.map((l) => l.trim()).filter(Boolean);
+}
 
+/** Split a stored ingredient list into display lines, annotated with unit and go conversions. */
+export function parseIngredients(text: string | null | undefined): string[] {
   // Rice first: `annotateLine` splices "(2.8 oz)" in between the number and the word that follows
   // it, which would break the "<n> g dry rice" match. Going rice-first also parks the go at the end
   // of the line, where it reads as a note rather than interrupting the amount.
-  return lines.map((l) => annotateLine(annotateRice(l.trim()))).filter(Boolean);
+  return splitIngredientLines(text).map((l) => annotateLine(annotateRice(l)));
+}
+
+// ── Structured ingredients ──────────────────────────────────────────────────────
+// `ingredients_json` stores the amount as data instead of prose. Rendering still goes through the
+// same annotators, so a structured row picks up the imperial and rice-go conversions for free and
+// the two storage shapes cannot drift into looking different on screen.
+
+/** Trim trailing zeros so 150 renders "150", not "150.00", while 1.5 survives. */
+function amountText(quantity: number, unit: string | null | undefined): string {
+  const n = round(quantity, 2);
+  return unit ? `${n} ${unit}` : `${n}`;
+}
+
+/**
+ * One structured ingredient as a display line: "454 g (16 oz) ground beef, 93/7, browned".
+ *
+ * Quantity and unit lead, because `annotateLine` only matches a weight at the START of a line —
+ * the same reason the legacy text convention put the amount first. `optional` and `note` are
+ * appended AFTER annotation: a note is free text and could contain a bare "go", which would make
+ * `annotateRice` treat the line as already carrying its go and skip the conversion.
+ */
+export function formatIngredient(ing: RecipeIngredient): string {
+  const head =
+    ing.quantity == null ? ing.item : `${amountText(ing.quantity, ing.unit)} ${ing.item}`;
+  const annotated = annotateLine(annotateRice(ing.prep ? `${head}, ${ing.prep}` : head));
+
+  let line = annotated;
+  if (ing.optional) line += " (optional)";
+  if (ing.note) line += ` — ${ing.note}`;
+  return line;
+}
+
+/**
+ * Ingredients bucketed by `group`, preserving first-seen order for both the groups and the rows
+ * inside them. Ungrouped rows collect under a null key, which the renderer prints without a
+ * heading — so a flat list stays flat rather than growing a spurious "Other" section.
+ */
+export function groupIngredients(
+  items: RecipeIngredient[],
+): { group: string | null; items: RecipeIngredient[] }[] {
+  const out: { group: string | null; items: RecipeIngredient[] }[] = [];
+  for (const ing of items) {
+    const key = ing.group?.trim() || null;
+    const bucket = out.find((b) => b.group === key);
+    if (bucket) bucket.items.push(ing);
+    else out.push({ group: key, items: [ing] });
+  }
+  return out;
 }


### PR DESCRIPTION
## What

Recipes get structured ingredients and steps: `recipes.ingredients_json` and `steps_json`, rendered as a real ingredient list and numbered method, editable in-app, and — the actual point — **read directly by the macro resolver instead of being parsed out of prose by a local model.**

## Why this isn't a formatting change

`recipes.ingredients` is free text, and it is the *input to the macro pipeline*. `resolveRecipeMacros` hands that prose to a 7B model to be split into `{query, qty, unit}` before USDA ever sees it. `parse.ts` documents why that's a liability in its own words: the model called a large egg 105 g (real ~50 g) and a cup of cooked rice 284 g (real ~158 g), both ~2× heavy. `quantity.ts` already re-lexes every number back out of the source fragment *"because the model demonstrably alters numbers it is asked to repeat."*

All of that machinery exists to recover structure that was thrown away at write time. When the amount is a number in a column:

- `estimateFromStructured` skips `parseFoodText` entirely — no Ollama call, no lexer, no rounding.
- An optional per-ingredient `fdc_id` skips USDA search *and* the model's record selection, so a re-resolve next month returns the same numbers as today. USDA's top hit for "chicken breast, cooked" is breaded microwaved tenders — 252 kcal against ~165 for the plain cut — and nothing but a pin prevents that drift.

## Two distinctions the resolver now keeps straight

| | meaning | effect on total | effect on confidence |
|---|---|---|---|
| `unquantified` | an amount was needed, none found, one was **invented** | included, soft | caps to low |
| `quantity: null` | author stated there is **no** amount ("salt, to taste") | excluded | none |

Conflating these would either make every recipe containing salt read "low", or hide a genuinely forgotten amount. Amount-less rows are persisted separately as `macro_amountless`, and `macro_source` records which path produced the numbers.

## Additive, not a cutover

~72 recipes hold prose today, four of them on this week's plan. The text columns stay and remain the fallback — readers prefer structured and drop back — so a half-finished backfill renders correctly throughout. `parseIngredients` (#665) keeps covering the legacy path, including its JSON-array recovery.

## Backfill

`web/scripts/backfill-structured-recipes.ts`, dry-run by default. It reuses `lexQuantity` so a backfilled amount is parsed exactly the way a typed one is.

**All-or-nothing per recipe**: because `quantity: null` excludes a row from the total, a line whose amount we failed to read would silently delete a real ingredient. A recipe converts only when every line yields an amount or is recognisably a seasoning.

Measured against the live library: **67 of 72 convert.** The 5 that don't genuinely have no amount written down — `Pasta, corn, spinach, green beans`, `Green beans, olive oil + lemon`, `cherry tomatoes`, an instruction that had been typed into the ingredients field, and the `Eating out` placeholder. Those stay on the text path and are printed for a human to fix in the editor.

Macros are **not** re-resolved by the backfill: existing totals came from the same ingredients and stay correct, and re-resolving 67 recipes would fire hundreds of USDA calls and rewrite stored numbers unattended.

## Editor

Row-based: quantity / unit / item / prep / `fdc_id` per ingredient, plus steps. Seeds from legacy text through `lexQuantity`; a line it can't read keeps its full text with a null amount rather than being given an invented one — which matters precisely because null means "excluded from macros."

Reorder is up/down buttons, not drag: no DnD dependency exists here and hand-rolled drag isn't keyboard operable.

## Shape

Mirrors `workout_plans.warmup/workout/cooldown`, which have stored arrays of typed objects since the initial schema. Meals were the odd one out.

## Deploy

The migration is **not yet applied** — `supabase/migrations/20260812000000_structured_recipes.sql` needs running against the self-hosted DB, then the backfill with `--write`.

## Testing

- 22 new unit tests (`structured-recipes.test.ts`); full suite **89/89 green**.
- Pins that a structured row renders identically to the text line it replaces (imperial + rice `go` annotations), that `quantity: null` survives validation uncoerced, and that a string quantity is rejected rather than silently dropped.
- `tsc --noEmit`, `eslint` (0 errors), `prettier --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016J2PijFVzguKQ3wo4sVUwC
