### PR TITLE
meals: a batch recipe logged the whole cook as one meal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **A batch recipe logged the whole cook as one meal.** `resolveRecipeMacros` persisted
+  `total.calories` — the sum of the ingredient list — into `recipes.calories`, which every consumer
+  reads as ONE serving, because that is the only reading that makes sense on a planned plate. For a
+  recipe whose ingredient list is the batch, those are different numbers, and the gap went into
+  `meal_log` rather than onto a screen where it could be noticed. Two recipes were live in that
+  state with a valid `macros_computed_at`: the tofu rice bowl (`typical_portions` 2, stored 829 kcal,
+  whose own ingredient note read _"this makes a ~1,034 g plate, which is 2 servings, not 1"_) and the
+  gochujang beef batch (3, stored 1783). Every "Ate this" on them overlogged by 2× and 3×.
+
+  The resolver now divides by `typical_portions` on write, so the ingredient list can say _1 lb of
+  beef, serves 3_ while the stored plate stays ~594 kcal. Dividing on the way in rather than at each
+  read is deliberate: there are eight-odd consumers across TypeScript and Python, and one of them
+  forgetting is a silent 2× in a health log. The batch figure and the divisor are kept in
+  `metadata.macro_batch_total` / `macro_portions` so the division stays auditable.
+
+  `typical_portions` was documented as _"Hint only… Not a claim"_; it is now load-bearing, and
+  treating it as decorative is what allowed the two rows above. A null, zero, 1, fractional or
+  negative count all pass the total through untouched — a bad value must degrade to inert, never to
+  a multiplier. The portion maths moved to a leaf module (`recipe-portions.ts`) so it is reachable
+  by the bundler-free unit runner; `recipe-macros.ts` re-exports it, so no import site changed.
+
+- **Single-paragraph recipes got a "method" of one step.** `stepRowsFrom` split only on newlines,
+  which is right for the 49 recipes written line-per-step and a silent no-op for any recipe written
+  as one prose blob — producing a single step holding the entire text. Valid JSON, so the backfill
+  reported success. It hit 15 of 72 recipes, including all four on the current meal plan, which is
+  why it read as wholly broken rather than as a fifth broken.
+
+  There is now a sentence fallback for text with no newlines. USDA citations and shouty planning
+  asides (`BATCH OF 3 - macros above are ONE SERVING`) are pulled out of the numbered method and
+  attached as `tips` on the adjacent step, which `StepList` already renders muted — a citation is
+  real and load-bearing, and actively misleading as step 6. The aside rule anchors on specific
+  openers rather than on "looks like caps", because mis-classifying a real step would silently
+  delete it from the method. Decimals and mid-sentence semicolons do not split.
+
+- **"Logs no macros" was only ever said in a tooltip.** An unresolved recipe falls through to a
+  status-only path that marks the plan row eaten and writes no `meal_log` row. That was already
+  labelled — button copy "Ate it" rather than "Ate this", plus a `title` — but `title` never appears
+  on touch, and this panel is used from the installed PWA on a phone, where the two outcomes
+  differed by one word. The consequence is now stated inline in the row. The recipe "Ate this"
+  tooltip also described its figure as `kcal for the batch`, which stops being true with the
+  per-serving change above; it now reads _one serving_.
+
 - **Recipe ingredients rendered as a raw JSON array, and rice lost its `go`.** Both were visible on
   the same screen. `recipes.ingredients` is a free-text column holding one ingredient per line, and
   both render sites (`PlannedMealDetail`, the `MealsClient` recipe browser) dropped it into a single
@@ -65,12 +107,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Fixed
 
 - **Grease-the-groove sessions were being classified as lifts.** Session classification tested that
-  *every* exercise name contained `grease-the-groove`, but a GtG session also carries accessory
+  _every_ exercise name contained `grease-the-groove`, but a GtG session also carries accessory
   movements with no such suffix (`Negative Pull-Up`, `Dead Hang`) — so real GtG sessions on 8/04,
   8/05, 8/06 and 8/07 all failed the test and read as lifting sessions. GtG is walk work and never
-  appears inside a lift, so the correct test is *any*. Caught by running the new prompt engine
+  appears inside a lift, so the correct test is _any_. Caught by running the new prompt engine
   against live rows, where it produced a "you trained today" suggestion on a pull-up-only day. Same
   class of bug as the GtG mis-scoring fixed in #650.
+
 ### Documentation
 
 - **`docs/architecture.svg` regenerated.** It is generated from `docs/architecture.d2`, which
@@ -92,15 +135,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - **Second drift pass — the first one missed three, including a rule file.**
   `.claude/rules/briefing.md` still told the session-start protocol that `run-syncs.py` "runs both
   sync scripts (oura, google_health) in parallel". It runs neither: it is one HTTP call that
-  refreshes five sources and needs the app container up. That file is *read by Claude at session
-  start*, so a stale instruction there is worse than a stale README.
+  refreshes five sources and needs the app container up. That file is _read by Claude at session
+  start_, so a stale instruction there is worse than a stale README.
   `docs/fitness-tracker-setup.md` opened with "Two sync scripts pull data from fitness APIs and
   write directly to Supabase" — the entire premise of the page.
   `docs/architecture.d2` described the sync layer as "Python scripts · TypeScript modules".
   **`docs/architecture.svg` is generated from that `.d2` and is now stale** — it needs a `d2`
   regeneration, which was not available in this environment.
 
-  Lesson recorded because it cost two passes: grepping for the deleted *filenames* found the
+  Lesson recorded because it cost two passes: grepping for the deleted _filenames_ found the
   obvious references. The damaging ones described the behaviour in prose without naming a file.
 
 ### Documentation
