### PR TITLE
meals: every recipe now says how hot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Every recipe in the library now says how hot.** The `timed-step-no-heat` check went from 41
+  recipes to **zero**: 45 steps across 33 recipes were rewritten with the heat level, pan guidance,
+  covered/uncovered state and doneness cue taken from the sourced technique families in
+  `docs/technique-sources.md`. Quantities were not touched — only how the food is cooked.
+
+  Three timings were corrected against the sources rather than merely annotated. Brown rice was
+  written at 25-30 min in one recipe and 40 in another; ATK and The Kitchn both give **45 min**
+  covered on low, and 25-30 leaves it chalky. White rice was at 15 min against their **18-20**.
+
+  The check itself needed two precision fixes found by running it on real data. It demanded an exact
+  `boiling water`, so `boiling salted water` was flagged. And it looked for cooking verbs across the
+  whole step including tips, so it fired on _"wet tofu will not **brown**"_, _"pat them dry or they
+  **steam** grey"_, _"the whole game in an air **fryer**"_, and a tip mentioning a _"**roasted**
+  vegetable"_ on a resting step — all steps that heat nothing. It now reads the instruction (first
+  sentence, tips excluded), while still flagging a step whose instruction genuinely cooks before it
+  rests.
+
 ### Added
 
 - **The audit now catches a timed cooking step that never says how hot.** A recipe step read, in

--- a/web/scripts/audit-recipes.ts
+++ b/web/scripts/audit-recipes.ts
@@ -68,7 +68,9 @@ const HEAT_CUE = new RegExp(
     // hot pan" and "boiling water" leave no doubt what to do; excluding them was flagging steps
     // that were already clear, and a check that cries wolf gets ignored.
     String.raw`\b(screaming|ripping|smoking|hot)\s+(hot\s+)?(pan|skillet|oven)\b`,
-    String.raw`\bdry hot pan\b|\bboiling water\b|\brolling boil\b|\bsteamer\b`,
+    // "boiling salted water" and "boiling well-salted water" are the same instruction as "boiling
+    // water" — allow an adjective or two between them rather than demanding the exact phrase.
+    String.raw`\bdry hot pan\b|\bboiling(\s+\w+){0,2}\s+water\b|\brolling boil\b|\bsteamer\b`,
   ].join("|"),
   "i",
 );
@@ -96,11 +98,20 @@ function timedStepsMissingHeat(steps: RecipeStep[] | null): string[] {
       if (mins < UNATTENDED_FLOOR_MINS) return false;
       const all = [s.text, ...(s.tips ?? [])].join(" ");
       if (HEAT_CUE.test(all)) return false;
+
       // Only exempt as non-thermal when the step names NO cooking verb — "sear 5 min then rest"
       // still needs a heat level for the searing half.
+      //
+      // Look for that verb in the INSTRUCTION ONLY: the first sentence, tips excluded. Cooking
+      // words turn up constantly in the surrounding rationale — "wet tofu will not BROWN", "pat
+      // them dry or they STEAM grey", "dry surface is the whole game in an air FRYER", and a tip
+      // on a resting step that mentions a "ROASTED vegetable". Every one of those was a false
+      // positive on the live run, and each would have had a heat level bolted onto a step that
+      // heats nothing.
+      const instruction = s.text.split(/(?<=[.!?])\s/)[0];
       const cooks =
         /\b(sear|brown|fry|saut|simmer|boil|roast|bake|steam|grill|braise|blister|char|wilt|reduce|toast)/i;
-      return !(NON_THERMAL.test(all) && !cooks.test(all));
+      return !(NON_THERMAL.test(all) && !cooks.test(instruction));
     })
     .map((s) => `step ${s.step}: "${s.text.slice(0, 60)}${s.text.length > 60 ? "…" : ""}"`);
 }

--- a/web/src/__tests__/heat-cue.test.ts
+++ b/web/src/__tests__/heat-cue.test.ts
@@ -112,3 +112,49 @@ describe("timedStepsMissingHeat", () => {
     assert.deepEqual(timedStepsMissingHeat(null), []);
   });
 });
+
+describe("timedStepsMissingHeat — precision fixes from the live sweep", () => {
+  it("accepts boiling water with adjectives in the way", () => {
+    // "Pasta into boiling salted water in the last 12 min" was flagged by an exact-phrase match.
+    assert.deepEqual(
+      timedStepsMissingHeat([
+        { step: 1, text: "Pasta into boiling salted water in the last 12 min." },
+      ]),
+      [],
+    );
+  });
+
+  it("ignores cooking verbs that appear only in the rationale, not the instruction", () => {
+    // Every one of these was a live false positive: the step heats nothing, but a cooking word
+    // turns up in the sentence explaining WHY.
+    for (const text of [
+      "Press the tofu 20 min under something heavy. Wet tofu will not brown, it will only stick.",
+      "Thaw the 227 g shrimp in cold water ~15 min. Pat them properly DRY or they steam grey.",
+      "Thighs patted completely dry and salted at least 20 min ahead. Dry surface is the whole game in an air fryer.",
+    ]) {
+      assert.deepEqual(timedStepsMissingHeat([{ step: 1, text }]), [], text.slice(0, 40));
+    }
+  });
+
+  it("ignores a cooking verb that appears only in a tip", () => {
+    assert.deepEqual(
+      timedStepsMissingHeat([
+        {
+          step: 1,
+          text: "Rest the chicken 5-10 min before slicing, then portion into 3 containers.",
+          tips: ["The template: a big cut of meat, a roasted vegetable and a starch."],
+        },
+      ]),
+      [],
+    );
+  });
+
+  it("still flags a step whose INSTRUCTION cooks, even if it also rests", () => {
+    // The exemption must not swallow the searing half of "sear 5 min, then rest".
+    assert.equal(
+      timedStepsMissingHeat([{ step: 1, text: "Sear 5-6 min a side in the oil. Rest 5 min." }])
+        .length,
+      1,
+    );
+  });
+});


### PR DESCRIPTION
## What

Completes the technique sweep. `timed-step-no-heat` goes from **41 recipes to zero**.

## The sweep

45 steps across 33 recipes rewritten with the heat level, pan guidance, covered/uncovered state and doneness cue drawn from the families in `docs/technique-sources.md`. **Quantities were not touched** — only how the food is cooked, per the split that policy sets out.

Grouped by family so the same food is cooked the same way everywhere: absorption rice, steamed brassicas, seared chicken breast, sautéed vegetables, charred sprouts, ground meat, braised cod, fried tofu, shellfish/boil, seared fish, roasted vegetables.

**Three timings were corrected against the sources, not merely annotated:**

| | Was | Source says |
|---|---|---|
| Brown rice | 25-30 min (one recipe), 40 (another) | **45 min** covered on low |
| White rice | 15 min | **18-20 min** |

25-30 minutes leaves brown rice chalky. Rice time barely varies with quantity, so the small portions here don't excuse it. Both ATK and The Kitchn agree.

## Two precision fixes to the check

Both found by running against real data rather than fixtures, which is the only reason no correct step got "fixed":

**Exact-phrase matching.** It demanded `boiling water`, so `Pasta into boiling salted water` was flagged. Now allows an adjective or two in between.

**Cooking verbs in the rationale.** It searched the whole step *including tips*, so it fired on steps that heat nothing:

- *"Press the tofu 20 min… wet tofu will not **brown**"*
- *"Thaw the shrimp in cold water… pat them dry or they **steam** grey"*
- *"Thighs patted dry and salted 20 min ahead… the whole game in an air **fryer**"*
- *"Rest the chicken 5-10 min"* — with a tip mentioning a *"**roasted** vegetable"*

It now reads the instruction only (first sentence, tips excluded), while still flagging a step whose instruction genuinely cooks before it rests — `Sear 5-6 min a side. Rest 5 min.` is still caught.

## Testing

- **4 new tests**; suite **154/154 green**.
- The new cases are the four real false positives above, pinned verbatim, plus the sear-then-rest case that must stay flagged.
- `tsc --noEmit`, `eslint`, `prettier --check` clean.

## Remaining audit findings

45 `unpinned-fdc-id` and 1 `unstamped-macros`, both unchanged and both deliberate — foods with no safe USDA match, and one recipe blocked on how count-units (`2 large` eggs) should resolve to grams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaQpyhtHDejGLYkcWj6xkd
