### PR TITLE
feat: task lists (TickTick-style folders) — Phase 1 of tasks overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **Task lists (TickTick-style folders).** Tasks can now be grouped into named lists — Groceries,
+  Health, etc. — instead of a flat checklist. New `task_lists` table (RLS-scoped per user) + a
+  nullable `tasks.list_id` (`on delete set null`, so deleting a list never deletes its tasks — they
+  fall back to Uncategorised). A migration promotes each existing distinct `tasks.category` to a
+  list and backfills `list_id`. The `/tasks` page gains a scrollable tab bar (All · each list ·
+  Uncategorised · + new), filters via `?list=`, and lets you create/rename/delete lists and assign
+  a task's list from the add form or its edit panel. MCP tools added: `get_task_lists`,
+  `create_task_list`; `add_task` gains `list_id`. List dots are neutral for now — a colored-dot
+  pass (via `globals.css` tokens) is a fast-follow. First phase of the tasks overhaul (lists →
+  calendar → history → dependencies #470).
+
 ### Documentation
 
 - **`data-sources.md` mislabelled `user_metric_preferences` as a units table.** The row read

--- a/supabase/migrations/20260814000000_task_lists.sql
+++ b/supabase/migrations/20260814000000_task_lists.sql
@@ -1,0 +1,64 @@
+-- Task Lists — a first-class home for what was the free-text `tasks.category`.
+--
+-- WHY A TABLE, NOT THE STRING
+--
+-- `tasks.category` is a nullable free-text column. Both the app UI and the assistant (via the
+-- add_task MCP tool) write it, so the same list fragments on typos and casing ("Groceries" vs
+-- "groceries" vs "grocery"), can't be renamed in one place, ordered, or given a colour. Promoting
+-- it to a real entity — one list per task (the folder model) — fixes all of that and is the
+-- backbone the rest of the tasks overhaul (calendar, history, dependencies) hangs off.
+--
+-- `tasks.list_id` is nullable and `on delete set null`: a task with no list is "uncategorised",
+-- and deleting a list never deletes its tasks — they fall back to uncategorised.
+--
+-- `category` is left in place for now; the backfill below seeds lists from it, and a later change
+-- can drop the column once nothing reads it.
+
+create table if not exists task_lists (
+  id         uuid primary key default gen_random_uuid(),
+  user_id    uuid not null references auth.users(id) on delete cascade,
+  name       text not null,
+  color      text,                              -- reserved for coloured dots; unset for now
+  sort_order integer not null default 0,
+  created_at timestamptz not null default now()
+);
+create index if not exists task_lists_user_id_idx on task_lists (user_id);
+
+alter table task_lists enable row level security;
+create policy "users access own data" on task_lists
+  for all to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+alter table tasks
+  add column if not exists list_id uuid references task_lists(id) on delete set null;
+create index if not exists tasks_list_id_idx on tasks (list_id);
+
+-- Backfill: promote each distinct non-empty category (per user) to a list, then point its tasks at
+-- it. Guarded by "not exists" so a re-run is a no-op.
+do $$
+declare
+  r record;
+  target_list_id uuid;
+begin
+  for r in
+    select distinct user_id, category
+    from tasks
+    where category is not null and btrim(category) <> ''
+  loop
+    select id into target_list_id
+      from task_lists
+      where user_id = r.user_id and name = r.category
+      limit 1;
+
+    if target_list_id is null then
+      insert into task_lists (user_id, name)
+        values (r.user_id, r.category)
+        returning id into target_list_id;
+    end if;
+
+    update tasks
+      set list_id = target_list_id
+      where user_id = r.user_id and category = r.category and list_id is null;
+  end loop;
+end $$;

--- a/web/src/app/(protected)/tasks/page.tsx
+++ b/web/src/app/(protected)/tasks/page.tsx
@@ -11,12 +11,14 @@ export const metadata: Metadata = {
 };
 import AddTaskForm from "@/components/tasks/add-task-form";
 import CompletedTasks from "@/components/tasks/completed-tasks";
-import type { Task } from "@/lib/types";
+import ListTabs from "@/components/tasks/list-tabs";
+import type { Task, TaskList } from "@/lib/types";
 
 async function addTask(
   title: string,
   priority: string,
   dueDate: string,
+  listId: string,
 ): Promise<{ error?: string }> {
   "use server";
   try {
@@ -31,6 +33,7 @@ async function addTask(
       priority: priority || "medium",
       status: "active",
       due_date: dueDate || null,
+      list_id: listId || null,
     });
     if (error) return { error: error.message };
     revalidatePath("/tasks");
@@ -77,7 +80,12 @@ async function archiveTask(taskId: string): Promise<{ error?: string }> {
 
 async function updateTask(
   taskId: string,
-  fields: { title?: string; due_date?: string | null; priority?: string | null },
+  fields: {
+    title?: string;
+    due_date?: string | null;
+    priority?: string | null;
+    list_id?: string | null;
+  },
 ): Promise<{ error?: string }> {
   "use server";
   try {
@@ -160,37 +168,132 @@ async function deleteSubtask(id: string): Promise<{ error?: string }> {
   }
 }
 
+async function createList(name: string): Promise<{ error?: string; id?: string }> {
+  "use server";
+  try {
+    const trimmed = name.trim();
+    if (!trimmed) return { error: "List name cannot be empty" };
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return { error: "Unauthorized" };
+    // A list is a folder — dedup case-insensitively so two "Groceries" can't exist.
+    const { data: existing } = await supabase
+      .from("task_lists")
+      .select("id")
+      .eq("user_id", user.id)
+      .ilike("name", trimmed)
+      .maybeSingle();
+    if (existing) return { id: existing.id };
+    const { data, error } = await supabase
+      .from("task_lists")
+      .insert({ user_id: user.id, name: trimmed })
+      .select("id")
+      .single();
+    if (error) return { error: error.message };
+    revalidatePath("/tasks");
+    return { id: data?.id };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Failed to create list" };
+  }
+}
+
+async function renameList(id: string, name: string): Promise<{ error?: string }> {
+  "use server";
+  try {
+    const trimmed = name.trim();
+    if (!trimmed) return { error: "List name cannot be empty" };
+    const supabase = await createClient();
+    const { error } = await supabase.from("task_lists").update({ name: trimmed }).eq("id", id);
+    if (error) return { error: error.message };
+    revalidatePath("/tasks");
+    return {};
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Failed to rename list" };
+  }
+}
+
+async function deleteList(id: string): Promise<{ error?: string }> {
+  "use server";
+  try {
+    const supabase = await createClient();
+    // FK is `on delete set null`, so a list's tasks survive as uncategorised.
+    const { error } = await supabase.from("task_lists").delete().eq("id", id);
+    if (error) return { error: error.message };
+    revalidatePath("/tasks");
+    revalidatePath("/dashboard");
+    return {};
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Failed to delete list" };
+  }
+}
+
 const priorityOrder = { high: 0, medium: 1, low: 2 };
 
-export default async function TasksPage() {
+export default async function TasksPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ list?: string }>;
+}) {
   const supabase = await createClient();
+  const selected = (await searchParams).list ?? "all"; // "all" | "none" | <listId>
 
-  const [activeResult, completedResult, subtasksResult] = await Promise.all([
-    supabase
-      .from("tasks")
-      .select("*")
-      .is("parent_id", null)
-      .eq("status", "active")
-      .order("created_at", { ascending: false }),
-    supabase
-      .from("tasks")
-      .select("*")
-      .is("parent_id", null)
-      .eq("status", "completed")
-      .order("completed_at", { ascending: false })
-      .limit(10),
-    supabase
-      .from("tasks")
-      .select("id, title, status, created_at, parent_id")
-      .not("parent_id", "is", null)
-      .eq("status", "active"),
-  ]);
+  let activeQuery = supabase
+    .from("tasks")
+    .select("*")
+    .is("parent_id", null)
+    .eq("status", "active")
+    .order("created_at", { ascending: false });
+  let completedQuery = supabase
+    .from("tasks")
+    .select("*")
+    .is("parent_id", null)
+    .eq("status", "completed")
+    .order("completed_at", { ascending: false })
+    .limit(10);
+  if (selected === "none") {
+    activeQuery = activeQuery.is("list_id", null);
+    completedQuery = completedQuery.is("list_id", null);
+  } else if (selected !== "all") {
+    activeQuery = activeQuery.eq("list_id", selected);
+    completedQuery = completedQuery.eq("list_id", selected);
+  }
+
+  const [listsResult, countRowsResult, activeResult, completedResult, subtasksResult] =
+    await Promise.all([
+      supabase
+        .from("task_lists")
+        .select("id, name, color, sort_order")
+        .order("sort_order", { ascending: true })
+        .order("name", { ascending: true }),
+      // Only list_id, across all lists — used to badge each tab with its active count.
+      supabase.from("tasks").select("list_id").is("parent_id", null).eq("status", "active"),
+      activeQuery,
+      completedQuery,
+      supabase
+        .from("tasks")
+        .select("id, title, status, created_at, parent_id")
+        .not("parent_id", "is", null)
+        .eq("status", "active"),
+    ]);
 
   if (activeResult.error) console.error("[tasks] active query error:", activeResult.error.message);
   if (completedResult.error)
     console.error("[tasks] completed query error:", completedResult.error.message);
   if (subtasksResult.error)
     console.error("[tasks] subtasks query error:", subtasksResult.error.message);
+  if (listsResult.error) console.error("[tasks] lists query error:", listsResult.error.message);
+
+  const lists = (listsResult.data ?? []) as TaskList[];
+
+  // Per-tab active counts. "none" = uncategorised; totals feed the "All" tab.
+  const counts: Record<string, number> = { all: 0, none: 0 };
+  for (const row of (countRowsResult.data ?? []) as { list_id: string | null }[]) {
+    counts.all += 1;
+    const key = row.list_id ?? "none";
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
 
   const subtasksByParent = new Map<string, Task[]>();
   for (const s of (subtasksResult.data ?? []) as Task[]) {
@@ -212,6 +315,9 @@ export default async function TasksPage() {
   const medium = tasks.filter((t) => t.priority === "medium");
   const low = tasks.filter((t) => t.priority === "low" || !t.priority);
 
+  // New tasks default into the list you're viewing ("all"/"none" → uncategorised).
+  const defaultListId = selected === "all" || selected === "none" ? "" : selected;
+
   return (
     <div className="max-w-2xl">
       {/* Header */}
@@ -231,8 +337,18 @@ export default async function TasksPage() {
         </p>
       </div>
 
+      {/* List tabs — TickTick-style folders (All · lists · +) */}
+      <ListTabs
+        lists={lists}
+        selected={selected}
+        counts={counts}
+        createAction={createList}
+        renameAction={renameList}
+        deleteAction={deleteList}
+      />
+
       {/* Always-visible add form — inline, hairline bottom rule, transparent */}
-      <AddTaskForm addAction={addTask} />
+      <AddTaskForm addAction={addTask} lists={lists} defaultListId={defaultListId} />
 
       {/* Priority groups — hairline-separated rows, no card shell */}
       {tasks.length > 0 && (
@@ -259,6 +375,7 @@ export default async function TasksPage() {
                     >
                       <TaskItem
                         task={task}
+                        lists={lists}
                         completeAction={completeTask}
                         archiveAction={archiveTask}
                         updateAction={updateTask}
@@ -283,7 +400,7 @@ export default async function TasksPage() {
             paddingTop: "var(--space-6)",
           }}
         >
-          No tasks. Add one above.
+          {selected === "all" ? "No tasks. Add one above." : "No tasks in this list yet."}
         </p>
       )}
 

--- a/web/src/components/tasks/add-task-form.tsx
+++ b/web/src/components/tasks/add-task-form.tsx
@@ -2,9 +2,17 @@
 
 import { useState, useTransition, useRef } from "react";
 import { Plus } from "lucide-react";
+import type { TaskList } from "@/lib/types";
 
 interface Props {
-  addAction: (title: string, priority: string, dueDate: string) => Promise<{ error?: string }>;
+  addAction: (
+    title: string,
+    priority: string,
+    dueDate: string,
+    listId: string,
+  ) => Promise<{ error?: string }>;
+  lists: TaskList[];
+  defaultListId: string;
 }
 
 const PRIORITIES = [
@@ -13,10 +21,11 @@ const PRIORITIES = [
   { key: "low", label: "Low", color: "var(--color-text-faint)" },
 ] as const;
 
-export default function AddTaskForm({ addAction }: Props) {
+export default function AddTaskForm({ addAction, lists, defaultListId }: Props) {
   const [title, setTitle] = useState("");
   const [priority, setPriority] = useState<"high" | "medium" | "low">("medium");
   const [dueDate, setDueDate] = useState("");
+  const [listId, setListId] = useState(defaultListId);
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -26,7 +35,7 @@ export default function AddTaskForm({ addAction }: Props) {
     if (!title.trim() || isPending) return;
     setError(null);
     startTransition(async () => {
-      const result = await addAction(title.trim(), priority, dueDate);
+      const result = await addAction(title.trim(), priority, dueDate, listId);
       if (result.error) {
         setError(result.error);
         return;
@@ -34,6 +43,7 @@ export default function AddTaskForm({ addAction }: Props) {
       setTitle("");
       setPriority("medium");
       setDueDate("");
+      // Keep the list selection — you're usually adding several to the same list.
       inputRef.current?.focus();
     });
   }
@@ -100,6 +110,31 @@ export default function AddTaskForm({ addAction }: Props) {
             </button>
           ))}
         </div>
+
+        {lists.length > 0 && (
+          <select
+            aria-label="List"
+            value={listId}
+            onChange={(e) => setListId(e.target.value)}
+            className="focus:outline-none flex-shrink-0"
+            style={{
+              fontSize: "var(--t-micro)",
+              background: "transparent",
+              border: "1px solid var(--rule)",
+              borderRadius: "var(--r-1)",
+              padding: "4px 8px",
+              color: listId ? "var(--color-text)" : "var(--color-text-faint)",
+              maxWidth: 120,
+            }}
+          >
+            <option value="">No list</option>
+            {lists.map((l) => (
+              <option key={l.id} value={l.id}>
+                {l.name}
+              </option>
+            ))}
+          </select>
+        )}
 
         <input
           type="date"

--- a/web/src/components/tasks/list-tabs.tsx
+++ b/web/src/components/tasks/list-tabs.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Plus, X, Check } from "lucide-react";
+import type { TaskList } from "@/lib/types";
+
+interface Props {
+  lists: TaskList[];
+  selected: string; // "all" | "none" | <listId>
+  counts: Record<string, number>;
+  createAction: (name: string) => Promise<{ error?: string; id?: string }>;
+  renameAction: (id: string, name: string) => Promise<{ error?: string }>;
+  deleteAction: (id: string) => Promise<{ error?: string }>;
+}
+
+export default function ListTabs({
+  lists,
+  selected,
+  counts,
+  createAction,
+  renameAction,
+  deleteAction,
+}: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [renaming, setRenaming] = useState(false);
+  const [renameValue, setRenameValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  function go(key: string) {
+    startTransition(() => {
+      router.push(key === "all" ? "/tasks" : `/tasks?list=${encodeURIComponent(key)}`);
+    });
+  }
+
+  function submitCreate() {
+    const name = newName.trim();
+    if (!name) return;
+    setError(null);
+    startTransition(async () => {
+      const res = await createAction(name);
+      if (res.error) {
+        setError(res.error);
+        return;
+      }
+      setNewName("");
+      setCreating(false);
+      if (res.id) router.push(`/tasks?list=${encodeURIComponent(res.id)}`);
+    });
+  }
+
+  const activeList = lists.find((l) => l.id === selected);
+
+  function submitRename() {
+    const name = renameValue.trim();
+    if (!activeList || !name || name === activeList.name) {
+      setRenaming(false);
+      return;
+    }
+    setError(null);
+    startTransition(async () => {
+      const res = await renameAction(activeList.id, name);
+      if (res.error) setError(res.error);
+      setRenaming(false);
+    });
+  }
+
+  function handleDelete() {
+    if (!activeList) return;
+    startTransition(async () => {
+      const res = await deleteAction(activeList.id);
+      if (res.error) {
+        setError(res.error);
+        return;
+      }
+      router.push("/tasks");
+    });
+  }
+
+  const tabs: { key: string; label: string }[] = [
+    { key: "all", label: "All" },
+    ...lists.map((l) => ({ key: l.id, label: l.name })),
+  ];
+  // Only surface the "Uncategorised" tab when there is something in it.
+  if ((counts.none ?? 0) > 0) tabs.push({ key: "none", label: "Uncategorised" });
+
+  return (
+    <div style={{ marginBottom: "var(--space-3)", opacity: isPending ? 0.6 : 1 }}>
+      <div
+        className="flex items-center no-scrollbar"
+        style={{ gap: "var(--space-2)", overflowX: "auto", paddingBottom: 2 }}
+      >
+        {tabs.map(({ key, label }) => {
+          const active = selected === key;
+          const list = lists.find((l) => l.id === key);
+          const count = counts[key] ?? 0;
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => go(key)}
+              className="flex items-center flex-shrink-0 transition-opacity hover:opacity-80"
+              style={{
+                gap: "var(--space-1)",
+                fontSize: "var(--t-micro)",
+                fontWeight: active ? 600 : 400,
+                color: active ? "var(--color-text-on-cta)" : "var(--color-text-muted)",
+                background: active ? "var(--accent)" : "var(--color-surface-raised, transparent)",
+                border: "1px solid var(--rule)",
+                borderRadius: 999,
+                padding: "4px 10px",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {list && (
+                <span
+                  className="rounded-full block"
+                  style={{
+                    width: 7,
+                    height: 7,
+                    background: list.color ?? "var(--color-text-faint)",
+                    flexShrink: 0,
+                  }}
+                  aria-hidden
+                />
+              )}
+              {label}
+              {count > 0 && <span className="tnum meta">· {count}</span>}
+            </button>
+          );
+        })}
+
+        {/* New list */}
+        {creating ? (
+          <div className="flex items-center flex-shrink-0" style={{ gap: 4 }}>
+            <input
+              autoFocus
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") submitCreate();
+                if (e.key === "Escape") {
+                  setCreating(false);
+                  setNewName("");
+                }
+              }}
+              placeholder="List name…"
+              className="focus:outline-none"
+              style={{
+                fontSize: "var(--t-micro)",
+                background: "transparent",
+                border: "1px solid var(--rule)",
+                borderRadius: 999,
+                padding: "4px 10px",
+                color: "var(--color-text)",
+                width: 120,
+              }}
+            />
+            <button
+              type="button"
+              onClick={submitCreate}
+              className="p-1 transition-opacity hover:opacity-70"
+              style={{ color: "var(--accent)" }}
+              title="Create list"
+            >
+              <Check size={14} />
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setCreating(true)}
+            className="flex items-center flex-shrink-0 transition-opacity hover:opacity-80"
+            style={{
+              gap: 3,
+              fontSize: "var(--t-micro)",
+              color: "var(--color-text-faint)",
+              border: "1px dashed var(--rule)",
+              borderRadius: 999,
+              padding: "4px 10px",
+              whiteSpace: "nowrap",
+            }}
+            title="New list"
+          >
+            <Plus size={12} />
+            List
+          </button>
+        )}
+      </div>
+
+      {/* Manage row for the selected list — rename / delete */}
+      {activeList && (
+        <div
+          className="flex items-center flex-wrap"
+          style={{ gap: "var(--space-2)", marginTop: "var(--space-2)" }}
+        >
+          {renaming ? (
+            <>
+              <input
+                autoFocus
+                value={renameValue}
+                onChange={(e) => setRenameValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") submitRename();
+                  if (e.key === "Escape") setRenaming(false);
+                }}
+                className="focus:outline-none"
+                style={{
+                  fontSize: "var(--t-micro)",
+                  background: "transparent",
+                  border: "1px solid var(--rule)",
+                  borderRadius: "var(--r-1)",
+                  padding: "3px 8px",
+                  color: "var(--color-text)",
+                }}
+              />
+              <button
+                type="button"
+                onClick={submitRename}
+                className="transition-opacity hover:opacity-80"
+                style={{
+                  fontSize: "var(--t-micro)",
+                  fontWeight: 500,
+                  background: "var(--accent)",
+                  color: "var(--color-text-on-cta)",
+                  borderRadius: "var(--r-1)",
+                  padding: "3px 8px",
+                }}
+              >
+                Save
+              </button>
+              <button
+                type="button"
+                onClick={() => setRenaming(false)}
+                className="p-1 transition-opacity hover:opacity-70"
+                style={{ color: "var(--color-text-faint)" }}
+                title="Cancel"
+              >
+                <X size={12} />
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={() => {
+                  setRenameValue(activeList.name);
+                  setRenaming(true);
+                }}
+                className="transition-opacity hover:opacity-70"
+                style={{ fontSize: "var(--t-micro)", color: "var(--color-text-muted)" }}
+              >
+                Rename
+              </button>
+              <span style={{ color: "var(--rule)" }}>·</span>
+              <button
+                type="button"
+                onClick={handleDelete}
+                className="transition-opacity hover:opacity-70"
+                style={{ fontSize: "var(--t-micro)", color: "var(--color-danger)" }}
+                title="Delete list (tasks move to Uncategorised)"
+              >
+                Delete list
+              </button>
+            </>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <p style={{ fontSize: "var(--t-micro)", color: "var(--color-danger)", marginTop: 4 }}>
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/tasks/task-item.tsx
+++ b/web/src/components/tasks/task-item.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition, useRef, useEffect } from "react";
 import { Archive, ChevronDown, ChevronRight, Pencil, X } from "lucide-react";
-import type { Task, Subtask } from "@/lib/types";
+import type { Task, Subtask, TaskList } from "@/lib/types";
 import { todayString } from "@/lib/timezone";
 
 function relativeDue(dateStr: string): { label: string; urgent: boolean } {
@@ -20,11 +20,17 @@ function relativeDue(dateStr: string): { label: string; urgent: boolean } {
 
 interface Props {
   task: Task;
+  lists: TaskList[];
   completeAction: (id: string) => Promise<{ error?: string }>;
   archiveAction: (id: string) => Promise<{ error?: string }>;
   updateAction: (
     id: string,
-    fields: { title?: string; due_date?: string | null; priority?: string | null },
+    fields: {
+      title?: string;
+      due_date?: string | null;
+      priority?: string | null;
+      list_id?: string | null;
+    },
   ) => Promise<{ error?: string }>;
   addSubtaskAction: (parentId: string, title: string) => Promise<{ error?: string }>;
   completeSubtaskAction: (id: string) => Promise<{ error?: string }>;
@@ -160,6 +166,7 @@ function SubtaskRow({
 
 export default function TaskItem({
   task,
+  lists,
   completeAction,
   archiveAction,
   updateAction,
@@ -183,6 +190,9 @@ export default function TaskItem({
   const [editPriority, setEditPriority] = useState<"high" | "medium" | "low">(
     (task.priority as "high" | "medium" | "low") ?? "medium",
   );
+  const [editListId, setEditListId] = useState(task.list_id ?? "");
+
+  const taskList = task.list_id ? lists.find((l) => l.id === task.list_id) : null;
 
   useEffect(() => {
     if (editing) inputRef.current?.focus();
@@ -297,13 +307,31 @@ export default function TaskItem({
               {task.title}
             </span>
           )}
-          {task.category && (
+          {taskList ? (
             <span
-              className="flex-shrink-0"
-              style={{ fontSize: "var(--t-micro)", color: "var(--color-text-faint)" }}
+              className="flex items-center flex-shrink-0"
+              style={{ gap: 4, fontSize: "var(--t-micro)", color: "var(--color-text-faint)" }}
             >
-              {task.category}
+              <span
+                className="rounded-full block"
+                style={{
+                  width: 6,
+                  height: 6,
+                  background: taskList.color ?? "var(--color-text-faint)",
+                }}
+                aria-hidden
+              />
+              {taskList.name}
             </span>
+          ) : (
+            task.category && (
+              <span
+                className="flex-shrink-0"
+                style={{ fontSize: "var(--t-micro)", color: "var(--color-text-faint)" }}
+              >
+                {task.category}
+              </span>
+            )
           )}
           {totalCount > 0 && (
             <span
@@ -418,6 +446,29 @@ export default function TaskItem({
             <option value="medium">Medium</option>
             <option value="low">Low</option>
           </select>
+          {lists.length > 0 && (
+            <select
+              aria-label="List"
+              value={editListId}
+              onChange={(e) => setEditListId(e.target.value)}
+              className="focus:outline-none"
+              style={{
+                fontSize: "var(--t-micro)",
+                background: "transparent",
+                border: "1px solid var(--rule)",
+                borderRadius: "var(--r-1)",
+                padding: "4px 8px",
+                color: "var(--color-text)",
+              }}
+            >
+              <option value="">No list</option>
+              {lists.map((l) => (
+                <option key={l.id} value={l.id}>
+                  {l.name}
+                </option>
+              ))}
+            </select>
+          )}
           <button
             onClick={() => {
               setShowEditPanel(false);
@@ -425,6 +476,7 @@ export default function TaskItem({
                 await updateAction(task.id, {
                   due_date: editDueDate || null,
                   priority: editPriority || null,
+                  list_id: editListId || null,
                 });
               });
             }}

--- a/web/src/lib/tools/tasks.ts
+++ b/web/src/lib/tools/tasks.ts
@@ -19,7 +19,9 @@ export function buildTasksTools({ supabase, userId }: ToolContext) {
       execute: async ({ status = "active" }) => {
         let q = supabase
           .from("tasks")
-          .select("id, title, priority, status, due_date, category, completed_at, created_at")
+          .select(
+            "id, title, priority, status, due_date, category, list_id, completed_at, created_at",
+          )
           .eq("status", status)
           .order("created_at", { ascending: false });
         if (userId) q = q.eq("user_id", userId);
@@ -29,13 +31,64 @@ export function buildTasksTools({ supabase, userId }: ToolContext) {
       },
     }),
 
+    get_task_lists: tool({
+      description:
+        "List the user's task lists (TickTick-style folders, e.g. Groceries, Health). Use to find a list_id before creating a task in it, or to check whether a list already exists.",
+      inputSchema: jsonSchema<Record<string, never>>({ type: "object", properties: {} }),
+      execute: async () => {
+        let q = supabase
+          .from("task_lists")
+          .select("id, name, color, sort_order")
+          .order("sort_order", { ascending: true })
+          .order("name", { ascending: true });
+        if (userId) q = q.eq("user_id", userId);
+        const { data, error } = await q;
+        if (error) return { error: error.message };
+        return data ?? [];
+      },
+    }),
+
+    create_task_list: tool({
+      description:
+        "Create a new task list (folder). Check get_task_lists first to avoid duplicates. Returns the new list including its id, which you can pass to add_task as list_id.",
+      inputSchema: jsonSchema<{ name: string }>({
+        type: "object",
+        required: ["name"],
+        properties: {
+          name: { type: "string", description: "List name, e.g. 'Groceries' or 'Health'." },
+        },
+      }),
+      execute: async ({ name }) => {
+        const trimmed = name.trim();
+        if (!trimmed) return err("List name cannot be empty.");
+        // Case-insensitive dedup — a list is a folder, not a note; two 'Groceries' is a bug.
+        const { data: existing } = await supabase
+          .from("task_lists")
+          .select("id, name, color, sort_order")
+          .eq("user_id", userId)
+          .ilike("name", trimmed)
+          .maybeSingle();
+        if (existing) return ok({ list: existing, deduped: true });
+
+        const { data, error: insertError } = await supabase
+          .from("task_lists")
+          .insert({ user_id: userId, name: trimmed })
+          .select("id, name, color, sort_order")
+          .single();
+        if (insertError) return err(insertError.message);
+        if (!data) return err("Insert returned no row — list may not have been saved.");
+        return ok({ list: data });
+      },
+    }),
+
     add_task: tool({
       description:
-        "Add a new task or subtask to the tasks table. To add an item to a list (e.g. shopping list, grocery list), first call get_tasks to find the parent task ID, then call add_task with parent_id set.",
+        "Add a new task or subtask. To put a task in a list (Groceries, Health, etc.), set list_id — call get_task_lists first, or create_task_list if the list doesn't exist yet. To add a checklist item UNDER an existing task, set parent_id (a subtask) instead. list_id groups top-level tasks; parent_id nests a task under another.",
       inputSchema: jsonSchema<{
         title: string;
         priority?: "high" | "medium" | "low";
         category?: string;
+        list_id?: string;
         due_date?: string;
         parent_id?: string;
       }>({
@@ -48,7 +101,15 @@ export function buildTasksTools({ supabase, userId }: ToolContext) {
             enum: ["high", "medium", "low"],
             description: "Task priority. Omit for subtasks.",
           },
-          category: { type: "string", description: "Task category." },
+          category: {
+            type: "string",
+            description: "Deprecated free-text category — prefer list_id.",
+          },
+          list_id: {
+            type: "string",
+            description:
+              "Task list UUID (from get_task_lists / create_task_list) to file this task under.",
+          },
           due_date: {
             type: "string",
             description: "Due date in YYYY-MM-DD format. Omit for subtasks.",
@@ -56,11 +117,11 @@ export function buildTasksTools({ supabase, userId }: ToolContext) {
           parent_id: {
             type: "string",
             description:
-              "Parent task UUID. Set this to add a subtask/list item under an existing task.",
+              "Parent task UUID. Set this to add a subtask/checklist item under an existing task.",
           },
         },
       }),
-      execute: async ({ title, priority, category, due_date, parent_id }) => {
+      execute: async ({ title, priority, category, list_id, due_date, parent_id }) => {
         if (due_date && !/^\d{4}-\d{2}-\d{2}$/.test(due_date)) {
           return err(`due_date must be YYYY-MM-DD format, got: "${due_date}"`);
         }
@@ -91,11 +152,13 @@ export function buildTasksTools({ supabase, userId }: ToolContext) {
             title,
             priority: parent_id ? null : (priority ?? null),
             category: category ?? null,
+            // A subtask inherits its parent's list; only top-level tasks carry a list_id.
+            list_id: parent_id ? null : (list_id ?? null),
             due_date: parent_id ? null : (due_date ?? null),
             status: "active",
             parent_id: parent_id ?? null,
           })
-          .select("id, title, priority, status, due_date, category, parent_id, created_at")
+          .select("id, title, priority, status, due_date, category, list_id, parent_id, created_at")
           .single();
         if (insertError) return err(insertError.message);
         if (!data) return err("Insert returned no row — task may not have been saved.");

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -30,10 +30,18 @@ export interface Task {
   status: "active" | "completed" | "archived";
   due_date: string | null;
   category: string | null;
+  list_id: string | null;
   completed_at: string | null;
   created_at: string;
   parent_id: string | null;
   subtasks?: Task[];
+}
+
+export interface TaskList {
+  id: string;
+  name: string;
+  color: string | null;
+  sort_order: number;
 }
 
 export interface FitnessLog {


### PR DESCRIPTION
Phase 1 of the tasks overhaul (design agreed with @Theioz): **lists / categories**, the backbone the rest hangs off. Later phases: task→calendar, completed history + 90-day retention, dependencies (#470).

## What it does

Groups tasks into named lists (Groceries, Health, …) instead of a flat checklist. One list per task (folder model); subtasks unchanged.

## Changes

**Schema** — `supabase/migrations/20260814000000_task_lists.sql`
- New `task_lists` (id, user_id, name, color, sort_order, created_at), RLS `users access own data`.
- `tasks.list_id uuid → task_lists on delete set null` (+ index). Deleting a list never deletes its tasks — they fall back to Uncategorised.
- Backfill: promotes each existing distinct `tasks.category` (per user) to a list and points those tasks at it. Idempotent. `category` kept for now.

**UI** — `/tasks`
- Scrollable tab bar: `All · <lists> · Uncategorised · + List` (mobile-first, not a desktop sidebar).
- Filter via `?list=<id>` (server-rendered); per-tab active counts.
- Create / rename / delete lists inline; assign a task's list from the add form and its edit panel.
- New tasks default into the list you're viewing.

**MCP tools** — `web/src/lib/tools/tasks.ts`
- `get_task_lists`, `create_task_list` (case-insensitive dedup); `add_task` gains `list_id` (subtasks inherit the parent's list).

## Deliberately deferred
- **Colored list dots** — dots are neutral for now. Real colors need `globals.css` tokens (hex is banned in `web/src` by `lint-tokens.sh`); fast-follow.
- **List reordering** — `sort_order` column exists, no UI yet.

## Checks (local)
`tsc` clean · eslint 0 errors · prettier clean · `lint-tokens.sh` pass · node 162/162 · python 25/25.

Deploy note: needs the migration applied + an app rebuild on compute-core; being a client change, the PWA stale-cache gotcha applies (hard-refresh after deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)