### PR TITLE
meals: the backfill's seasoning test defeated its own safety rule

### DIFF
--- a/web/scripts/backfill-structured-recipes.ts
+++ b/web/scripts/backfill-structured-recipes.ts
@@ -7,113 +7,18 @@
  *
  * Needs SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in the environment.
  *
- * WHY A SCRIPT AND NOT A SQL MIGRATION
- *
- * The conversion needs the same quantity lexer the macro pipeline uses (`lexQuantity`), so that a
- * backfilled amount is read exactly the way a logged amount is. Reimplementing that in PL/pgSQL
- * would create a second parser that silently drifts from the first.
- *
- * THE SAFETY RULE: ALL-OR-NOTHING PER RECIPE
- *
- * A row with `quantity: null` is EXCLUDED from the macro total by design — that is what makes
- * "salt, to taste" behave. It also means a line whose amount we failed to read would silently
- * delete a real ingredient from a real total. The text path at least invents an amount and flags
- * the recipe low-confidence; converting it badly would look cleaner and be worse.
- *
- * So a recipe is converted only when EVERY line either yields an amount or is recognisably a
- * seasoning. Anything else leaves the whole recipe on the text path and is printed for a human to
- * fix in the editor. Measured on the live library at time of writing: 67 of 72 convert, and the 5
- * that don't genuinely have no amount written down anywhere ("Pasta, corn, spinach, green beans").
+ * This file is IO only. The conversion — and the safety rule that decides whether a recipe may be
+ * converted at all — lives in src/lib/nutrition/recipe-backfill.ts, where the tests can reach it
+ * without pulling the Supabase client into a dependency-free test job.
  *
  * MACROS ARE NOT RE-RESOLVED HERE.
  *
- * Existing totals were computed from the same ingredients and stay correct; re-resolving 67 recipes
+ * Existing totals were computed from the same ingredients and stay correct; re-resolving 66 recipes
  * would fire hundreds of USDA calls and change stored numbers in bulk with no one watching. The
  * structured path takes over the next time a recipe is edited or explicitly re-resolved.
  */
 import { createClient } from "@supabase/supabase-js";
-import { lexQuantity } from "../src/lib/nutrition/quantity.ts";
-import { splitIngredientLines } from "../src/lib/units.ts";
-import type { RecipeIngredient, RecipeStep } from "../src/lib/types.ts";
-
-/** Lines that legitimately carry no amount. Kept narrow — see the safety rule above. */
-const TRULY_AMOUNTLESS =
-  /\b(to taste|to garnish|for garnish|to serve|zero[- ]cal|as needed|optional)\b/i;
-const SEASONING = /\b(salt|pepper|powder|cumin|seasoning|spice|paprika|herbs?)\b/i;
-
-/**
- * "kimchi 120 g", "Ribeye 0.78 lb (354g)" — the amount TRAILS the food.
- *
- * `lexQuantity` reads only a LEADING amount, deliberately: a trailing number in meal text is more
- * often a temperature or a year. Handling the trailing form here keeps that lexer untouched, and it
- * matters because rows written in August 2026 used exactly this shape.
- */
-const TRAILING =
-  /^(.*?)[\s,(]*(\d+(?:\.\d+)?)\s*(g|kg|ml|l|oz|lb|tbsp|tsp|cup|clove|can|slice)s?\b/i;
-
-export function ingredientRowsFrom(text: string): {
-  rows: RecipeIngredient[];
-  unresolved: string[];
-} {
-  let lines = splitIngredientLines(text);
-  // Semicolon prose, e.g. "cod 227 g; kimchi 120 g; 2 large eggs".
-  if (lines.length === 1 && lines[0].includes(";")) {
-    lines = lines[0]
-      .split(";")
-      .map((s) => s.trim())
-      .filter(Boolean);
-  }
-
-  const rows: RecipeIngredient[] = [];
-  const unresolved: string[] = [];
-
-  for (let raw of lines) {
-    raw = raw
-      .replace(/^PER SERVING \([^)]*\)\.\s*/i, "")
-      .replace(/\.$/, "")
-      .trim();
-    if (!raw) continue;
-
-    const lead = lexQuantity(raw);
-    if (lead) {
-      const at = raw.indexOf(lead.source);
-      const item = (at < 0 ? raw : raw.slice(at + lead.source.length))
-        .trim()
-        .replace(/^(of\s+|[,\-–—]\s*)/i, "");
-      rows.push({ item: item || raw, quantity: lead.qty, unit: lead.unit });
-      continue;
-    }
-
-    const tail = TRAILING.exec(raw);
-    if (tail && tail[1].trim()) {
-      const rest = raw
-        .slice(tail[0].length)
-        .trim()
-        .replace(/^[),\s]+/, "");
-      rows.push({
-        item: tail[1].trim().replace(/[,(]$/, "").trim(),
-        quantity: parseFloat(tail[2]),
-        unit: tail[3].toLowerCase(),
-        note: rest || null,
-      });
-      continue;
-    }
-
-    rows.push({ item: raw, quantity: null, unit: null });
-    if (!TRULY_AMOUNTLESS.test(raw) && !SEASONING.test(raw)) unresolved.push(raw);
-  }
-  return { rows, unresolved };
-}
-
-/** Numbered or newline-separated instructions -> steps. Blank-line groups win over single lines. */
-export function stepRowsFrom(text: string | null): RecipeStep[] | null {
-  const t = (text ?? "").trim();
-  if (!t) return null;
-  const chunks = (t.includes("\n\n") ? t.split(/\n{2,}/) : t.split("\n"))
-    .map((c) => c.trim().replace(/^\d+[.)]\s*/, ""))
-    .filter(Boolean);
-  return chunks.length ? chunks.map((text, i) => ({ step: i + 1, text })) : null;
-}
+import { ingredientRowsFrom, stepRowsFrom } from "../src/lib/nutrition/recipe-backfill.ts";
 
 async function main() {
   const write = process.argv.includes("--write");
@@ -160,7 +65,11 @@ async function main() {
   if (!write) console.log("\nDry run. Re-run with --write to apply.");
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+// Only run when invoked directly. Importing this module for its exported converters — which the
+// tests and any ad-hoc tooling do — must not execute main() and demand credentials.
+if (process.argv[1] && import.meta.filename === process.argv[1]) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/web/src/__tests__/structured-recipes.test.ts
+++ b/web/src/__tests__/structured-recipes.test.ts
@@ -25,6 +25,7 @@ import {
   parseIngredientRows,
   parseStepRows,
 } from "../lib/nutrition/recipe-structured.ts";
+import { ingredientRowsFrom } from "../lib/nutrition/recipe-backfill.ts";
 
 // ── formatIngredient ────────────────────────────────────────────────────────────
 
@@ -191,4 +192,45 @@ test("blank tips are dropped rather than stored as empty strings", () => {
 
 test("a non-array payload is rejected", () => {
   assert.throws(() => parseIngredientRows({ item: "beef" }), RecipeShapeError);
+});
+
+// ── backfill converter ──────────────────────────────────────────────────────────
+// The all-or-nothing rule is only as good as its "this is just seasoning" test, and the first
+// draft of that test was wrong in the most dangerous possible direction.
+
+test("a line mixing seasoning with real food BLOCKS the recipe", () => {
+  // `/\bpepper\b/` over the whole line matched "Onion, bell pepper, marinara", classifying a line
+  // with marinara and onion in it as seasoning. quantity:null excludes a row from the total, so
+  // that would have silently deleted real calories from Turkey Pasta.
+  const { unresolved } = ingredientRowsFrom("Onion, bell pepper, marinara");
+  assert.equal(unresolved.length, 1);
+});
+
+test("a line that is only seasoning converts with a null amount", () => {
+  const { rows, unresolved } = ingredientRowsFrom("salt, pepper, garlic");
+  assert.equal(unresolved.length, 0);
+  assert.equal(rows[0].quantity, null);
+});
+
+test("'to taste' and 'to garnish' are amount-less by declaration", () => {
+  assert.equal(ingredientRowsFrom("Scallions to garnish").unresolved.length, 0);
+  assert.equal(ingredientRowsFrom("Truffle hot sauce to taste (zero-cal)").unresolved.length, 0);
+});
+
+test("a trailing amount is read — the shape the 2026-08-12 rows used", () => {
+  const { rows } = ingredientRowsFrom("kimchi 120 g");
+  assert.equal(rows[0].quantity, 120);
+  assert.equal(rows[0].unit, "g");
+  assert.match(rows[0].item, /kimchi/);
+});
+
+test("a leading amount still wins, and semicolon prose splits", () => {
+  const { rows } = ingredientRowsFrom("227 g cod; 2 large eggs");
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0].quantity, 227);
+  assert.equal(rows[1].quantity, 2);
+});
+
+test("a real food with no amount anywhere blocks", () => {
+  assert.equal(ingredientRowsFrom("cherry tomatoes").unresolved.length, 1);
 });

--- a/web/src/lib/nutrition/recipe-backfill.ts
+++ b/web/src/lib/nutrition/recipe-backfill.ts
@@ -1,0 +1,139 @@
+/**
+ * Pure conversion from the legacy free-text ingredient columns to structured rows.
+ *
+ * Split out of scripts/backfill-structured-recipes.ts so it can be tested. The CI `node` job runs
+ * `node --test` with NO npm install — deliberately, so unit tests stay pure logic — so a test that
+ * reaches a module importing @supabase/supabase-js fails to resolve. Keeping the parsing here and
+ * the IO in the script means the interesting half is covered and the boring half needs no deps.
+ *
+ * WHY A SCRIPT AND NOT A SQL MIGRATION
+ *
+ * The conversion needs the same quantity lexer the macro pipeline uses (`lexQuantity`), so that a
+ * backfilled amount is read exactly the way a logged amount is. Reimplementing that in PL/pgSQL
+ * would create a second parser that silently drifts from the first.
+ *
+ * THE SAFETY RULE: ALL-OR-NOTHING PER RECIPE
+ *
+ * A row with `quantity: null` is EXCLUDED from the macro total by design — that is what makes
+ * "salt, to taste" behave. It also means a line whose amount we failed to read would silently
+ * delete a real ingredient from a real total. The text path at least invents an amount and flags
+ * the recipe low-confidence; converting it badly would look cleaner and be worse.
+ *
+ * So a recipe is converted only when EVERY line either yields an amount or is recognisably a
+ * seasoning. Anything else leaves the whole recipe on the text path and is printed for a human to
+ * fix in the editor. Measured on the live library at time of writing: 66 of 72 convert, and the 6
+ * that don't genuinely have no amount written down anywhere ("Pasta, corn, spinach, green beans",
+ * "Onion, bell pepper, marinara", "cherry tomatoes").
+ *
+ * MACROS ARE NOT RE-RESOLVED HERE.
+ *
+ * Existing totals were computed from the same ingredients and stay correct; re-resolving 66 recipes
+ * would fire hundreds of USDA calls and change stored numbers in bulk with no one watching. The
+ * structured path takes over the next time a recipe is edited or explicitly re-resolved.
+ */
+import { lexQuantity } from "./quantity.ts";
+import { splitIngredientLines } from "../units.ts";
+import type { RecipeIngredient, RecipeStep } from "../types.ts";
+
+/** Lines that legitimately carry no amount. Kept narrow — see the safety rule above. */
+const TRULY_AMOUNTLESS =
+  /\b(to taste|to garnish|for garnish|to serve|zero[- ]cal|as needed|optional)\b/i;
+
+/**
+ * Ingredients that contribute ~nothing and are safe to carry at `quantity: null`.
+ *
+ * EVERY comma/&/plus-separated component of a line must match. A substring test over the whole
+ * line is not good enough and the first draft of this proved it: `/\bpepper\b/` matched
+ * "Onion, bell pepper, marinara", so a line carrying marinara and onion — real calories — was
+ * classified as seasoning and would have been silently dropped from Turkey Pasta's total. That is
+ * precisely the failure the all-or-nothing rule exists to prevent, defeated by its own allowlist.
+ *
+ * So the unit of judgement is the component, not the line, and anything not on this list blocks the
+ * whole recipe for a human to look at.
+ */
+const NEGLIGIBLE_COMPONENT =
+  /^(salt|black pepper|white pepper|pepper|peppercorns?|garlic|garlic powder|onion powder|chili powder|chilli powder|cumin|paprika|oregano|thyme|basil|parsley|cilantro|coriander|cinnamon|seasoning|spices?|herbs?|lemon|lime|lemon juice|lime juice|water|no oil|zero[- ]cal)$/i;
+
+/** True only when every component of the line is individually negligible. */
+function isAllNegligible(line: string): boolean {
+  const parts = line
+    .replace(/\([^)]*\)/g, "") // drop parentheticals like "(no oil)"
+    .split(/,|\band\b|&|\+/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+  return parts.length > 0 && parts.every((p) => NEGLIGIBLE_COMPONENT.test(p));
+}
+
+/**
+ * "kimchi 120 g", "Ribeye 0.78 lb (354g)" — the amount TRAILS the food.
+ *
+ * `lexQuantity` reads only a LEADING amount, deliberately: a trailing number in meal text is more
+ * often a temperature or a year. Handling the trailing form here keeps that lexer untouched, and it
+ * matters because rows written in August 2026 used exactly this shape.
+ */
+const TRAILING =
+  /^(.*?)[\s,(]*(\d+(?:\.\d+)?)\s*(g|kg|ml|l|oz|lb|tbsp|tsp|cup|clove|can|slice)s?\b/i;
+
+export function ingredientRowsFrom(text: string): {
+  rows: RecipeIngredient[];
+  unresolved: string[];
+} {
+  let lines = splitIngredientLines(text);
+  // Semicolon prose, e.g. "cod 227 g; kimchi 120 g; 2 large eggs".
+  if (lines.length === 1 && lines[0].includes(";")) {
+    lines = lines[0]
+      .split(";")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+
+  const rows: RecipeIngredient[] = [];
+  const unresolved: string[] = [];
+
+  for (let raw of lines) {
+    raw = raw
+      .replace(/^PER SERVING \([^)]*\)\.\s*/i, "")
+      .replace(/\.$/, "")
+      .trim();
+    if (!raw) continue;
+
+    const lead = lexQuantity(raw);
+    if (lead) {
+      const at = raw.indexOf(lead.source);
+      const item = (at < 0 ? raw : raw.slice(at + lead.source.length))
+        .trim()
+        .replace(/^(of\s+|[,\-–—]\s*)/i, "");
+      rows.push({ item: item || raw, quantity: lead.qty, unit: lead.unit });
+      continue;
+    }
+
+    const tail = TRAILING.exec(raw);
+    if (tail && tail[1].trim()) {
+      const rest = raw
+        .slice(tail[0].length)
+        .trim()
+        .replace(/^[),\s]+/, "");
+      rows.push({
+        item: tail[1].trim().replace(/[,(]$/, "").trim(),
+        quantity: parseFloat(tail[2]),
+        unit: tail[3].toLowerCase(),
+        note: rest || null,
+      });
+      continue;
+    }
+
+    rows.push({ item: raw, quantity: null, unit: null });
+    if (!TRULY_AMOUNTLESS.test(raw) && !isAllNegligible(raw)) unresolved.push(raw);
+  }
+  return { rows, unresolved };
+}
+
+/** Numbered or newline-separated instructions -> steps. Blank-line groups win over single lines. */
+export function stepRowsFrom(text: string | null): RecipeStep[] | null {
+  const t = (text ?? "").trim();
+  if (!t) return null;
+  const chunks = (t.includes("\n\n") ? t.split(/\n{2,}/) : t.split("\n"))
+    .map((c) => c.trim().replace(/^\d+[.)]\s*/, ""))
+    .filter(Boolean);
+  return chunks.length ? chunks.map((text, i) => ({ step: i + 1, text })) : null;
+}


### PR DESCRIPTION
Follow-up to #667, found while auditing the dry run before writing anything to the live library.

## The bug

The backfill converts a recipe only when every line yields an amount **or is recognisably seasoning** — because a `quantity: null` row is *excluded* from the macro total. A line whose amount we failed to read wouldn't soften the number, it would silently delete calories.

That seasoning test was a substring match over the whole line:

```
/\b(salt|pepper|powder|cumin|seasoning|spice|paprika|herbs?)\b/i
```

`\bpepper\b` matches **"Onion, bell pepper, marinara"**. So a line carrying marinara and onion was classified as seasoning, and `Turkey Pasta` would have been converted with those calories dropped — the exact failure the all-or-nothing rule exists to prevent, defeated by its own allowlist.

Nothing was written to the database; this was caught by dumping every `quantity: null` row the dry run produced and reading them.

## The fix

The unit of judgement is now the **component**, not the line. A line is negligible only when every comma/`&`/plus-separated part is individually on the list, so "Onion, bell pepper, marinara" blocks on `onion` and `marinara` while "salt, pepper, garlic" still converts.

| | before | after |
|---|---|---|
| converted | 67 | **66** |
| blocked for a human | 5 | **6** |

`Turkey Pasta` joins the blocked set. The remaining 7 null rows are all genuinely negligible — verified by hand:

```
chili powder, cumin, salt
Truffle hot sauce to taste (zero-cal)
Scallions to garnish            (x2)
salt, pepper, garlic
lemon, salt, pepper
Lemon, garlic, paprika, black pepper (no oil)
```

## Also

`main()` ran on import, so importing the exported converters for an offline audit threw on missing credentials before converting a line. Now guarded on being invoked directly — which is what made the audit above possible.

## Testing

Six new tests, including the bell-pepper case by name. Suite **95/95**. tsc, eslint, prettier, lint-tokens all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016J2PijFVzguKQ3wo4sVUwC
