### PR TITLE
fix: coach_check counts only real misses, not rest days (#666)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **A deliberate rest day counted as a missed session.** `coach_check.py`'s miss streak keyed off
+  session-existence alone and ignored `workout_plans.status`, so a `cancelled`/`skipped` day (a
+  chosen rest) read as a miss — inflating the streak that escalates coaching (2 misses cuts volume,
+  3 concludes the program is wrong). With the completion flip from #666 now writing real statuses,
+  the count reads them: a miss is a `planned` day with no session; `cancelled`/`skipped`/`completed`
+  are skipped. Extracted the count into a pure `consecutive_misses()` with unit tests, and made
+  `coach_check` importable on a bare interpreter (its `_supabase` import moved into `main()`) so the
+  helper can be tested without dependencies. This is the residual half of #666 — the rule that "a
+  rest is not a miss" now lives in code instead of a memory note. (#666)
+
 - **A completed workout still read as a miss.** Nothing in the app ever moved
   `workout_plans.status` off `planned` — logging the workout left the plan `planned` forever, and
   `coach_check.py` escalates off consecutive missed *planned* days (2 misses drops volume, 3

--- a/scripts/coach_check.py
+++ b/scripts/coach_check.py
@@ -17,7 +17,9 @@ from datetime import date, timedelta
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
 sys.path.insert(0, os.path.dirname(__file__))
-from _supabase import get_client, get_owner_user_id  # noqa: E402
+# NOTE: `_supabase` (and its `dotenv` dep) is imported lazily in main(), NOT here — so this
+# module stays importable on a bare interpreter and the pure helpers below (consecutive_misses)
+# can be unit-tested without pip installs. Same reason weekly_plan.py keeps its top imports stdlib.
 
 REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 TZ = os.environ.get("USER_TIMEZONE", "America/Los_Angeles")
@@ -124,6 +126,34 @@ def regressions(c, uid, today):
     return [ex for ex, v in cur.items() if ex in prev and prev[ex] > 0 and v < prev[ex] * 0.95]
 
 
+def consecutive_misses(recent, session_dates):
+    """Count consecutive missed sessions, most-recent day first.
+
+    `recent`: workout_plans rows ordered by date DESC, each `{"date", "status"}`.
+    `session_dates`: set of `performed_on` for logged PROGRAMMED sessions.
+
+    A miss is a **`planned` day with no logged session**. This deliberately reads `status`:
+    a `cancelled` or `skipped` day is a chosen rest, and a `completed` day is done — none of
+    them are misses, so they are skipped, not counted. A logged session ends the streak.
+
+    Why this cares about status: the escalation off this number is real (2 misses cuts volume,
+    3 says the program is wrong, not the user). Before #666 the app never set
+    `workout_plans.status`, so this loop keyed off session-existence alone and a deliberate rest
+    read as a miss — inflating the streak and firing a false "the program is too much" nudge.
+    That mis-read is the same open-loop defect that killed the May coaching attempt (see the
+    module docstring), which is why the rule lives here in code now instead of in a runbook: a
+    rest day must never be able to masquerade as a failure to train.
+    """
+    miss = 0
+    for p in recent:
+        if p["date"] in session_dates:
+            break
+        if p.get("status") != "planned":
+            continue
+        miss += 1
+    return miss
+
+
 def post_session(c, uid, today):
     planned = c.table("workout_plans").select("name,status").eq("user_id", uid) \
         .eq("date", today.isoformat()).execute().data
@@ -182,11 +212,7 @@ def post_session(c, uid, today):
     # session read as completed and `miss` never left 0 — the nudge silently died.
     sess = {r["performed_on"]
             for r in programmed_sessions(c, uid, today - timedelta(days=21), today)}
-    miss = 0
-    for p in recent:
-        if p["date"] in sess:
-            break
-        miss += 1
+    miss = consecutive_misses(recent, sess)
 
     name = planned[0]["name"]
     if miss >= 3:
@@ -244,6 +270,8 @@ def main():
     ap.add_argument("--post-session", action="store_true")
     ap.add_argument("--weekly", action="store_true")
     a = ap.parse_args()
+
+    from _supabase import get_client, get_owner_user_id  # lazy — see top-of-file note
 
     c, uid, t = get_client(), get_owner_user_id(), today_local()
     if a.weekly:

--- a/tests/test_coach_check_misses.py
+++ b/tests/test_coach_check_misses.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Tests for consecutive_misses in scripts/coach_check.py.
+
+Run: python3 -m unittest discover -s tests -v
+
+WHY THIS EXISTS
+
+The miss count drives a real escalation: 2 misses cuts training volume, 3 concludes the program
+is wrong rather than the user. Before #666 the app never set `workout_plans.status`, so this count
+keyed off session-existence alone — and a deliberate rest (a `cancelled`/`skipped` day with no
+session) read as a MISS, inflating the streak and firing a false "the program is too much" nudge.
+That mis-read is the same open-loop defect that killed the May coaching attempt.
+
+The rule — a miss is a `planned` day with no session; a chosen rest is never a miss — now lives in
+code instead of in a memory file. These tests pin it. The failure mode is silent (a wrong integer
+that reads as plausible), so it needs its own tests.
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+# coach_check imports _supabase (and dotenv) lazily inside main(), so importing the module for the
+# pure helper needs no dependencies — matching the bare-interpreter CI job. Guard the env anyway.
+os.environ.setdefault("USER_TIMEZONE", "America/Los_Angeles")
+
+from coach_check import consecutive_misses  # noqa: E402
+
+
+def plans(*rows):
+    """rows are (date, status), most-recent first — the order coach_check queries them in."""
+    return [{"date": d, "status": s} for d, s in rows]
+
+
+class TestConsecutiveMisses(unittest.TestCase):
+    def test_no_plans_is_zero(self):
+        self.assertEqual(consecutive_misses([], set()), 0)
+
+    def test_a_logged_session_ends_the_streak(self):
+        recent = plans(("2026-08-13", "planned"), ("2026-08-11", "completed"))
+        # 8/13 has no session (miss), 8/11 was trained → stop.
+        self.assertEqual(consecutive_misses(recent, {"2026-08-11"}), 1)
+
+    def test_most_recent_logged_day_is_zero_misses(self):
+        recent = plans(("2026-08-13", "completed"))
+        self.assertEqual(consecutive_misses(recent, {"2026-08-13"}), 1 - 1)  # == 0
+
+    def test_three_planned_no_session_is_three(self):
+        recent = plans(
+            ("2026-08-13", "planned"),
+            ("2026-08-11", "planned"),
+            ("2026-08-09", "planned"),
+        )
+        self.assertEqual(consecutive_misses(recent, set()), 3)
+
+    def test_cancelled_day_is_not_a_miss_and_does_not_reset(self):
+        # A deliberate rest between two genuine misses: the rest is transparent, the two
+        # planned-no-session days still count. This is the whole point of reading status.
+        recent = plans(
+            ("2026-08-13", "planned"),
+            ("2026-08-12", "cancelled"),
+            ("2026-08-11", "planned"),
+        )
+        self.assertEqual(consecutive_misses(recent, set()), 2)
+
+    def test_skipped_day_is_not_a_miss(self):
+        recent = plans(("2026-08-13", "skipped"), ("2026-08-11", "skipped"))
+        self.assertEqual(consecutive_misses(recent, set()), 0)
+
+    def test_all_cancelled_deload_week_fires_no_miss(self):
+        recent = plans(
+            ("2026-08-13", "cancelled"),
+            ("2026-08-11", "cancelled"),
+            ("2026-08-09", "cancelled"),
+        )
+        # Must not escalate to "the program is too much" on a chosen deload.
+        self.assertEqual(consecutive_misses(recent, set()), 0)
+
+    def test_completed_without_a_session_row_is_not_a_miss(self):
+        # Defensive: a completed status but no session row (a data anomaly) is not un-actioned,
+        # so it is skipped rather than counted.
+        recent = plans(("2026-08-13", "completed"), ("2026-08-11", "planned"))
+        self.assertEqual(consecutive_misses(recent, set()), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-up to #666 (the residual half). #666 made the app write real `workout_plans.status` values; this makes the one consumer of that column — `coach_check.py` — actually read them.

## Problem

`coach_check.py`'s miss streak counted **any** past plan with no logged session as a miss, ignoring `status`. So a `cancelled`/`skipped` day — a deliberate rest — read as a miss. That inflates the streak the coaching escalation keys off:

- 2 misses → next session cut to 3 exercises
- 3 misses → "the program is too much as written"

Prod currently has 43 `skipped` + 5 `cancelled` rows, so a chosen rest in the last 21 days could fire a false "the program is wrong" nudge. That mis-read is the same open-loop defect that killed the May coaching attempt.

## Fix

- Extracted the count into a pure **`consecutive_misses(recent, session_dates)`** that reads `status`: a miss is a `planned` day with no session; `cancelled`/`skipped`/`completed` are skipped; a logged session ends the streak. A rest day is neutral — it neither counts nor resets.
- Moved `coach_check`'s `_supabase` import into `main()` so the module imports on a **bare interpreter** — the python CI job installs no deps by design, and this keeps the helper testable there (same reason `weekly_plan.py` keeps its top imports stdlib-only).
- Added `tests/test_coach_check_misses.py` (8 cases: rest-not-a-miss, deload week fires nothing, streak semantics, defensive completed-without-session).

The behavioural rule "a rest is not a miss" now lives in code (with the *why* in the docstring) instead of a private memory note.

## Tests

`python3 -m unittest discover -s tests -v` → 25/25 pass on a bare interpreter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)