### PR TITLE
meals: enforce recipe invariants in the database, and audit what is stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **Recipe invariants are enforced in the database, and audited on demand.** The write-path guard
+  added previously covers `POST /api/recipes` and `PATCH /api/recipes/[id]` — the app's own editor.
+  It does not cover anything talking to PostgREST with the service key, which is how every
+  assistant- and script-written recipe has ever been created, and therefore how every defect these
+  rules exist to prevent actually got in. A rule enforced only on the path that never broke it is
+  not enforcement.
+
+  `recipes_check_invariants` is a `BEFORE INSERT OR UPDATE` trigger that rejects a spoon-measured
+  ingredient given a bare gram quantity, and a recipe storing more than 1,200 kcal as a single
+  serving. It runs for every writer, psql included. Verified against the live database through
+  PostgREST: both violation classes rejected with an actionable message, legitimate writes
+  unaffected.
+
+  `fdc_id` pinning is deliberately **not** enforced. 45 ingredient lines have no safe USDA match —
+  gochujang has no record at all, and lines like "cod, cooked weight" need a prep-state judgement —
+  so a NOT NULL rule would make those recipes uneditable. `web/scripts/audit-recipes.ts` reports
+  them instead: visible, not fatal. It also reports undeclared batches, unstamped macros, single-step
+  methods and unsplit instructions, exits non-zero when anything is found, and reuses the shipped
+  `spoonViolations` rather than restating the rules.
+
+  The audit's first run found **four more recipes storing a whole batch as one serving**, all with
+  valid stamps and all silently overlogging: Lemon Garlic Chicken + Pasta at **4,646 kcal per
+  "meal"**, Ribeye Roast Meal Prep at 3,884, Chicken/Rice/Green Beans at 2,810, and Turkey Pasta at
+  1,623. Each declared its own portion count in its instructions and nothing read it. Corrected by
+  division — the batch totals were right, only the divide was missing — taking the lower bound where
+  a range was given, so the stored serving errs large and the log never understates.
+
 ### Fixed
 
 - **Recipe methods rendered with no numbers, so steps and their asides looked identical.**

--- a/supabase/migrations/20260813120000_recipe_invariants.sql
+++ b/supabase/migrations/20260813120000_recipe_invariants.sql
@@ -1,0 +1,82 @@
+-- Enforce two recipe invariants in the DATABASE, not just in the API route.
+--
+-- WHY HERE AND NOT ONLY IN parseIngredientRows
+--
+-- The TypeScript guard added in #670 covers POST /api/recipes and PATCH /api/recipes/[id] — the
+-- app's own editor. It does not cover anything talking to PostgREST with the service key, which is
+-- how every assistant- and script-written recipe has ever been created. That is the path that
+-- produced all of the defects these rules exist to prevent:
+--
+--   * the spoon rule was applied by hand across 25 recipes on 2026-07-31 and every recipe written
+--     afterwards ignored it, twice, until a human noticed;
+--   * six recipes stored a WHOLE BATCH against a per-meal reading, so "Ate this" logged the entire
+--     cook as one sitting — up to 4,646 kcal in a single meal_log row.
+--
+-- A rule enforced only on the path that never broke it is not enforcement. These run on every
+-- writer, including psql.
+--
+-- WHAT IS DELIBERATELY *NOT* ENFORCED: fdc_id pinning. 45 ingredient lines are still unpinned
+-- because their food genuinely has no safe USDA match (gochujang has no record at all; "cod, cooked
+-- weight" needs a prep-state judgement). A NOT NULL rule would block editing those recipes at all.
+-- scripts/audit-recipes.ts reports them instead — visible, not fatal.
+
+create or replace function public.recipes_check_invariants()
+returns trigger
+language plpgsql
+as $$
+declare
+  ing        jsonb;
+  item_text  text;
+  unit_text  text;
+  qty        numeric;
+begin
+  if new.ingredients_json is not null and jsonb_typeof(new.ingredients_json) = 'array' then
+    for ing in select * from jsonb_array_elements(new.ingredients_json)
+    loop
+      item_text := lower(coalesce(ing->>'item', ''));
+      unit_text := ing->>'unit';
+      -- A non-numeric quantity is a different defect with its own error; ignore it here.
+      begin
+        qty := nullif(ing->>'quantity', '')::numeric;
+      exception when others then
+        qty := null;
+      end;
+
+      -- Gochujang is exempt: it has NO USDA record, so no portion table exists to resolve a volume
+      -- against, and writing "1 tbsp" would leave a re-resolve with no way back to grams. It keeps
+      -- grams and carries the spoon in its label.
+      if unit_text = 'g'
+         and qty is not null and qty > 0
+         and item_text !~ 'gochujang'
+         and item_text ~ '(avocado|olive|sesame|cooking|vegetable) oil|tomato paste|soy sauce|shoyu|tamari|peanut butter|flaxseed'
+      then
+        raise exception
+          'recipe "%": ingredient "%" is measured by spoon, not weighed — give a volume (tsp/tbsp) and keep the grams in the item label',
+          new.name, ing->>'item';
+      end if;
+    end loop;
+  end if;
+
+  -- An undeclared batch stores the whole cook where every consumer expects one serving. The ceiling
+  -- is set from the library's real spread: the largest genuine single plate is ~1,050 kcal (the
+  -- ribeye) and the smallest real batch was 1,562, so 1,200 separates them without a false positive.
+  if coalesce(new.calories, 0) > 1200 and coalesce(new.typical_portions, 1) <= 1 then
+    raise exception
+      'recipe "%": % kcal stored as a single serving — set typical_portions, or "Ate this" logs the whole batch as one meal',
+      new.name, new.calories;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists recipes_check_invariants on public.recipes;
+
+create trigger recipes_check_invariants
+  before insert or update of ingredients_json, calories, typical_portions, name
+  on public.recipes
+  for each row
+  execute function public.recipes_check_invariants();
+
+comment on function public.recipes_check_invariants() is
+  'Rejects spoon-measured ingredients given a bare gram quantity, and batch recipes that never declared typical_portions. Applies to every writer including PostgREST, which the API-layer guard in #670 does not cover.';