@@ -141,7 +184,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
   This is fallout from #656/#657, and the reason is worth stating plainly: the codebase held two
   complete sync implementations that had silently drifted. Both carried the same workout-dedup
-  bug. #656 fixed the Python copy, which *read* as fixing the system, while the nightly cron —
+  bug. #656 fixed the Python copy, which _read_ as fixing the system, while the nightly cron —
   running the TypeScript copy — kept writing duplicate rows until #657. The duplicated 30-minute
   skip window even carried a comment saying "same as run-syncs.py": the hazard was written down
   and then ignored. Fixing one copy of a duplicated rule is indistinguishable from fixing the
@@ -166,7 +209,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `tests/test_google_health_dedupe.py` is deleted and ported to
   `web/src/__tests__/google-health-dedupe.test.ts`, which additionally pins the ±5 min window
   edges and documents a **known limitation**: the overlap index is keyed by date only, not
-  date+activity, so two *different* activities starting within 5 minutes collapse into one. That
+  date+activity, so two _different_ activities starting within 5 minutes collapse into one. That
   predates this change (the Python sync indexed by date only too) and is asserted rather than
   fixed — narrowing the key would stop losing real sessions but would re-admit duplicates whenever
   two writers label one session differently, which is a live pattern in the 2026-07-31 data. That
@@ -178,7 +221,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `warmup + workout + cooldown` into the list feeding the recovery and same-day-redundancy checks,
   while `_work_entries()` already excluded warmups for the superset check. The two disagreed, and
   the consequence was that the RAMP protocol's **Potentiate** step was unrepresentable: it is a
-  ~50% ramp-up set of the day's *first lift*, and it only potentiates if it sits immediately before
+  ~50% ramp-up set of the day's _first lift_, and it only potentiates if it sits immediately before
   the working sets — which the redundancy rule then read as two same-pattern exercises back-to-back
   and rejected. Week 2 (7/27-8/01) passed only by accident, because its warmup happened to end on a
   Band Pull-Apart rather than a squat. `day_plans` now counts the working block only, via the same
@@ -189,7 +232,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - **`log_habit.py` — the scripted habit path was broken for every call.** It upserts with
   `on_conflict="habit_id,date"`, but the table's constraint is `user_id,habit_id,date`, so Postgres
   rejected it with `42P10 there is no unique or exclusion constraint matching the ON CONFLICT
-  specification`. Not intermittent — it could never have succeeded.
+specification`. Not intermittent — it could never have succeeded.
 
 ### Documented
 
@@ -205,7 +248,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   at the same time showing the same `pastMeals` rows — the first deduped to 10 by normalized name,
   the second in full chronological order. Two views of one dataset, stacked. The dedupe was the only
   thing "Recent meals" added, and it bought little: with a 6-day window most repeats are already
-  adjacent in "Past 6 Days", and the deduped list silently hid the *repeat* rows, which is exactly
+  adjacent in "Past 6 Days", and the deduped list silently hid the _repeat_ rows, which is exactly
   what makes a meal worth re-logging. Removed the section, the `recentMeals` `useMemo`, the now-unused
   `pastMeals` prop on `TodayTab`, and the `normalizeName` helper whose only caller it was. The
   re-log path is unaffected: `MealRowDisplay`'s `onRelog` is still wired for today's meals, and
@@ -217,9 +260,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   fix, meal-plan constraints and the superset UI. The `graphify` binary is installed on **no**
   current host, so `CLAUDE.md`'s "run `graphify update .` after modifying code files" was
   unsatisfiable and the graph could only get staler. The problem was not that it had become useless
-  but that it was actively misleading: `CLAUDE.md` told agents to read `GRAPH_REPORT.md` *before*
-  answering architecture questions and to navigate `graphify-out/wiki/` *instead of reading raw
-  files* — a directory that does not exist — and a `PreToolUse` hook in `.claude/settings.json`
+  but that it was actively misleading: `CLAUDE.md` told agents to read `GRAPH_REPORT.md` _before_
+  answering architecture questions and to navigate `graphify-out/wiki/` _instead of reading raw
+  files_ — a directory that does not exist — and a `PreToolUse` hook in `.claude/settings.json`
   repeated that instruction on every `Glob`/`Grep`. A three-month-stale map that agents are told to
   trust over the source is worse than no map. Removed: the 6 tracked files (2.3 MB) from this
   **public** repo, the `CLAUDE.md` section, the `core.md` session-close step, the `PreToolUse` hook,
@@ -238,14 +281,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   straight sets. Nothing errored; the plan simply meant something different from what it showed,
   and only an eyeball caught it. `validate_supersets()` in `scripts/weekly_plan.py` now fails the
   plan on: a "(supersets)" day with no slots, partial slotting, malformed slots, non-contiguous
-  pairs (grouping is positional — `groupBySuperset` walks *consecutive* same-letter entries, so
+  pairs (grouping is positional — `groupBySuperset` walks _consecutive_ same-letter entries, so
   a split pair renders as two broken groups), lone or self-paired slots, `pair_with` that isn't
   reciprocal or names an exercise outside the group, out-of-order slot digits, and members of a
   pair disagreeing on `sets` (the group header shows one round count for both). Wired into both
   `validate` and the correction prompt, and the planner prompt now documents the fields so plans
   are written right rather than only caught afterward. Covered by `tests/` — the project's first
   Python tests — run in CI by a new stdlib-only `python-tests` workflow, since a guard against a
-  *silent* failure is itself worthless if it silently stops firing.
+  _silent_ failure is itself worthless if it silently stops firing.
 
 - **Sessions auto-load Mr. Bridge context on start.** A new `SessionStart` hook (wired in
   `.claude/settings.json`, handled by `.claude/hooks/scripts/hooks.py`) injects an instruction
@@ -330,7 +373,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   aggregates several writers (watch, phone, connected apps) and routinely emits one activity
   twice in a single response: once from the writer holding the HR sensor, with `hr_zones`
   populated, and once as a coarse copy with `hr_zones` null and a wild calorie figure. On the
-  *next* run the pair is in `existing` and further copies are suppressed — which is why the
+  _next_ run the pair is in `existing` and further copies are suppressed — which is why the
   duplicates sat as stable pairs rather than multiplying, and why nothing looked wrong.
   Separately, `existing` was filtered to `WORKOUT_SOURCES = ["google_health", "fitbit"]`, which
   excludes `"manual"`, so a hand-logged session could neither suppress an auto-import nor be
@@ -338,7 +381,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `DEDUPE_SOURCES` that adds `"manual"` (`WORKOUT_SOURCES` still means "what this sync writes").
   Observed damage: 2026-07-31 held a 13-minute walk twice at 84 and 467 kcal, and one
   basketball game three times — 431 + 792 + 454 = 1677 kcal — inflating the day to 2963 active
-  calories against a 2500 *weekly* goal; 2026-08-02 held a phantom 295-minute "Cardio Workout"
+  calories against a 2500 _weekly_ goal; 2026-08-02 held a phantom 295-minute "Cardio Workout"
   worth 1867 kcal, the watch reading alcohol-elevated resting HR as five hours of exercise.
   The affected rows were neutralised in place rather than deleted, since the 7-day lookback
   re-imports deleted rows. Covered by `tests/test_google_health_dedupe.py`, which fails on the
@@ -349,7 +392,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `scripts/fetch_briefing_data.py` still printed `FLAG: effort >=8 — drop next session load 10%`
   and `FLAG: effort >=9 — cut a set next session` on every logged session. Those bands were
   **retired 2026-07-18**: 8-9/10 is roughly 1-3 RIR, which is the productive zone the program
-  now targets, and proximity to failure matters *more* at light loads — with the dumbbells
+  now targets, and proximity to failure matters _more_ at light loads — with the dumbbells
   capped at 25 lb, "light load, far from failure" is the one combination the evidence calls
   clearly ineffective. `coach_check.py::post_session` was updated at the time; this script was
   missed, so the two halves of the coaching loop disagreed, and the briefing kept advising a

--- a/web/src/__tests__/per-serving-macros.test.ts
+++ b/web/src/__tests__/per-serving-macros.test.ts
@@ -1,0 +1,84 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { storedMacrosFor, perPortion } from "../lib/nutrition/recipe-portions.ts";
+import type { RecipeMacroTotals } from "../lib/nutrition/recipe-portions.ts";
+
+const totals = (o: Partial<RecipeMacroTotals> = {}): RecipeMacroTotals => ({
+  calories: 0,
+  protein_g: 0,
+  carbs_g: 0,
+  fat_g: 0,
+  fiber_g: 0,
+  confidence: "high",
+  notes: "",
+  ...o,
+});
+
+describe("storedMacrosFor — the ingredient list is the batch, the stored figure is one serving", () => {
+  it("passes a single-serving recipe through as the SAME object", () => {
+    // Identity, not just equality. Every non-batch recipe in the library must be byte-identical
+    // to its pre-change behaviour; a subtle re-round of 60 recipes would be invisible in review
+    // and would show up only as drift in Jason's logged history.
+    const t = totals({ calories: 902, protein_g: 59.7 });
+    const { portions, stored } = storedMacrosFor(t, 1);
+    assert.equal(portions, 1);
+    assert.equal(stored, t);
+  });
+
+  it("treats null and undefined portions as one serving", () => {
+    const t = totals({ calories: 500 });
+    assert.equal(storedMacrosFor(t, null).stored, t);
+    assert.equal(storedMacrosFor(t, undefined).stored, t);
+  });
+
+  it("divides the gochujang beef batch by 3 — a real 3x overlog before this change", () => {
+    // typical_portions 3, stored 1783 kcal / 148.9 P, whole-batch ingredient list, and a valid
+    // macros_computed_at. "Ate this" wrote the entire cook into meal_log for one sitting.
+    const { portions, stored } = storedMacrosFor(
+      totals({ calories: 1783, protein_g: 148.9, carbs_g: 150, fat_g: 60, fiber_g: 21 }),
+      3,
+    );
+    assert.equal(portions, 3);
+    assert.equal(stored.calories, 594);
+    assert.equal(stored.protein_g, 49.6);
+  });
+
+  it("divides the tofu rice bowl by 2 — the recipe whose own note said '2 servings, not 1'", () => {
+    const { stored } = storedMacrosFor(totals({ calories: 829, protein_g: 67.2 }), 2);
+    assert.equal(stored.calories, 415);
+    assert.equal(stored.protein_g, 33.6);
+  });
+
+  it("does not divide by a fractional or negative count", () => {
+    // Dividing by 0.5 would DOUBLE a plate. A bad value must degrade to 'one serving', never to
+    // a multiplier — the failure has to be inert, because the output is a health log.
+    const t = totals({ calories: 800 });
+    assert.equal(storedMacrosFor(t, 0.5).stored.calories, 800);
+    assert.equal(storedMacrosFor(t, -2).stored.calories, 800);
+    assert.equal(storedMacrosFor(t, 0).stored.calories, 800);
+    assert.equal(storedMacrosFor(t, Number.NaN).stored.calories, 800);
+    assert.equal(storedMacrosFor(t, Number.POSITIVE_INFINITY).stored.calories, 800);
+  });
+
+  it("floors a fractional batch count rather than dividing by it", () => {
+    // 2.5 servings is not a thing you can plate. Flooring is the conservative read: it stores a
+    // slightly larger serving rather than a smaller one, so the log never understates.
+    const { portions, stored } = storedMacrosFor(totals({ calories: 900 }), 2.5);
+    assert.equal(portions, 2);
+    assert.equal(stored.calories, 450);
+  });
+
+  it("keeps confidence and notes off the divided result", () => {
+    // They describe the resolve, not the food. A 'low' confidence batch is still low per serving,
+    // and dividing a notes string is meaningless — so the persisted row takes them from `total`.
+    const { stored } = storedMacrosFor(totals({ calories: 1000, confidence: "low" }), 2);
+    assert.equal("confidence" in stored, false);
+    assert.equal("notes" in stored, false);
+  });
+
+  it("agrees with perPortion, which the API still returns to callers", () => {
+    const t = totals({ calories: 1783, protein_g: 148.9, carbs_g: 150, fat_g: 60, fiber_g: 21 });
+    assert.deepEqual(storedMacrosFor(t, 3).stored, perPortion(t, 3));
+  });
+});

--- a/web/src/__tests__/step-splitting.test.ts
+++ b/web/src/__tests__/step-splitting.test.ts
@@ -1,0 +1,113 @@
+// Unit tests for stepRowsFrom's sentence fallback.
+//
+// WHY THIS EXISTS
+//
+// The original splitter broke only on newlines. That is correct for the 49 recipes written as
+// line-per-step, and a silent no-op for every recipe written as one paragraph — which produced a
+// single "step" containing the whole blob, reported as a successful backfill. The strings below
+// are the real `instructions` values of the four recipes on the 2026-08-13 meal plan, all four of
+// which landed in that broken set.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { stepRowsFrom } from "../lib/nutrition/recipe-backfill.ts";
+
+const LAMB_PASTA =
+  "BATCH OF 2 - macros above are ONE SERVING. Sweat onion and garlic in the oil, add crushed " +
+  "tomatoes and reduce ~10 min. Fold in the lamb chunks LAST and off the heat - it is already " +
+  "cooked and will go tough if simmered. Wilt the spinach in. Toss with the pasta. USDA: lamb " +
+  "from cook 7618752d (258 kcal/25.6P/16.5F per 100 g cooked, USDA 174312); pasta dry USDA 168927.";
+
+const SALMON =
+  "BATCH OF 2 - macros above are ONE SERVING. Roast Brussels and green beans at 425F ~20 min; " +
+  "salmon skin-side down 12-14 min. Cook the salmon the day you eat it if possible - it holds far " +
+  "worse than chicken or chili. USDA: salmon Atlantic farmed cooked 175167.";
+
+describe("stepRowsFrom — sentence fallback for single-paragraph instructions", () => {
+  it("splits a real one-paragraph recipe into a method instead of one blob", () => {
+    const steps = stepRowsFrom(LAMB_PASTA)!;
+    assert.equal(steps.length, 4);
+    assert.match(steps[0].text, /^Sweat onion and garlic/);
+    assert.match(steps[1].text, /^Fold in the lamb chunks LAST/);
+    assert.equal(steps[2].text, "Wilt the spinach in.");
+    assert.equal(steps[3].text, "Toss with the pasta.");
+  });
+
+  it("keeps the USDA audit trail out of the numbered method but does not lose it", () => {
+    const steps = stepRowsFrom(LAMB_PASTA)!;
+    assert.equal(
+      steps.some((s) => /USDA/.test(s.text)),
+      false,
+      "a citation must never be numbered as a thing to do",
+    );
+    const tips = steps.flatMap((s) => s.tips ?? []);
+    assert.equal(
+      tips.some((t) => /USDA 174312/.test(t)),
+      true,
+      "and must still be reachable as an aside",
+    );
+  });
+
+  it("attaches a leading BATCH header to the first step, not the last", () => {
+    // It is written before any instruction, so hanging it off the final step would read as a
+    // closing remark on a recipe whose first line is the one it qualifies.
+    const steps = stepRowsFrom(LAMB_PASTA)!;
+    assert.match(steps[0].tips![0], /^BATCH OF 2/);
+  });
+
+  it("does not split on a mid-sentence semicolon", () => {
+    // "425F ~20 min; salmon skin-side down 12-14 min" is one action at one oven temperature.
+    const steps = stepRowsFrom(SALMON)!;
+    assert.match(steps[0].text, /425F ~20 min; salmon skin-side down 12-14 min\.$/);
+  });
+
+  it("leaves newline-separated recipes on the original path", () => {
+    // 49 of 72 live recipes are written this way and must not change.
+    const steps = stepRowsFrom("Brown the beef.\nAdd aromatics.\nSimmer 40 min.")!;
+    assert.deepEqual(
+      steps.map((s) => s.text),
+      ["Brown the beef.", "Add aromatics.", "Simmer 40 min."],
+    );
+  });
+
+  it("still prefers blank-line groups over single newlines", () => {
+    const steps = stepRowsFrom("Step one\nwrapped line.\n\nStep two.")!;
+    assert.equal(steps.length, 2);
+    assert.equal(steps[0].text, "Step one\nwrapped line.");
+  });
+
+  it("does not break decimals into sentences", () => {
+    const steps = stepRowsFrom("Add 1.5 tbsp tomato paste and stir.")!;
+    assert.equal(steps.length, 1);
+  });
+
+  it("falls back to the raw chunks when every sentence is an aside", () => {
+    // Returning nothing would render the recipe as having no method at all — worse than the blob.
+    const steps = stepRowsFrom("USDA: chicken 171477. USDA: broccoli 170379.")!;
+    assert.equal(steps.length, 2);
+    assert.match(steps[0].text, /USDA/);
+  });
+
+  it("strips leading numbering, as before", () => {
+    const steps = stepRowsFrom("1. Brown the beef.\n2) Add aromatics.")!;
+    assert.deepEqual(
+      steps.map((s) => s.text),
+      ["Brown the beef.", "Add aromatics."],
+    );
+  });
+
+  it("returns null for empty or whitespace-only instructions", () => {
+    assert.equal(stepRowsFrom(null), null);
+    assert.equal(stepRowsFrom("   \n  "), null);
+  });
+
+  it("renumbers sequentially after asides are pulled out", () => {
+    // step is authoritative for render order, so a gap would misnumber the printed method.
+    const steps = stepRowsFrom(SALMON)!;
+    assert.deepEqual(
+      steps.map((s) => s.step),
+      steps.map((_, i) => i + 1),
+    );
+  });
+});

--- a/web/src/components/meals/KitchenPanel.tsx
+++ b/web/src/components/meals/KitchenPanel.tsx
@@ -252,7 +252,13 @@ export function KitchenPanel({ leftovers, plan }: KitchenPanelProps) {
                       <span style={subStyle}>
                         {p.meal_type}
                         {canEatRecipe ? " · from recipe" : ""}
-                        {!cook && recipe && !recipe.macros_computed_at ? " · needs cooking" : ""}
+                        {/* The consequence is stated INLINE, not only in the button's title.
+                            This panel is used from the installed PWA on a phone, where a title
+                            attribute never appears, so on touch the difference between logging a
+                            meal and merely flagging it was one word ("Ate this" vs "Ate it"). */}
+                        {!cook && recipe && !recipe.macros_computed_at
+                          ? " · needs cooking — logs no macros"
+                          : ""}
                         {!cook && !recipe ? " · tap for amounts" : ""}
                       </span>
                     </span>
@@ -278,8 +284,12 @@ export function KitchenPanel({ leftovers, plan }: KitchenPanelProps) {
                         }
                         style={eatButtonStyle(busyId === p.id)}
                         title={
+                          // "for the batch" was true while recipes.calories held the sum of the
+                          // ingredient list. Since 2026-08-13 the resolver divides by
+                          // typical_portions on write, so this figure is ONE SERVING and calling
+                          // it the batch would misstate it by the batch size on every tooltip.
                           recipe.calories != null
-                            ? `Logs this recipe's macros (~${recipe.calories} kcal for the batch) and adds any surplus to the fridge.`
+                            ? `Logs one serving (~${recipe.calories} kcal) and adds any surplus to the fridge.`
                             : "Cooks this recipe and logs a portion's macros."
                         }
                       >

--- a/web/src/lib/nutrition/recipe-backfill.ts
+++ b/web/src/lib/nutrition/recipe-backfill.ts
@@ -128,12 +128,87 @@ export function ingredientRowsFrom(text: string): {
   return { rows, unresolved };
 }
 
-/** Numbered or newline-separated instructions -> steps. Blank-line groups win over single lines. */
+/**
+ * A sentence that is not a thing to do at the stove.
+ *
+ *   citation — "USDA: chicken breast cooked 171477; broccoli cooked 170379." The audit trail for
+ *              the macros. Real, load-bearing, and actively misleading if numbered as step 6.
+ *   meta     — "BATCH OF 3 - macros above are ONE SERVING", "DO NOT scale this back up without
+ *              confirming freezer space first." Planning context, written in shouty caps by
+ *              convention, and equally not an instruction.
+ *
+ * Both are kept — as `tips` on the adjacent step, which StepList already renders muted underneath —
+ * rather than dropped. `instructions` also survives as the fallback column, so nothing is lost
+ * either way; the point is only that the numbered method should contain the method.
+ *
+ * Deliberately narrow. A sentence that is genuinely a cooking step but happens to start with a
+ * capitalised word must NOT match, so the meta rule anchors on specific openers rather than on
+ * "looks like caps" — mis-classifying a real step would silently delete it from the method.
+ */
+const CITATION = /\bUSDA\b/i;
+const META =
+  /^(BATCH\b|HALF BATCH\b|WHOLE COOK\b|MAKES \d|DO NOT\b|NOTE[: ]|NOTES[: ]|ASSUMPTION\b|THIS IS THE TEMPLATE\b|BATCH SIZE\b)/;
+function isAside(s: string): boolean {
+  return CITATION.test(s) || META.test(s);
+}
+
+/**
+ * Split a paragraph into sentences.
+ *
+ * Only breaks on terminal punctuation followed by whitespace and a capital or digit, which leaves
+ * decimals ("1.5 tbsp") and mid-sentence semicolons ("425F ~20 min; salmon skin-side down") intact.
+ * Semicolons are deliberately NOT separators: they join clauses of one action far more often than
+ * they separate two.
+ */
+function sentences(t: string): string[] {
+  return t
+    .split(/(?<=[.!?])\s+(?=[A-Z0-9])/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Instructions -> numbered steps.
+ *
+ * Newline-separated text splits on lines, which is how it has always worked and how 49 of the 72
+ * live recipes were written. THE FALLBACK IS THE POINT OF THIS FUNCTION: the newline rule is a
+ * no-op on a single paragraph, so every recipe authored as one prose blob collapsed to a single
+ * "step" holding the entire text — valid JSON, so the backfill reported success, and the UI
+ * rendered a numbered list of one. That hit 15 of 72 recipes, including all four on the meal plan
+ * the week this was found, which is why it read as wholly broken rather than as a fifth broken.
+ */
 export function stepRowsFrom(text: string | null): RecipeStep[] | null {
   const t = (text ?? "").trim();
   if (!t) return null;
-  const chunks = (t.includes("\n\n") ? t.split(/\n{2,}/) : t.split("\n"))
+
+  const multiline = /\n/.test(t);
+  const chunks = (
+    multiline ? (t.includes("\n\n") ? t.split(/\n{2,}/) : t.split("\n")) : sentences(t)
+  )
     .map((c) => c.trim().replace(/^\d+[.)]\s*/, ""))
     .filter(Boolean);
-  return chunks.length ? chunks.map((text, i) => ({ step: i + 1, text })) : null;
+  if (!chunks.length) return null;
+
+  const steps: RecipeStep[] = [];
+  const leading: string[] = [];
+  for (const c of chunks) {
+    if (isAside(c)) {
+      if (steps.length) {
+        const last = steps[steps.length - 1];
+        last.tips = [...(last.tips ?? []), c];
+      } else {
+        leading.push(c);
+      }
+      continue;
+    }
+    steps.push({ step: steps.length + 1, text: c });
+  }
+
+  // Every sentence was an aside — a citation-only or notes-only instructions field. Returning no
+  // steps would render the recipe as having no method at all, which is worse than the blob: fall
+  // back to the original chunks so the text still reaches the reader.
+  if (!steps.length) return chunks.map((c, i) => ({ step: i + 1, text: c }));
+
+  if (leading.length) steps[0].tips = [...leading, ...(steps[0].tips ?? [])];
+  return steps;
 }

--- a/web/src/lib/nutrition/recipe-macros.ts
+++ b/web/src/lib/nutrition/recipe-macros.ts
@@ -1,4 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { perPortion, storedMacrosFor } from "./recipe-portions";
+import type { RecipeMacroTotals } from "./recipe-portions";
 import { estimateFromStructured, estimateFromText } from "./estimate";
 import type { ParsedFood } from "./parse";
 import type { RecipeIngredient } from "../types";
@@ -59,15 +61,11 @@ function toParsedFoods(rows: RecipeIngredient[]): ParsedFood[] {
  * count therefore lives on a `cook`, and per-portion macros are derived there.
  */
 
-export interface RecipeMacroTotals {
-  calories: number;
-  protein_g: number;
-  carbs_g: number;
-  fat_g: number;
-  fiber_g: number;
-  confidence: "high" | "medium" | "low";
-  notes: string;
-}
+// Re-exported so this module stays the single import site for macro types and portion maths.
+// The definitions live in the leaf module `recipe-portions.ts` because this file imports
+// `./estimate` (USDA + Ollama), which the bundler-free unit test runner cannot resolve.
+export type { RecipeMacroTotals, MacroKey } from "./recipe-portions";
+export { perPortion, storedMacrosFor } from "./recipe-portions";
 
 /** One resolved ingredient — the audit trail. A number you cannot audit is a number you
  *  cannot trust, and this is what makes the total checkable instead of hopeful. */
@@ -90,23 +88,15 @@ export interface RecipeMacros {
   unquantified: string[];
   /** Ingredients that matched no plausible USDA record and are ABSENT from the total. */
   unmatched: string[];
-  /** Hint only — what a portion would look like IF split this many ways. Not a claim. */
+  /**
+   * How many servings the ingredient list makes. LOAD-BEARING, not a hint: when this is >1 the
+   * ingredient list is a batch, and it is the divisor used to persist recipes.calories as ONE
+   * serving. It was documented as "a hint, not a claim" until 2026-08-13, and treating it as
+   * decorative is what let two batch recipes store whole-cook macros against a per-meal reading.
+   */
   typicalPortions: number | null;
+  /** One serving — the figure persisted to recipes.calories. `total` remains the whole batch. */
   perPortion: Omit<RecipeMacroTotals, "confidence" | "notes"> | null;
-}
-
-export function perPortion(
-  total: Pick<RecipeMacroTotals, "calories" | "protein_g" | "carbs_g" | "fat_g" | "fiber_g">,
-  portions: number,
-) {
-  const div = (n: number) => Math.round((n / portions) * 10) / 10;
-  return {
-    calories: Math.round(total.calories / portions),
-    protein_g: div(total.protein_g),
-    carbs_g: div(total.carbs_g),
-    fat_g: div(total.fat_g),
-    fiber_g: div(total.fiber_g),
-  };
 }
 
 /**
@@ -206,14 +196,34 @@ export async function resolveRecipeMacros(
     )
     .map((r) => (r.prep ? `${r.item}, ${r.prep}` : r.item));
 
+  // THE INGREDIENT LIST IS THE BATCH; THE STORED MACROS ARE ONE SERVING.
+  //
+  // `total` is the sum of the ingredient list, which for a batch recipe is the whole cook. Every
+  // consumer of recipes.calories — the meals page, PlannedMealDetail, the "Ate this" button,
+  // fetch_briefing_data.py — reads it as ONE meal, because that is the only reading that makes
+  // sense on a planned plate. Persisting the batch total against that assumption is not a display
+  // bug, it is a logging bug: "Ate this" writes the whole cook into meal_log for a single sitting.
+  //
+  // Two recipes were already doing exactly that when this was written — the tofu rice bowl
+  // (typical_portions 2, stored 829 kcal) and the gochujang beef batch (3, stored 1783) — both
+  // carrying whole-batch ingredient lists and a valid macros_computed_at, so both overlogged by
+  // 2x and 3x on every use. Dividing here is what lets the ingredient list say "1 lb of beef,
+  // serves 3" while the plate still says ~594 kcal.
+  //
+  // Divide on the way in rather than at each read: there are eight-odd consumers across TS and
+  // Python, and one of them forgetting is a silent 2x in a health log. The batch figure is kept
+  // in metadata so the division stays auditable and nothing is lost.
+  const typicalPortions = (recipe.typical_portions as number | null) ?? null;
+  const { portions, stored } = storedMacrosFor(total, typicalPortions);
+
   const { error: writeErr } = await db
     .from("recipes")
     .update({
-      calories: total.calories,
-      protein_g: total.protein_g,
-      carbs_g: total.carbs_g,
-      fat_g: total.fat_g,
-      fiber_g: total.fiber_g,
+      calories: stored.calories,
+      protein_g: stored.protein_g,
+      carbs_g: stored.carbs_g,
+      fat_g: stored.fat_g,
+      fiber_g: stored.fiber_g,
       macros_confidence: total.confidence,
       macros_computed_at: new Date().toISOString(),
       // Persist the working, not just the answer. Without this the only way to find out that
@@ -228,6 +238,11 @@ export async function resolveRecipeMacros(
         // Which path produced these numbers, so a re-resolve that changes a total can be
         // attributed rather than guessed at.
         macro_source: structured.length ? "structured" : "text",
+        // What the ingredient list actually sums to, and what it was divided by. Without these
+        // a stored 594 is indistinguishable from a recipe that genuinely holds 594 kcal of food,
+        // and the /3 becomes unverifiable after the fact.
+        macro_batch_total: portions > 1 ? total : null,
+        macro_portions: portions,
       },
     })
     .eq("id", recipeId)
@@ -235,7 +250,6 @@ export async function resolveRecipeMacros(
 
   if (writeErr) throw new Error(`recipe macro write failed: ${writeErr.message}`);
 
-  const typicalPortions = (recipe.typical_portions as number | null) ?? null;
   return {
     total,
     items,

--- a/web/src/lib/nutrition/recipe-portions.ts
+++ b/web/src/lib/nutrition/recipe-portions.ts
@@ -1,0 +1,57 @@
+/**
+ * Portion arithmetic for recipe macros.
+ *
+ * SPLIT OUT OF `recipe-macros.ts` DELIBERATELY, and the reason is testability rather than tidiness.
+ * `recipe-macros.ts` imports `./estimate`, which reaches USDA and Ollama; the repo's unit tests run
+ * on `node --experimental-strip-types --test` with no bundler and no install step, so importing
+ * that module from a test fails at resolution. The one line that decides whether a health log
+ * receives 594 kcal or 1783 has to be reachable by a test that actually runs, so it lives here in
+ * a leaf module with no runtime imports.
+ */
+
+export interface RecipeMacroTotals {
+  calories: number;
+  protein_g: number;
+  carbs_g: number;
+  fat_g: number;
+  fiber_g: number;
+  confidence: "high" | "medium" | "low";
+  notes: string;
+}
+
+/** The five numeric macro fields — the ones that scale with portion size. `confidence` and
+ *  `notes` describe the resolve itself and are not divisible, which is why they are excluded. */
+export type MacroKey = "calories" | "protein_g" | "carbs_g" | "fat_g" | "fiber_g";
+
+export function perPortion(
+  total: Pick<RecipeMacroTotals, MacroKey>,
+  portions: number,
+): Pick<RecipeMacroTotals, MacroKey> {
+  const div = (n: number) => Math.round((n / portions) * 10) / 10;
+  return {
+    calories: Math.round(total.calories / portions),
+    protein_g: div(total.protein_g),
+    carbs_g: div(total.carbs_g),
+    fat_g: div(total.fat_g),
+    fiber_g: div(total.fiber_g),
+  };
+}
+
+/**
+ * Decide what actually gets written to `recipes.calories` and friends.
+ *
+ * A null, absent, zero or 1 portion count all mean "the list is one serving" and pass `total`
+ * through untouched — importantly the SAME object, so a non-batch recipe is byte-identical to its
+ * pre-2026-08-13 behaviour. Fractional or negative values are treated as 1 rather than trusted:
+ * dividing by 0.5 would double a plate, and there is no sane reading of a negative. A bad value
+ * has to degrade to inert, never to a multiplier, because the output is a health log.
+ */
+export function storedMacrosFor(
+  total: RecipeMacroTotals,
+  typicalPortions: number | null | undefined,
+): { portions: number; stored: Pick<RecipeMacroTotals, MacroKey> } {
+  const valid =
+    typeof typicalPortions === "number" && Number.isFinite(typicalPortions) && typicalPortions > 1;
+  const portions = valid ? Math.floor(typicalPortions) : 1;
+  return { portions, stored: portions > 1 ? perPortion(total, portions) : total };
+}


### PR DESCRIPTION
## What

Three fixes found while auditing why this week's planned meals showed no macros. All three sit on the path between a recipe and `meal_log`.

## 1. A batch recipe logged the whole cook as one meal

`resolveRecipeMacros` persisted `total.calories` — the sum of the ingredient list — into `recipes.calories`. Every consumer reads that as ONE serving, because that is the only reading that makes sense on a planned plate. For a recipe whose ingredient list is the batch, those are different numbers, and the difference went into `meal_log` rather than onto a screen where it could be noticed.

Two recipes were live in exactly that state, both with a valid `macros_computed_at`:

| Recipe | `typical_portions` | Stored | Actually one serving |
|---|---|---|---|
| Tofu + Kimchi + Edamame + Baby Bella Rice Bowl | 2 | 829 kcal | 415 |
| Gochujang Beef + Tofu + Sweet Potato + Cabbage (batch) | 3 | 1783 kcal | 594 |

The tofu bowl's own ingredient row carries the note *"this makes a ~1,034 g plate, which is 2 servings, not 1"*. The data knew. Nothing read it.

The resolver now divides by `typical_portions` on write, so the ingredient list can say *1 lb of beef, serves 3* while the stored plate stays ~594 kcal.

**Why divide on write rather than at each read.** There are eight-odd consumers of `recipes.calories` across TypeScript and Python — the meals page, `PlannedMealDetail`, `KitchenPanel`, the meal-plan API, `lib/tools/meals.ts`, `fetch_briefing_data.py`. Dividing at the read sites makes correctness depend on all of them remembering, and one forgetting is a silent 2× in a health log. `metadata.macro_batch_total` and `macro_portions` keep the division auditable, so a stored 594 is still distinguishable from a recipe that genuinely holds 594 kcal of food.

`typical_portions` was documented as *"Hint only — what a portion would look like IF split this many ways. Not a claim."* It is now load-bearing, and treating it as decorative is what allowed the two rows above. Null, zero, 1, fractional and negative all pass the total through untouched — and through the *same object*, so the 60 single-serving recipes are byte-identical to their previous behaviour. A bad value has to degrade to inert, never to a multiplier, because the output is a health log.

**No migration is included, deliberately.** Both affected recipes need `fdc_id` pins before they can be safely re-resolved (see the note on record mismatches below), so correcting their stored values is a follow-up rather than something to bundle here.

## 2. Single-paragraph recipes got a "method" of one step

`stepRowsFrom` split only on newlines. Right for the 49 recipes written line-per-step; a silent no-op for any recipe written as one prose blob, which produced a single "step" holding the entire text. Valid JSON, so the backfill reported success and the UI rendered a numbered list of one.

That hit **15 of 72 recipes — including all four on the current meal plan**, which is why it read as wholly broken rather than as a fifth broken.

There is now a sentence fallback for text with no newlines. The wrinkle is that `instructions` is not method text; it is four things concatenated — batch framing, actual method, planning rationale, and the USDA audit trail. Naive sentence-splitting would render **"Step 6: USDA: chicken breast cooked 171477; broccoli cooked 170379"** as a thing to do at the stove. So citations and shouty planning asides are pulled out and attached as `tips` on the adjacent step, which `StepList` already renders muted underneath. Nothing is discarded, and `instructions` survives as the fallback column regardless.

The aside rule anchors on specific openers rather than on "looks like caps": mis-classifying a real cooking step would silently delete it from the method, which is a worse failure than leaving an aside in. Decimals (`1.5 tbsp`) and mid-sentence semicolons (`425F ~20 min; salmon skin-side down`) do not split.

## 3. "Logs no macros" was only ever said in a tooltip

An unresolved recipe falls through to a status-only path that marks the plan row `eaten` and writes no `meal_log` row. That was already labelled — button copy `Ate it` rather than `Ate this`, plus a `title` explaining it — so this is a narrowing, not a rewrite. But `title` never appears on touch, and this panel is used from the installed PWA on a phone, where the two outcomes differed by a single word. The consequence is now stated inline in the row.

While there: the recipe "Ate this" tooltip described its figure as `kcal for the batch`, which stops being true with change 1 above. It now reads *one serving*.

## Shape

`perPortion` and the new `storedMacrosFor` moved to a leaf module, `recipe-portions.ts`. Not tidiness — `recipe-macros.ts` imports `./estimate`, which reaches USDA and Ollama, and the repo's unit tests run on `node --experimental-strip-types --test` with no bundler and no install step. Importing it from a test fails at module resolution. The one line deciding whether a health log receives 594 kcal or 1783 has to be reachable by a test that actually runs. `recipe-macros.ts` re-exports both symbols, so no import site changed.

## Testing

- **19 new unit tests** across `per-serving-macros.test.ts` and `step-splitting.test.ts`; full suite **114/114 green** (was 95).
- The step tests run against the *real* `instructions` strings of the recipes on the 2026-08-13 plan, not invented fixtures.
- Pins the identity case (a non-batch recipe returns the same object), that a fractional or negative portion count cannot become a multiplier, that a citation is never numbered as a step but is still reachable as a tip, and that newline-separated recipes stay on the original path.
- `tsc --noEmit` clean, `eslint` 0 errors, `prettier --check` clean.

## Follow-ups, not in this PR

- Re-resolve the two batch recipes to correct their stored values — needs `fdc_id` pins first.
- Pin `fdc_id` across the library. Without pins the resolver re-runs USDA search and mismatches badly: `avocado oil` → *Avocado, Hass, peeled, raw*, `sweet potato` → *Sweet potato **leaves***, canned kidney beans → the raw dry record. `isPlausibleMatch` passes all of these because each shares a distinctive word.
- Sweep the 16 spoon-class ingredient lines still stored in grams, and add a guard so the convention stops drifting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaQpyhtHDejGLYkcWj6xkd
