### PR TITLE
fix: flip workout_plans.status to completed on session log (#666)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **A completed workout still read as a miss.** Nothing in the app ever moved
+  `workout_plans.status` off `planned` — logging the workout left the plan `planned` forever, and
+  `coach_check.py` escalates off consecutive missed *planned* days (2 misses drops volume, 3
+  concludes the program is wrong). A stale past `planned` row is indistinguishable from a miss, so
+  an audit found 11 past plans still `planned`, **9 of them sessions actually completed** — the
+  coaching loop was reading near-total failure during a consistent training block, the same
+  open-loop defect that killed the first coaching attempt.
+
+  Logging a set (`POST /api/strength-sessions`) or saving the end-of-workout recap (`PATCH`) now
+  flips the linked plan to `completed` via a shared `markPlanCompleted` helper. The recap is
+  optional, so both paths write it — a sets-only workout no longer stays `planned`. The flip is
+  idempotent (a `.neq('status','completed')` guard makes repeat set-logs a no-op) and non-fatal
+  (a failure is surfaced as `workout_plan_update_error`, never swallowed). A migration backfills
+  historical rows by FK or same-date match. (#666)
+
 - **"Ate this" logged a fraction of a batch meal.** `cooks` stores the whole cook; `recipes` stores
   one serving. `createCook` copied the recipe's figures in unscaled, so a cook came out short by
   exactly its batch size — and `eatFromCook`, which divides the cook total by `portions` to get a

--- a/supabase/migrations/20260813130000_backfill_workout_plan_status.sql
+++ b/supabase/migrations/20260813130000_backfill_workout_plan_status.sql
@@ -1,0 +1,22 @@
+-- #666: nothing in the app ever set workout_plans.status to 'completed'. A plan created as
+-- 'planned' stayed 'planned' even after its session was logged, so coach_check.py read done days
+-- as misses. The app now flips status on set-log / recap (POST + PATCH /api/strength-sessions);
+-- this backfills the historical rows so past adherence reads true.
+--
+-- Idempotent: prod was hand-corrected 2026-08-10, so this is a no-op there. It makes any other
+-- environment (dev, seeded demo) consistent, and re-running is safe.
+--
+-- A session links to its plan two ways: the workout_plan_id FK, or same user + same date
+-- (sessions are frequently logged without the FK, matched only by performed_on = date). Only
+-- 'planned' rows are touched, so an explicit 'cancelled'/'skipped' is never clobbered.
+
+update workout_plans p
+set status = 'completed',
+    updated_at = now()
+where p.status = 'planned'
+  and exists (
+    select 1
+    from strength_sessions s
+    where s.user_id = p.user_id
+      and (s.workout_plan_id = p.id or s.performed_on = p.date)
+  );

--- a/web/src/__tests__/mark-plan-completed.test.ts
+++ b/web/src/__tests__/mark-plan-completed.test.ts
@@ -1,0 +1,107 @@
+// Unit tests for markPlanCompleted — the single place that flips workout_plans.status to
+// 'completed' when a session is logged.
+//
+// WHY THIS EXISTS (#666)
+//
+// Nothing in the app ever set workout_plans.status off 'planned'. Logging the workout left the
+// plan 'planned', and coach_check.py reads a past 'planned' row as a MISS — so on 2026-08-10, 11
+// past plans were stale, 9 of them sessions actually completed, and the coaching loop saw
+// near-total failure during a consistent training block.
+//
+// The failure is invisible to a type check: the update is well-formed, it just never ran. These
+// tests pin the behaviour that matters — the flip is scoped to the right plan AND user, it is
+// guarded so it cannot un-complete or churn, and a DB error is returned (never swallowed).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { markPlanCompleted } from "../lib/fitness/mark-plan-completed.ts";
+
+type Filter = [op: string, column: string, value: unknown];
+
+interface Recorder {
+  table?: string;
+  updatePayload?: Record<string, unknown>;
+  filters: Filter[];
+  updateCalled: boolean;
+}
+
+/** Minimal Supabase stub that records the update chain and resolves to a fixed result. */
+function fakeClient(result: { error: { message: string } | null }) {
+  const rec: Recorder = { filters: [], updateCalled: false };
+
+  const builder = {
+    eq(column: string, value: unknown) {
+      rec.filters.push(["eq", column, value]);
+      return builder;
+    },
+    neq(column: string, value: unknown) {
+      rec.filters.push(["neq", column, value]);
+      return builder;
+    },
+    // Thenable: awaiting the terminal filter resolves to the Supabase-shaped result.
+    then(resolve: (v: { error: unknown }) => void) {
+      resolve({ error: result.error });
+    },
+  };
+
+  const client = {
+    from(table: string) {
+      rec.table = table;
+      return {
+        update(payload: Record<string, unknown>) {
+          rec.updateCalled = true;
+          rec.updatePayload = payload;
+          return builder;
+        },
+      };
+    },
+  };
+
+  // The helper only needs .from().update().eq().neq(); the cast keeps it honest at the call site.
+  return { client: client as unknown as Parameters<typeof markPlanCompleted>[0], rec };
+}
+
+describe("markPlanCompleted", () => {
+  it("no-ops (no DB call) when planId is null or undefined", async () => {
+    for (const planId of [null, undefined]) {
+      const { client, rec } = fakeClient({ error: null });
+      const err = await markPlanCompleted(client, "user-1", planId);
+      assert.equal(err, null);
+      assert.equal(rec.updateCalled, false, "must not issue an update without a plan id");
+    }
+  });
+
+  it("flips status to completed, scoped to plan id AND user, guarded against re-completing", async () => {
+    const { client, rec } = fakeClient({ error: null });
+    const err = await markPlanCompleted(client, "user-1", "plan-42");
+
+    assert.equal(err, null);
+    assert.equal(rec.table, "workout_plans");
+    assert.equal(rec.updatePayload?.status, "completed");
+    assert.ok(rec.updatePayload?.updated_at, "should stamp updated_at");
+
+    // Both scoping filters must be present — a flip missing the user scope would touch other
+    // users' rows; missing the id would touch every plan.
+    assert.deepEqual(
+      rec.filters.filter((f) => f[0] === "eq"),
+      [
+        ["eq", "id", "plan-42"],
+        ["eq", "user_id", "user-1"],
+      ],
+    );
+
+    // The neq guard is what makes repeat calls (every set in a workout) a 0-row no-op instead of
+    // a rewrite, and stops a completed plan from being needlessly re-touched.
+    assert.deepEqual(
+      rec.filters.filter((f) => f[0] === "neq"),
+      [["neq", "status", "completed"]],
+    );
+  });
+
+  it("returns the error message rather than throwing or swallowing it", async () => {
+    const { client } = fakeClient({ error: { message: "rls denied" } });
+    const err = await markPlanCompleted(client, "user-1", "plan-42");
+    assert.equal(err, "rls denied");
+  });
+});

--- a/web/src/app/api/strength-sessions/route.ts
+++ b/web/src/app/api/strength-sessions/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { todayString } from "@/lib/timezone";
 import { upsertExercisePRs } from "@/lib/fitness/compute-prs";
+import { markPlanCompleted } from "@/lib/fitness/mark-plan-completed";
 
 interface LogSetBody {
   performed_on?: string;
@@ -106,7 +107,22 @@ export async function POST(req: Request) {
 
   if (setErr) return Response.json({ error: setErr.message }, { status: 500 });
 
-  return Response.json({ session_id: sessionId, set: setRow }, { status: 201 });
+  // A logged set means the day's plan was done — close the completion loop (#666). The plan id
+  // rides on the request; fall back to the existing session's link when the body omits it.
+  const planUpdateError = await markPlanCompleted(
+    supabase,
+    user.id,
+    body.workout_plan_id ?? existing?.workout_plan_id ?? null,
+  );
+
+  return Response.json(
+    {
+      session_id: sessionId,
+      set: setRow,
+      ...(planUpdateError ? { workout_plan_update_error: planUpdateError } : {}),
+    },
+    { status: 201 },
+  );
 }
 
 export async function PATCH(req: Request) {
@@ -186,10 +202,21 @@ export async function PATCH(req: Request) {
   if (error) return Response.json({ error: error.message }, { status: 500 });
   if (!data) return Response.json({ error: "Session not found" }, { status: 404 });
 
+  // Saving a recap means the workout happened — flip the linked plan to completed (#666). Prefer
+  // the session's stored link; fall back to the plan id the recap carried when the session had none.
+  const planUpdateError = await markPlanCompleted(
+    supabase,
+    user.id,
+    (data.workout_plan_id as string | null) ?? body.workout_plan_id ?? null,
+  );
+
   // Fire-and-forget PR computation on session completion
   upsertExercisePRs(supabase, user.id, sessionId).catch(() => {});
 
-  return Response.json(data);
+  return Response.json({
+    ...data,
+    ...(planUpdateError ? { workout_plan_update_error: planUpdateError } : {}),
+  });
 }
 
 export async function DELETE(req: Request) {

--- a/web/src/lib/fitness/mark-plan-completed.ts
+++ b/web/src/lib/fitness/mark-plan-completed.ts
@@ -1,0 +1,50 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// WHY THIS EXISTS (#666)
+//
+// Nothing in the app ever moved `workout_plans.status` off `'planned'`. A plan row was created
+// as `planned` and stayed that way forever — logging the workout did not change it. Only
+// cancel/reschedule wrote status, and only to `'cancelled'`.
+//
+// `scripts/coach_check.py` escalates off consecutive missed *planned* days (2 misses drops
+// volume, 3 concludes the program is wrong). A stale `planned` row in the past is
+// indistinguishable from a miss, so on 2026-08-10 an audit found 11 past plans still `planned`,
+// **9 of them sessions actually completed** — the coaching loop was reading near-total failure
+// during a consistent training block. This is the same open-loop defect that killed coaching
+// attempt #1, arriving through the status column.
+//
+// The fix is to flip the plan to `completed` the moment its session is written. That happens on
+// two paths — logging a set (`POST`) and saving the end-of-workout recap (`PATCH`) — and the
+// recap is optional, so both must call this or a sets-only workout stays `planned`. This helper
+// is the single place that flip lives.
+
+/**
+ * Flip a workout plan to `completed` because its session was logged.
+ *
+ * Idempotent: the `.neq('status', 'completed')` guard makes a repeat call (e.g. every set in a
+ * 13-set workout) a 0-row no-op rather than a needless rewrite. Overrides `cancelled`/`skipped`
+ * as well — a logged session is ground truth that the workout was done.
+ *
+ * Non-fatal by contract: the caller's primary write (the set, or the recap) has already
+ * succeeded before this runs. A failure here is returned, not thrown, so the caller can surface
+ * it in the response without failing the whole request — but it is never swallowed silently,
+ * which is the exact failure mode #666 is about.
+ *
+ * @returns an error message if the update failed, otherwise `null`.
+ */
+export async function markPlanCompleted(
+  supabase: SupabaseClient,
+  userId: string,
+  planId: string | null | undefined,
+): Promise<string | null> {
+  if (!planId) return null;
+
+  const { error } = await supabase
+    .from("workout_plans")
+    .update({ status: "completed", updated_at: new Date().toISOString() })
+    .eq("id", planId)
+    .eq("user_id", userId)
+    .neq("status", "completed");
+
+  return error?.message ?? null;
+}


### PR DESCRIPTION
## Problem

Nothing in the app ever moved `workout_plans.status` off `planned`. A plan was created `planned` and stayed that way forever — completing the workout did not change it (only cancel/reschedule wrote status, and only `cancelled`).

`scripts/coach_check.py` escalates off **consecutive missed *planned* days** (2 misses drops volume, 3 concludes the program is wrong rather than the user). A stale past `planned` row is indistinguishable from a miss, so the 2026-08-10 audit found **11 past plans still `planned`, 9 of them sessions actually completed** — the coaching loop was reading near-total failure during a consistent training block. Same open-loop defect that killed the first coaching attempt, arriving through the status column.

## Fix

- **`web/src/lib/fitness/mark-plan-completed.ts`** — one helper that flips the plan to `completed`, scoped to `(id, user_id)`, guarded by `.neq('status','completed')`.
  - *Idempotent*: repeat calls (every set in a workout) match 0 rows — no churn.
  - *Ground truth*: overrides `cancelled`/`skipped` too — a logged session means it was done.
  - *Non-fatal*: returns an error string rather than throwing; the caller's primary write already succeeded. Never swallowed silently (the #666 failure mode).
- **`web/src/app/api/strength-sessions/route.ts`** — both `POST` (set logged) and `PATCH` (recap saved) call it. **Both** matter: the end-of-workout recap is optional, so a sets-only workout must still complete the plan. A failure surfaces as `workout_plan_update_error` in the response.
- **`supabase/migrations/20260813130000_backfill_workout_plan_status.sql`** — backfills historical `planned` rows that have a logged session (by FK **or** same-date match). Only touches `planned`, so explicit `cancelled`/`skipped` are preserved. Idempotent — no-op against prod (hand-corrected 2026-08-10).
- `coach_check.py` needs no change: its miss counter already keys off session existence, so once statuses are correct it reads true.

## Acceptance

- ✅ Completing a workout that has a plan for that date sets the plan to `completed` without manual intervention (both set-log and recap paths).
- ✅ `coach_check.py` streak/miss counts match reality on a week where sessions were logged.

## Tests

- New `web/src/__tests__/mark-plan-completed.test.ts` (node native runner): null-planId no-op, correct scoping + `completed` payload + `neq` guard, error passthrough.
- Full node suite 162/162, `tsc --noEmit` clean, eslint 0 errors, prettier clean, `lint-tokens.sh` pass.

Closes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)