--- a/web/scripts/audit-recipes.ts
+++ b/web/scripts/audit-recipes.ts
@@ -1,0 +1,156 @@
+/**
+ * Report every recipe that violates a stored-data invariant. Read-only — it changes nothing.
+ *
+ * WHY THIS EXISTS
+ *
+ * Two of this project's conventions have now drifted silently for weeks at a time. The spoon-unit
+ * rule was applied by hand across 25 recipes on 2026-07-31 and every recipe written afterwards
+ * ignored it, until a human noticed. `macros_computed_at` being absent made four planned meals
+ * unloggable, and that was found by accident too. The pattern is not carelessness; it is that
+ * nothing looks. A rule with no reporter is a rule that decays to a suggestion.
+ *
+ * The write path (`parseIngredientRows`) and the database trigger both REJECT bad data going
+ * forward. This is the other half: it tells you what is already stored, including rows written
+ * before those guards existed and rows written by tooling that talks to PostgREST directly.
+ *
+ * Usage, from web/:
+ *   node --experimental-strip-types scripts/audit-recipes.ts
+ *   node --experimental-strip-types scripts/audit-recipes.ts --json
+ *
+ * Needs SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY and OWNER_USER_ID. Exits 1 if anything is found,
+ * so it can gate a cron or a CI job.
+ */
+import { spoonViolations } from "../src/lib/nutrition/recipe-structured.ts";
+import type { RecipeIngredient, RecipeStep } from "../src/lib/types.ts";
+
+interface Row {
+  id: string;
+  name: string;
+  ingredients_json: RecipeIngredient[] | null;
+  steps_json: RecipeStep[] | null;
+  instructions: string | null;
+  typical_portions: number | null;
+  calories: number | null;
+  macros_computed_at: string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+interface Finding {
+  kind: string;
+  recipe: string;
+  detail: string;
+}
+
+/** A single plate above this is almost certainly a batch that forgot to declare its portions.
+ *  Set from the library's real spread: the largest genuine single serving is ~1050 kcal (the
+ *  ribeye), and the smallest known batch is 1562. Anything past this deserves a human look. */
+const SINGLE_PLATE_CEILING = 1200;
+
+function audit(rows: Row[]): Finding[] {
+  const out: Finding[] = [];
+  for (const r of rows) {
+    const ings = r.ingredients_json ?? [];
+    const quantified = ings.filter((i) => typeof i.quantity === "number" && i.quantity > 0);
+
+    for (const v of spoonViolations(r.ingredients_json)) {
+      out.push({
+        kind: "spoon-unit",
+        recipe: r.name,
+        detail: `"${v.item}" is ${v.grams} g — should be ${v.suggestion}`,
+      });
+    }
+
+    const unpinned = quantified.filter((i) => !i.fdc_id);
+    if (unpinned.length) {
+      out.push({
+        kind: "unpinned-fdc-id",
+        recipe: r.name,
+        // Without a pin a re-resolve re-runs USDA search, which has matched avocado OIL to an
+        // avocado and sweet potato to sweet potato LEAVES — both passing the plausibility guard.
+        detail: `${unpinned.length}/${quantified.length} ingredients unpinned: ${unpinned
+          .map((i) => i.item)
+          .slice(0, 4)
+          .join(", ")}${unpinned.length > 4 ? "…" : ""}`,
+      });
+    }
+
+    // A batch whose portions are undeclared stores the whole cook where every consumer expects one
+    // serving, so "Ate this" logs the entire batch into meal_log for a single sitting.
+    if ((r.calories ?? 0) > SINGLE_PLATE_CEILING && (r.typical_portions ?? 1) <= 1) {
+      out.push({
+        kind: "undeclared-batch",
+        recipe: r.name,
+        detail: `${r.calories} kcal stored as one serving with typical_portions=${r.typical_portions}`,
+      });
+    }
+
+    if (r.calories != null && !r.macros_computed_at) {
+      out.push({
+        kind: "unstamped-macros",
+        recipe: r.name,
+        // macros_computed_at is the gate: without it the recipe renders as a stub and "Ate this"
+        // marks the plan row eaten while writing no meal_log row at all.
+        detail: `has ${r.calories} kcal but no macros_computed_at — renders as a stub, logs nothing`,
+      });
+    }
+
+    if (r.steps_json?.length === 1 && r.steps_json[0].text.length > 200) {
+      out.push({
+        kind: "single-step-blob",
+        recipe: r.name,
+        detail: `the whole method is one ${r.steps_json[0].text.length}-char step`,
+      });
+    }
+
+    if (!r.steps_json?.length && r.instructions?.trim()) {
+      out.push({ kind: "no-structured-steps", recipe: r.name, detail: "instructions never split" });
+    }
+  }
+  return out;
+}
+
+async function main() {
+  const url = process.env.SUPABASE_URL?.replace("host.docker.internal", "localhost");
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const owner = process.env.OWNER_USER_ID;
+  if (!url || !key || !owner)
+    throw new Error("SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY and OWNER_USER_ID are required");
+
+  const select =
+    "id,name,ingredients_json,steps_json,instructions,typical_portions,calories,macros_computed_at,metadata";
+  const res = await fetch(
+    `${url}/rest/v1/recipes?user_id=eq.${owner}&select=${select}&order=name`,
+    {
+      headers: { apikey: key, Authorization: `Bearer ${key}` },
+    },
+  );
+  if (!res.ok) throw new Error(`recipe fetch failed: ${res.status} ${await res.text()}`);
+  const rows = (await res.json()) as Row[];
+
+  const findings = audit(rows);
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify({ scanned: rows.length, findings }, null, 2));
+  } else {
+    const byKind = new Map<string, Finding[]>();
+    for (const f of findings) byKind.set(f.kind, [...(byKind.get(f.kind) ?? []), f]);
+    console.log(`scanned ${rows.length} recipes\n`);
+    for (const [kind, list] of [...byKind].sort((a, b) => b[1].length - a[1].length)) {
+      console.log(`${kind}  (${list.length})`);
+      for (const f of list) console.log(`   ${f.recipe}\n      ${f.detail}`);
+      console.log();
+    }
+    console.log(findings.length ? `${findings.length} findings` : "clean");
+  }
+  if (findings.length) process.exitCode = 1;
+}
+
+// Only run when invoked directly, so `audit` stays importable by tests.
+if (process.argv[1] && import.meta.filename === process.argv[1]) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(2);
+  });
+}
+
+export { audit, SINGLE_PLATE_CEILING };
+export type { Row, Finding };

--- a/web/src/__tests__/audit-recipes.test.ts
+++ b/web/src/__tests__/audit-recipes.test.ts
@@ -1,0 +1,122 @@
+// Unit tests for the recipe invariant audit.
+//
+// WHY THIS EXISTS
+//
+// Both of this project's data conventions have decayed silently for weeks at a time, and both were
+// found by a human reading a page rather than by anything in the system. The write-path guard and
+// the database trigger stop NEW violations; this reporter is what surfaces the ones already stored,
+// including rows written before either guard existed. Its own thresholds are worth pinning, because
+// a reporter that stops reporting is indistinguishable from a clean library.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { audit, SINGLE_PLATE_CEILING } from "../../scripts/audit-recipes.ts";
+import type { Row } from "../../scripts/audit-recipes.ts";
+
+const recipe = (o: Partial<Row> = {}): Row => ({
+  id: "r1",
+  name: "Test Recipe",
+  ingredients_json: null,
+  steps_json: null,
+  instructions: null,
+  typical_portions: 1,
+  calories: 500,
+  macros_computed_at: "2026-08-13T00:00:00Z",
+  metadata: null,
+  ...o,
+});
+
+const kinds = (rows: Row[]) => audit(rows).map((f) => f.kind);
+
+describe("audit-recipes", () => {
+  it("passes a fully compliant recipe", () => {
+    assert.deepEqual(
+      audit([
+        recipe({
+          ingredients_json: [
+            { item: "chicken breast", quantity: 300, unit: "g", fdc_id: 171077 },
+            { item: "avocado oil (14 g)", quantity: 1, unit: "tbsp", fdc_id: 173573 },
+            { item: "salt, pepper", quantity: null, unit: null },
+          ],
+          steps_json: [{ step: 1, text: "Cook it." }],
+        }),
+      ]),
+      [],
+    );
+  });
+
+  it("catches the batch that logs the whole cook as one meal", () => {
+    // The real one: Lemon Garlic Chicken + Pasta, 4646 kcal with typical_portions null.
+    const f = audit([recipe({ calories: 4646, typical_portions: null })]);
+    assert.deepEqual(
+      f.map((x) => x.kind),
+      ["undeclared-batch"],
+    );
+    assert.match(f[0].detail, /4646 kcal stored as one serving/);
+  });
+
+  it("does not flag a large single plate as a batch", () => {
+    // The ribeye is genuinely ~1010 kcal for one sitting. A ceiling that catches it would train
+    // Jason to ignore the report, which is how the spoon rule decayed in the first place.
+    assert.deepEqual(kinds([recipe({ calories: 1010, typical_portions: 1 })]), []);
+    assert.ok(SINGLE_PLATE_CEILING > 1010 && SINGLE_PLATE_CEILING < 1562);
+  });
+
+  it("does not flag a batch that correctly declared its portions", () => {
+    assert.deepEqual(kinds([recipe({ calories: 594, typical_portions: 3 })]), []);
+  });
+
+  it("catches macros with no computed-at stamp", () => {
+    // The gate: without it the recipe renders as a stub and "Ate this" writes no meal_log row.
+    assert.deepEqual(kinds([recipe({ calories: 354, macros_computed_at: null })]), [
+      "unstamped-macros",
+    ]);
+  });
+
+  it("catches unpinned quantified ingredients but ignores amount-less ones", () => {
+    const f = audit([
+      recipe({
+        ingredients_json: [
+          { item: "chicken breast", quantity: 300, unit: "g" },
+          { item: "salt, pepper", quantity: null, unit: null },
+        ],
+      }),
+    ]);
+    assert.deepEqual(
+      f.map((x) => x.kind),
+      ["unpinned-fdc-id"],
+    );
+    assert.match(f[0].detail, /1\/1 ingredients unpinned/);
+  });
+
+  it("catches a spoon-class ingredient still in grams", () => {
+    assert.ok(
+      kinds([
+        recipe({ ingredients_json: [{ item: "avocado oil", quantity: 4, unit: "g", fdc_id: 1 }] }),
+      ]).includes("spoon-unit"),
+    );
+  });
+
+  it("catches a method that is still one undivided blob", () => {
+    assert.ok(
+      kinds([recipe({ steps_json: [{ step: 1, text: "x".repeat(250) }] })]).includes(
+        "single-step-blob",
+      ),
+    );
+  });
+
+  it("does not flag a short single-step recipe", () => {
+    // "Scramble, fry, or boil." is a legitimate one-step method.
+    assert.deepEqual(
+      kinds([recipe({ steps_json: [{ step: 1, text: "Scramble, fry, or boil." }] })]),
+      [],
+    );
+  });
+
+  it("catches instructions that never became structured steps", () => {
+    assert.deepEqual(kinds([recipe({ instructions: "Cook it.", steps_json: null })]), [
+      "no-structured-steps",
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Closes the gap under the write-path guard, and adds a reporter for what is already stored.

## The gap

The guard added in #670 covers `POST /api/recipes` and `PATCH /api/recipes/[id]` — the app's own editor. It does not cover anything talking to PostgREST with the service key.

That is how **every** assistant- and script-written recipe has ever been created, and therefore how every defect these rules exist to prevent actually got in. A rule enforced only on the path that never broke it is not enforcement.

## The trigger

`recipes_check_invariants`, `BEFORE INSERT OR UPDATE`, rejects two things:

1. A spoon-measured ingredient given a bare gram quantity — the rule that has now drifted twice, both times caught by a human rather than the system.
2. A recipe storing more than 1,200 kcal as a single serving — the shape that logs a whole cook into `meal_log` for one sitting.

Verified against the **live** database through PostgREST, which is the path that mattered:

```
TEST 1 — spoon-class ingredient in bare grams
   REJECTED: ingredient "avocado oil" is measured by spoon, not weighed…
TEST 2 — a batch stored as one serving
   REJECTED: 2500 kcal stored as a single serving — set typical_portions,
             or "Ate this" logs the whole batch as one meal
TEST 3 — a legitimate write
   ACCEPTED, recipe restored byte-identical
```

The 1,200 ceiling is set from the library's real spread: the largest genuine single plate is the ribeye at ~1,010 kcal, the smallest real batch was 1,562. A ceiling that fired on the ribeye would train the reader to ignore it, which is precisely how the spoon rule decayed.

**`fdc_id` pinning is deliberately not enforced.** 45 ingredient lines have no safe USDA match — gochujang has no record at all, and `cod, cooked weight` needs a prep-state judgement — so a NOT NULL rule would make those recipes uneditable. Better reported than fatal.

## The audit

`web/scripts/audit-recipes.ts` — read-only, exits non-zero when anything is found so it can gate a cron or CI. It reuses the shipped `spoonViolations` rather than restating the rules, and reports unpinned ingredients, undeclared batches, unstamped macros, single-step methods, and instructions that never became steps.

**Its first run found four more recipes storing a whole batch as one serving**, every one with a valid `macros_computed_at`, every one silently overlogging on "Ate this":

| Recipe | Stored as one meal | Portions | Corrected |
|---|---|---|---|
| Lemon Garlic Chicken + Pasta | **4,646 kcal** | 8 | 581 |
| Ribeye Roast Meal Prep | 3,884 | 6 | 647 |
| Chicken, Rice, Green Beans | 2,810 | 5 | 562 |
| Turkey Pasta | 1,623 | 4 | 406 |

Each of these declared its own portion count **in its own instructions** — *"Divide by the number of portions; ~8 is typical. This is the largest recipe in the library and logging it as one meal is a 4600 kcal error."* The warning was written down and nothing read it. That is the argument for a reporter in one sentence.

Corrected by division: the batch totals were already right, only the divide was missing, so this was arithmetic on existing numbers rather than a re-resolve. Where a range was given the lower bound was taken, so the stored serving errs large and the log never understates.

## Also done in the same pass (data, not code)

`fdc_id` pin coverage went **11% → 72%** (32/293 → 212/293 ingredient lines), using records verified individually against the ingredient's prep state. The remaining 81 lines are left unpinned on purpose: foods with no USDA record, meats needing a cooked-vs-raw judgement, and non-foods like `scant`, `water` and `mixed veg` that are data-quality problems the audit should keep surfacing rather than have a pin forced onto them.

Several lookups during that pass returned exactly the documented failures — `almonds raw` matched **Abiyuch**, `oats raw` matched oat *oil*, `chicken thigh` matched chicken *skin*. Matching nothing beats matching the wrong food.

## Testing

- **10 new unit tests**; suite **139/139 green** (was 129).
- Pins the ceiling from both sides: a 4,646 kcal batch is caught, a 1,010 kcal ribeye is not.
- Pins that a short single-step recipe ("Scramble, fry, or boil.") is not reported as a blob, and that amount-less rows are not reported as unpinned.
- `tsc --noEmit` clean, `eslint` 0 errors, `prettier --check` clean.

## Deploy

The migration is **already applied** to the self-hosted database (that is how the live verification above was run). No app rebuild is needed — this branch adds no runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaQpyhtHDejGLYkcWj6xkd
