### PR TITLE
docs: source recipe technique from tested publications, not from me

### DIFF
--- a/docs/technique-sources.md
+++ b/docs/technique-sources.md
@@ -1,0 +1,111 @@
+# Recipe technique sources
+
+Recipe **technique** is taken from well-reviewed, tested sources — not generated. This is the same
+rule that already governs macros: numbers come from USDA, never from a model. Jason asked for it on
+2026-08-13, the day a step reading `Simmer 40 min.` with no heat level burned a chili to the bottom
+of the pan.
+
+## The split — this is the load-bearing part
+
+|                | Comes from                     | Why                                                                                                                                                                                   |
+| -------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Technique**  | a tested, well-reviewed source | heat per stage, covered/uncovered, stir frequency, doneness cues, resting. This is where the recipes were weak and where thousands of reviewers have already found the failure modes. |
+| **Quantities** | **us**                         | targeted to 1800 kcal / 150 g protein and built around what is in the fridge. Source recipes are sized for families and would break both the macros and the portion count.            |
+| **Macros**     | **USDA**, pinned by `fdc_id`   | unchanged. See `feedback_mrbridge_resolver_needs_fdc_pins`.                                                                                                                           |
+
+Adopting a source's _amounts_ is the failure mode to avoid. Take how it is cooked, not how much.
+
+Record the provenance in `recipes.metadata.technique_source`:
+
+```json
+{
+  "url": "https://…",
+  "title": "…",
+  "rating": 4.86,
+  "reviews": 357,
+  "taken": "heat levels per stage, covered simmer, stir frequency",
+  "not_taken": "quantities and ingredient list — those stay macro-targeted",
+  "recorded_on": "2026-08-13"
+}
+```
+
+## Source policy
+
+**Prefer** publications that test and explain: America's Test Kitchen / Cook's Illustrated, NYT
+Cooking, Once Upon a Chef, The Kitchn. They publish the _reason_ a parameter is what it is, which is
+what makes a technique transferable to a different quantity.
+
+**Avoid** SEO recipe farms. A search for chili technique returned nine results, of which the vague,
+mutually-contradictory ones were mostly aggregators recycling each other. Rating alone is not the
+filter — a tested method with stated reasoning is.
+
+**Serious Eats and Bon Appétit block our crawler** and cannot be fetched. Both are otherwise
+excellent; if a Kenji method is wanted it has to be entered by hand.
+
+## Sourced parameters
+
+Everything below was read off the source, not recalled.
+
+### Braise / chili — [Once Upon a Chef, Classic Beef Chili](https://www.onceuponachef.com/recipes/classic-beef-chili.html) (4.86★, 357 reviews)
+
+Brown **HIGH**; aromatics **MEDIUM**, stirring frequently 4–6 min; bloom the spices 1–2 min before
+any liquid; simmer **LOW and COVERED**. Do not drain the rendered liquid. Thin with water if it
+tightens; finish uncovered to thicken. Their simmer is 2 h and they note longer is better.
+
+### Pan-seared chicken breast — [ATK](https://www.americastestkitchen.com/recipes/5861-pan-seared-chicken-breasts) · [The Kitchn](https://www.thekitchn.com/how-to-cook-golden-juicy-chicken-breast-on-the-stove-248171)
+
+Oil in the skillet over **MEDIUM-HIGH until smoking**; 3–4 min to brown the first side; flip, **drop
+to MEDIUM**, 3–4 min more; **165°F** internal; rest 3–5 min.
+Cold-start variant ([ATK](https://www.americastestkitchen.com/recipes/16150-cold-start-pan-seared-chicken-breasts)):
+oiled chicken into an unheated dry skillet, **HIGH** 2 min, flip every 2 min, drop to **MEDIUM** to
+**155°F**, rest 10 min — juicier, and the better option for meal prep.
+
+### Roasted vegetables — [ATK](https://www.americastestkitchen.com/articles/8018-how-to-roast-any-vegetable) · [The Kitchn](https://www.thekitchn.com/how-to-roast-any-vegetable-101221)
+
+**425°F**, single layer with space between. **Crowding steams instead of roasting** — split across
+two sheets rather than pile one. Stir every 10–15 min. Done when easily pierced and showing charred
+edges. Times at 425°F:
+
+| Family                                              | Time          |
+| --------------------------------------------------- | ------------- |
+| Roots — potato, sweet potato, carrot, beet          | **30–45 min** |
+| Winter squash                                       | 20–60 min     |
+| Crucifers — broccoli, cauliflower, Brussels sprouts | **15–25 min** |
+| Soft — zucchini, bell pepper                        | 10–20 min     |
+| Thin — asparagus, green beans                       | 10–20 min     |
+
+This immediately corrected our Roast Chicken recipe: sweet potato had been written at 25–30 min,
+under the 30–45 the root-vegetable row calls for.
+
+### Rice, absorption — [ATK water:rice ratio](https://www.americastestkitchen.com/articles/1692-nailing-the-perfect-ratio-of-water-to-rice) · [The Kitchn](https://www.thekitchn.com/how-to-cook-rice-on-the-stove-44333)
+
+Rinse under cool water to shed loose starch. Bring to a boil, then **reduce to LOW and COVER**.
+White **18–20 min**; brown **45 min**. **Do not peek** — lifting the lid changes both the time and
+the absorption. Rest off the heat, lid on, **10 min**.
+
+### Pan-seared steak — [ATK](https://www.americastestkitchen.com/recipes/12368-pan-seared-strip-steaks) · [Once Upon a Chef](https://www.onceuponachef.com/recipes/how-to-cook-steak-on-the-stovetop.html) · [The Kitchn](https://www.thekitchn.com/how-to-sear-a-steak-23733871)
+
+Heavy pan — cast iron or stainless — preheated over **HIGH** until it just smokes (~10 min for cast
+iron). 3–4 min a side for a 1–1½″ cut. Pull at **125–130°F** for medium-rare. Rest **5–10 min**.
+
+### Roasted salmon — [ATK](https://www.americastestkitchen.com/recipes/4127-oven-roasted-salmon) · [The Kitchn](https://www.thekitchn.com/how-to-cook-salmon-in-the-oven-cooking-lessons-from-the-kitchn-204559)
+
+**425°F**, skin-side down on a lined sheet, **12–15 min**, until opaque and it flakes. **125–130°F**
+for medium; 145°F is the food-safety figure if you want it fully done.
+
+### Pan-fried tofu — [The Kitchn](https://www.thekitchn.com/how-to-make-crispy-tofu-without-deepfrying-cooking-lessons-from-the-kitchn-201265) · [ATK](https://www.americastestkitchen.com/articles/7718-how-to-cook-tofu-that-stays-intact)
+
+Press first — wet tofu will not brown. **MEDIUM-HIGH until the oil shimmers**; the tofu should
+sizzle on contact, and if it does not, the pan is not ready. Single layer, **4–5 min a side**, and
+**wait until it releases from the pan** before turning it — forcing it early is what tears it.
+
+## Enforcement
+
+`web/scripts/audit-recipes.ts` reports `timed-step-no-heat`: any step of 3 minutes or more with no
+heat cue. Burner levels, oven temperatures, `off the heat`, and unambiguous plain-English cues
+(`screaming hot pan`, `boiling water`) all count. **`simmer`, `boil` and `saute` do not** — they name
+a target state without saying what to set the burner to, which is exactly the gap that caused the
+burn.
+
+Steps that are timed but genuinely unheated — resting, pressing tofu, thawing, brining, tempering —
+are exempt. They were 17 of the first 69 hits, and a check that cries wolf gets ignored.

--- a/web/scripts/audit-recipes.ts
+++ b/web/scripts/audit-recipes.ts
@@ -57,8 +57,32 @@ const SINGLE_PLATE_CEILING = 1200;
  * without saying what to set the burner to, which is precisely the gap that caused the burn. What
  * counts is a burner level, an oven temperature, or an explicit instruction that the heat is off.
  */
-const HEAT_CUE =
-  /\b(low|medium|high|medium-low|medium-high|med-high)\b|\b\d{3}\s?°?\s?[FC]\b|\boff the heat\b|\bresidual heat\b|\bheat off\b/i;
+const HEAT_CUE = new RegExp(
+  [
+    // Burner levels and oven temperatures — the unambiguous forms.
+    String.raw`\b(low|medium|high|medium-low|medium-high|med-high)\b`,
+    String.raw`\b\d{3}\s?°?\s?[FC]\b`,
+    // Explicitly no heat.
+    String.raw`\boff the heat\b|\bresidual heat\b|\bheat off\b`,
+    // Plain-English cues that DO pin the temperature, even without a burner setting. "Screaming
+    // hot pan" and "boiling water" leave no doubt what to do; excluding them was flagging steps
+    // that were already clear, and a check that cries wolf gets ignored.
+    String.raw`\b(screaming|ripping|smoking|hot)\s+(hot\s+)?(pan|skillet|oven)\b`,
+    String.raw`\bdry hot pan\b|\bboiling water\b|\brolling boil\b|\bsteamer\b`,
+  ].join("|"),
+  "i",
+);
+
+/**
+ * Timed steps where nothing is being heated at all.
+ *
+ * Resting a steak, pressing tofu, thawing shrimp, brining a breast, bringing meat up from the
+ * fridge — these take time and involve no burner, so demanding a heat setting is nonsense. On the
+ * first live run 17 of 69 flagged steps were this, which is a false-positive rate that would have
+ * had me "correcting" steps that were already right.
+ */
+const NON_THERMAL =
+  /\b(rest|rested|resting|thaw|thawed|press(ed)?|brine[d]?|marinate[d]?|chill(ed)?|soak(ed)?|salt(ed)? .*(ahead|before)|out of the fridge|room temperature|come to temp|sit|stand|cool(ed)? (uncovered|completely)?)\b/i;
 
 /** Steps short enough to be unattended are exempt — a 1-2 minute step cannot scorch unwatched. */
 const UNATTENDED_FLOOR_MINS = 3;
@@ -70,8 +94,13 @@ function timedStepsMissingHeat(steps: RecipeStep[] | null): string[] {
       const inlineMins = /\b(\d+)(?:\s*[-–]\s*\d+)?\s*min\b/i.exec(s.text);
       const mins = s.duration_mins ?? (inlineMins ? Number(inlineMins[1]) : 0);
       if (mins < UNATTENDED_FLOOR_MINS) return false;
-      // Tips carry the "bare simmer means the lowest setting" style guidance, so they count too.
-      return !HEAT_CUE.test([s.text, ...(s.tips ?? [])].join(" "));
+      const all = [s.text, ...(s.tips ?? [])].join(" ");
+      if (HEAT_CUE.test(all)) return false;
+      // Only exempt as non-thermal when the step names NO cooking verb — "sear 5 min then rest"
+      // still needs a heat level for the searing half.
+      const cooks =
+        /\b(sear|brown|fry|saut|simmer|boil|roast|bake|steam|grill|braise|blister|char|wilt|reduce|toast)/i;
+      return !(NON_THERMAL.test(all) && !cooks.test(all));
     })
     .map((s) => `step ${s.step}: "${s.text.slice(0, 60)}${s.text.length > 60 ? "…" : ""}"`);
 }


### PR DESCRIPTION
## What

Establishes recipe **technique** as sourced from tested publications rather than generated, and fixes the heat-cue check that was wrong about a quarter of what it flagged.

## The rule

Same one that already governs macros: numbers come from USDA, never from a model. Technique now comes from sources that have been tested and reviewed by thousands of people, never from me. It would have prevented the burn — no tested chili recipe says `simmer 40 min` with no heat level.

**The load-bearing part is the split:**

| | Comes from | Why |
|---|---|---|
| Technique | tested source | heat per stage, covered/uncovered, stir frequency, doneness cues |
| **Quantities** | **us** | macro-targeted to 1800/150 and built around the fridge. Source recipes are family-sized and would break both the macros and the portion count |
| Macros | USDA, `fdc_id`-pinned | unchanged |

Adopting a source's *amounts* is the failure mode to avoid. Take how it's cooked, not how much. Provenance goes in `recipes.metadata.technique_source`, including a `not_taken` field.

## Sourced parameters

`docs/technique-sources.md` records what was actually read off the sources for seven families: braise, pan-seared chicken breast (including ATK's cold-start variant), roasted vegetables, absorption rice, seared steak, roasted salmon, pan-fried tofu. Includes ATK's roasting-time table by vegetable family, which is the single most reusable thing in there.

**It has already paid twice:**

- The chili's simmer should be **covered**, not the lid-ajar I'd guessed at — a closed lid holds the liquid that stops the scorch.
- Sweet potato was written at 25–30 min when ATK's root-vegetable row at 425°F is **30–45**.

**Source policy:** prefer publications that test *and explain the reasoning* — ATK/Cook's Illustrated, NYT Cooking, Once Upon a Chef, The Kitchn — because a stated reason is what makes a technique transferable to a different quantity. Rating alone is not the filter; the vague, mutually-contradictory results in these searches were mostly aggregators recycling each other. Serious Eats and Bon Appétit **block our crawler** and cannot be fetched, which is recorded so nobody wastes time discovering it again.

## The check was wrong about 19 of 69 steps

Running it against the live library exposed two defects, and reviewing that output before editing anything is the only reason no already-correct step got "fixed":

**False positives — it demanded a heat setting on steps that heat nothing.** `Rest 8-10 min`, `Press the tofu 20 min`, `Thaw the shrimp in cold water ~15 min`, `Steak out of the fridge 30 min ahead`, `brined 30 min`. 17 of 69. Now exempt — but only when the step names no cooking verb, so `sear 5 min then rest` still needs its heat level.

**False negatives — it rejected real cues written in plain English.** `Screaming hot pan`, `dry hot pan`, `boiling water` all pin the temperature perfectly well without naming a burner setting.

69 flagged steps → **50**, across 41 → 35 recipes. `simmer`/`boil`/`saute` still deliberately do not count, since naming a target state without a burner setting is the original gap.

## Testing

Suite **150/150 green**, unchanged — the existing heat-cue tests all still hold under the widened cue set and the new exemption. `tsc --noEmit`, `eslint` and `prettier --check` clean.

Three files unrelated to this work (`settings/page.tsx`, `calendar/range/route.ts`, `metric-preferences.ts`) are unformatted on `main`; `prettier --write .` picked them up and they were reverted to keep this PR scoped. Worth a separate cleanup.

## Next

The 35 recipes with genuinely unqualified steps are reported, not yet rewritten. Applying the family parameters to each is the remaining sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaQpyhtHDejGLYkcWj6xkd
