### PR TITLE
docs: correct user_metric_preferences label in data-sources.md (#653)

### DIFF
--- a/.claude/rules/data-sources.md
+++ b/.claude/rules/data-sources.md
@@ -27,8 +27,10 @@ says "MCP tool", that tool is available to you directly in this session.
 | `backlog_items` + `backlog_sessions` | Manual + TMDB/IGDB/OpenLibrary metadata | `/api/backlog/*`, or `list_backlog` / `add_backlog_item` / `update_backlog_item` / `log_backlog_session` **MCP tools** |
 | `notifications`, `packages` | ntfy push history; Gmail package scan | `/api/cron/sync` |
 | `stocks_cache`, `sports_cache` | Polygon.io; ESPN | `/api/stocks/refresh`, `/api/sports/refresh` |
-| `user_metric_preferences` | Unit preferences (kg/lb) | `/settings` |
+| `user_metric_preferences` | Per-metric **source** preference — which integration to trust for each metric (e.g. HRV from Oura, body composition from Google Health). Rows are `(user_id, metric, preferred_source)`; `metric` ∈ sleep/hrv/steps/active_calories/readiness/body_composition. **Not units.** Empty in prod → falls back to `METRIC_DEFAULTS` (`web/src/lib/metric-preferences.ts`) | `/settings` (integrations panel writes it via the `saveMetricPreferences` server action; per-metric upsert) |
 | `chat_sessions`, `chat_messages` | **Orphaned.** Retained for history; nothing writes them since the chat was deleted (#476) | — |
+
+**Units are not a table.** Display units come solely from `profile.weight_unit`. Weights are stored canonically in **kg** (`strength_session_sets.weight_kg`, `exercise_prs.weight_pr_kg`) and converted at the UI boundary by `kgToDisplay` / `displayToKg` in `web/src/lib/units.ts`. There is no separate units table — if you are hunting a unit bug, this is the only place units live.
 
 ## Nutrition: the numbers come from data, not from a model
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Documentation
+
+- **`data-sources.md` mislabelled `user_metric_preferences` as a units table.** The row read
+  "Unit preferences (kg/lb)", but the table has nothing to do with units — it maps a metric
+  category to a preferred data source (`(user_id, metric, preferred_source)`, e.g. HRV from Oura,
+  body composition from Google Health) and is written by the `/settings` integrations panel. The
+  wrong label sent a session hunting a unit-conversion bug that did not exist. Corrected the row and
+  added a note that units live solely in `profile.weight_unit` — storage is canonical kg, converted
+  at the UI boundary by `web/src/lib/units.ts`. (#653)
+
 ### Fixed
 
 - **"Ate this" logged a fraction of a batch meal.** `cooks` stores the whole cook; `recipes` stores


### PR DESCRIPTION
## Problem

`.claude/rules/data-sources.md` documented `user_metric_preferences` as **"Unit preferences (kg/lb)"**. The table has nothing to do with units — per `web/src/lib/metric-preferences.ts` it maps a metric category to a preferred data source: `(user_id, metric, preferred_source)`, e.g. HRV from Oura, body composition from Google Health. The wrong label sends a reader hunting a unit-conversion bug that doesn't exist (which is exactly what prompted the issue).

## Changes

- Corrected the `user_metric_preferences` row to describe per-metric **source** preference, with the column shape, the `metric` enum, and the empty-table → `METRIC_DEFAULTS` fallback.
- Documented that `/settings` writes it (integrations panel → `saveMetricPreferences` server action; per-metric upsert). Verified in `web/src/app/(protected)/settings/page.tsx` + `web/src/components/settings/integrations-settings.tsx`.
- Added a note that units are **not** a table: display units come solely from `profile.weight_unit`, storage is canonical kg (`strength_session_sets.weight_kg`, `exercise_prs.weight_pr_kg`), conversion at the UI boundary by `web/src/lib/units.ts`.
- CHANGELOG updated under `[Unreleased]`.

Docs-only; no code paths touched.

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)