### PR TITLE
meals: recipe steps rendered without their numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Recipe methods rendered with no numbers, so steps and their asides looked identical.**
+  `globals.css` begins with `@import "tailwindcss"`, and Tailwind v4's preflight resets
+  `ol, ul { list-style: none }`. `StepList` never restated it, so its `<ol>` drew no markers —
+  silently, since nothing errors and the markup is a perfectly correct ordered list. The component's
+  own doc comment claimed "numbered steps" and `<li value={s.step}>` set the numbering right; the
+  browser simply had nothing to draw. `IngredientList` escaped only because it happens to declare
+  `listStyle: "disc outside"`, which is why ingredients looked fine while the method did not.
+
+  The visible result was a recipe card whose method read as one undifferentiated run of lines, with
+  the `BATCH OF 2` header and the USDA citation indistinguishable from the cooking steps. Fixed by
+  declaring `decimal outside`, and the same latent bug is fixed in the workout plan's exercise
+  tips, which had been reserving `paddingLeft` for bullets that never drew.
+
+  The styles moved to `step-list-styles.ts` so a unit test can import them — the test runner cannot
+  load `.tsx`, and **the defect was an absent property**, which nothing but an assertion of its
+  presence will catch. Type checking cannot see it, and review did not.
+
 ### Added
 
 - **Spoon-measured ingredients are now enforced at the write path, not just documented.** "Things

--- a/web/src/__tests__/step-list-styles.test.ts
+++ b/web/src/__tests__/step-list-styles.test.ts
@@ -1,0 +1,56 @@
+// Regression test for StepList's list markers.
+//
+// WHY THIS EXISTS
+//
+// `globals.css` begins with `@import "tailwindcss"`, and Tailwind v4's preflight resets
+// `ol, ul { list-style: none }`. A list that does not restate `list-style` renders with NO markers,
+// silently — nothing errors, the markup is still a correct `<ol>`, and the component's own doc
+// comment can go on claiming "numbered steps" while the page shows none.
+//
+// That shipped. The recipe method rendered as an undifferentiated run of lines, with the asides
+// indistinguishable from the steps, and it took Jason pasting the page back to find it. The defect
+// was an ABSENT property, which review does not catch and no type checks — only asserting the
+// presence of the declaration does.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  stepListStyle,
+  stepTipsStyle,
+  stepLegacyStyle,
+} from "../components/meals/step-list-styles.ts";
+
+describe("StepList styles survive the Tailwind preflight reset", () => {
+  it("numbers the method — the <ol> must ask for decimal explicitly", () => {
+    assert.ok(stepListStyle.listStyle, "listStyle must be declared, not left to the browser");
+    assert.match(String(stepListStyle.listStyle), /decimal/);
+  });
+
+  it("marks asides with discs so they read as subordinate to the numbered steps", () => {
+    assert.ok(stepTipsStyle.listStyle, "listStyle must be declared, not left to the browser");
+    assert.match(String(stepTipsStyle.listStyle), /disc/);
+  });
+
+  it("keeps steps and asides visually distinct", () => {
+    // If these ever converge, the method and its footnotes render identically again, which is the
+    // exact symptom that was reported.
+    assert.notEqual(stepListStyle.listStyle, stepTipsStyle.listStyle);
+    assert.notEqual(stepListStyle.color, stepTipsStyle.color);
+  });
+
+  it("indents both lists so the markers are not clipped by `outside` positioning", () => {
+    // `outside` draws the marker in the padding box. Zero padding hides it just as effectively as
+    // `list-style: none`, so the fix is only complete with room to draw it.
+    for (const s of [stepListStyle, stepTipsStyle]) {
+      assert.ok(s.paddingLeft, "a list using `outside` markers needs left padding");
+      assert.notEqual(parseFloat(String(s.paddingLeft)), 0);
+    }
+  });
+
+  it("leaves the legacy free-text fallback alone", () => {
+    // It is a <p>, not a list — it must keep pre-line so stored newlines still break.
+    assert.equal(stepLegacyStyle.whiteSpace, "pre-line");
+    assert.equal(stepLegacyStyle.listStyle, undefined);
+  });
+});

--- a/web/src/components/fitness/weekly-workout-plan.tsx
+++ b/web/src/components/fitness/weekly-workout-plan.tsx
@@ -224,6 +224,10 @@ function ExerciseRow({
               style={{
                 fontSize: "var(--t-micro)",
                 color: "var(--color-text-muted)",
+                // Explicit, because Tailwind v4's preflight resets `ol, ul { list-style: none }`.
+                // Without this the bullets never drew and the paddingLeft below was reserving
+                // space for a marker that was not there.
+                listStyle: "disc outside",
                 margin: "var(--space-1) 0 0",
                 paddingLeft: "var(--space-4)",
                 lineHeight: 1.5,

--- a/web/src/components/meals/StepList.tsx
+++ b/web/src/components/meals/StepList.tsx
@@ -1,4 +1,10 @@
 import type { RecipeStep } from "@/lib/types";
+import {
+  stepListStyle as listStyle,
+  stepDurationStyle as durationStyle,
+  stepTipsStyle as tipsStyle,
+  stepLegacyStyle as legacyStyle,
+} from "./step-list-styles";
 
 /**
  * A recipe's method, as numbered steps.
@@ -39,28 +45,3 @@ export function StepList({ steps, text }: { steps?: RecipeStep[] | null; text?: 
   if (!trimmed) return null;
   return <p style={legacyStyle}>{trimmed}</p>;
 }
-
-const listStyle: React.CSSProperties = {
-  fontSize: "var(--t-meta)",
-  color: "var(--color-text)",
-  lineHeight: 1.6,
-  paddingLeft: "1.3em",
-  margin: 0,
-};
-
-const durationStyle: React.CSSProperties = { color: "var(--color-text-muted)" };
-
-const tipsStyle: React.CSSProperties = {
-  listStyle: "disc outside",
-  paddingLeft: "1.1em",
-  margin: "0.2em 0 0",
-  color: "var(--color-text-muted)",
-};
-
-const legacyStyle: React.CSSProperties = {
-  fontSize: "var(--t-meta)",
-  color: "var(--color-text)",
-  lineHeight: 1.6,
-  whiteSpace: "pre-line",
-  margin: 0,
-};

--- a/web/src/components/meals/step-list-styles.ts
+++ b/web/src/components/meals/step-list-styles.ts
@@ -1,0 +1,46 @@
+import type { CSSProperties } from "react";
+
+/**
+ * Styles for `StepList`, in a plain `.ts` module so a unit test can import them.
+ *
+ * WHY THEY LIVE HERE. `list-style` must be declared explicitly on every list in this app, never
+ * left to the browser default. `globals.css` starts with `@import "tailwindcss"`, and Tailwind v4's
+ * preflight resets `ol, ul { list-style: none }`. A list that does not restate it renders with no
+ * markers at all — silently, because nothing errors and the markup is still a correct `<ol>`.
+ *
+ * That is the bug this file was split out to prevent recurring. `StepList` promised "numbered
+ * steps" in its own doc comment and set `<li value={s.step}>` correctly, but its `<ol>` never asked
+ * for `decimal`. The method rendered as an undifferentiated run of lines, indistinguishable from
+ * its own tips — which is how it reached Jason. `IngredientList` escaped only because it happens to
+ * declare `listStyle: "disc outside"`.
+ *
+ * The defect was an ABSENT property. Only a test asserting its presence can catch that, and the
+ * test runner cannot import a `.tsx` file, so the constants have to be reachable from here.
+ */
+
+export const stepListStyle: CSSProperties = {
+  fontSize: "var(--t-meta)",
+  color: "var(--color-text)",
+  lineHeight: 1.6,
+  listStyle: "decimal outside",
+  paddingLeft: "1.3em",
+  margin: 0,
+};
+
+export const stepDurationStyle: CSSProperties = { color: "var(--color-text-muted)" };
+
+/** Asides under a step: muted, and disc-marked so they read as subordinate to the numbers. */
+export const stepTipsStyle: CSSProperties = {
+  listStyle: "disc outside",
+  paddingLeft: "1.1em",
+  margin: "0.2em 0 0",
+  color: "var(--color-text-muted)",
+};
+
+export const stepLegacyStyle: CSSProperties = {
+  fontSize: "var(--t-meta)",
+  color: "var(--color-text)",
+  lineHeight: 1.6,
+  whiteSpace: "pre-line",
+  margin: 0,
+};


### PR DESCRIPTION
## What

Recipe methods were rendering without their numbers, so the steps and their asides looked identical. Reported from the page:

```
How to make it

Sweat onion and garlic in the oil, add crushed tomatoes and reduce ~10 min.
BATCH OF 2 - macros above are ONE SERVING.
Fold in the lamb chunks LAST and off the heat - it is already cooked…
Wilt the spinach in.
Toss with the pasta.
USDA: lamb from cook 7618752d…
```

`steps_json` was correct — four steps, with the batch header as a tip on step 1 and the citation as a tip on step 4. The data was right and the markup was right. Nothing drew.

## Cause

`globals.css` line 1 is `@import "tailwindcss"`, and **Tailwind v4's preflight resets `ol, ul { list-style: none }`**. `StepList`'s style object declared `fontSize`, `color`, `lineHeight`, `paddingLeft` and `margin` — but never `listStyle`, so it inherited `none`.

This fails in the worst possible way: nothing errors, the DOM is a perfectly correct `<ol>` with `<li value={n}>`, the numbering logic is right, and the component's own doc comment goes on claiming *"A recipe's method, as numbered steps."* The browser simply had nothing to draw. Type checking cannot see an absent CSS property, and neither did review.

`IngredientList` was unaffected **only** because it happens to declare `listStyle: "disc outside"` — which is exactly why the ingredients half looked correct while the method half did not, and why the report was "ingredients are good, the steps aren't".

## Fix

`decimal outside` on the method list. An audit of every `<ol>`/`<ul>` in the app found one more instance of the same latent bug — the workout plan's exercise tips, reserving `paddingLeft: var(--space-4)` for bullets that never drew — fixed here too.

## Why the styles moved to their own module

The defect was an **absent property**. The only thing that catches that class of bug is a test asserting the declaration exists, and the repo's test runner is `node --experimental-strip-types --test` with no bundler and no install step, which cannot load a `.tsx` file. So the constants moved to `step-list-styles.ts`, mirroring why `recipe-portions.ts` was split out in #669.

## Testing

- **5 new unit tests**; suite **129/129 green** (was 124).
- Asserts the `<ol>` asks for `decimal` and the tips ask for `disc`; that the two never converge on the same marker *or* the same colour, since that convergence is the reported symptom; that both lists keep non-zero left padding, because `outside` markers draw in the padding box and zero padding hides them as effectively as `none`; and that the legacy free-text fallback stays a `<p>` with `pre-line`.
- `tsc --noEmit` clean, `eslint` 0 errors, `prettier --check` clean.

## Note

This is a rendering fix only — no data changes. The stored `steps_json` was already regenerated for all 70 recipes (24 by the shipped splitter, 3 hand-authored where `instructions` held a decision log rather than a method).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaQpyhtHDejGLYkcWj6xkd
