### PR TITLE
feat: schedule a task onto Google Calendar — Phase 2 of tasks overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **Schedule a task onto Google Calendar (time block).** A task can now be dropped on the calendar
+  as an explicit block: a calendar button on each row opens a date + time + duration picker
+  ("Add to calendar"), and the row shows a chip with the block time. New nullable columns
+  `tasks.calendar_event_id / scheduled_start / scheduled_end`, and a `scheduleTask` / `unscheduleTask`
+  helper that mirrors the workout_plans calendar pattern — create/patch/delete the event on
+  `primary`, store the event id back on the task, and **partial-success** on failure (the block is
+  saved even if Google isn't connected; the UI shows a soft warning). MCP tools added:
+  `schedule_task`, `unschedule_task`; `get_tasks` now returns the block. Phase 2 of the tasks
+  overhaul (lists → **calendar** → history → dependencies #470). Completing/archiving a task leaves
+  its event in place for now — auto-clearing a future block is a possible follow-up.
+
 - **Task lists (TickTick-style folders).** Tasks can now be grouped into named lists — Groceries,
   Health, etc. — instead of a flat checklist. New `task_lists` table (RLS-scoped per user) + a
   nullable `tasks.list_id` (`on delete set null`, so deleting a list never deletes its tasks — they

--- a/supabase/migrations/20260814010000_task_scheduling.sql
+++ b/supabase/migrations/20260814010000_task_scheduling.sql
@@ -1,0 +1,13 @@
+-- Task scheduling — put a task on the Google Calendar as an explicit time block.
+--
+-- Mirrors the workout_plans pattern: the link between an app row and its Google event is a single
+-- `calendar_event_id` text column, cleared to null when the event is removed. `scheduled_start` /
+-- `scheduled_end` record the block so the app can show it (and re-patch the event on edit) without
+-- a round-trip to Google. All nullable — a task with no block is simply unscheduled.
+
+alter table tasks
+  add column if not exists calendar_event_id text,
+  add column if not exists scheduled_start   timestamptz,
+  add column if not exists scheduled_end     timestamptz;
+
+create index if not exists tasks_scheduled_start_idx on tasks (scheduled_start);

--- a/web/src/app/(protected)/tasks/page.tsx
+++ b/web/src/app/(protected)/tasks/page.tsx
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
 import AddTaskForm from "@/components/tasks/add-task-form";
 import CompletedTasks from "@/components/tasks/completed-tasks";
 import ListTabs from "@/components/tasks/list-tabs";
+import { scheduleTask, unscheduleTask } from "@/lib/tasks/schedule-task";
 import type { Task, TaskList } from "@/lib/types";
 
 async function addTask(
@@ -229,6 +230,53 @@ async function deleteList(id: string): Promise<{ error?: string }> {
   }
 }
 
+async function scheduleTaskAction(
+  taskId: string,
+  startISO: string,
+  endISO: string,
+): Promise<{ error?: string; warning?: string }> {
+  "use server";
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return { error: "Unauthorized" };
+    const res = await scheduleTask({ supabase, userId: user.id, taskId, startISO, endISO });
+    if (!res.ok) return { error: res.error ?? "Failed to schedule" };
+    revalidatePath("/tasks");
+    revalidatePath("/dashboard");
+    // The block saved even if Google didn't — surface that as a soft warning, not a failure.
+    return res.calendar_synced
+      ? {}
+      : { warning: `Saved, but calendar didn't sync: ${res.calendar_error ?? "unknown"}` };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Failed to schedule" };
+  }
+}
+
+async function unscheduleTaskAction(taskId: string): Promise<{ error?: string; warning?: string }> {
+  "use server";
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return { error: "Unauthorized" };
+    const res = await unscheduleTask({ supabase, userId: user.id, taskId });
+    if (!res.ok) return { error: res.error ?? "Failed to remove from calendar" };
+    revalidatePath("/tasks");
+    revalidatePath("/dashboard");
+    return res.calendar_synced
+      ? {}
+      : {
+          warning: `Block cleared, but the calendar event may remain: ${res.calendar_error ?? "unknown"}`,
+        };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Failed to remove from calendar" };
+  }
+}
+
 const priorityOrder = { high: 0, medium: 1, low: 2 };
 
 export default async function TasksPage({
@@ -382,6 +430,8 @@ export default async function TasksPage({
                         addSubtaskAction={addSubtask}
                         completeSubtaskAction={completeSubtask}
                         deleteSubtaskAction={deleteSubtask}
+                        scheduleAction={scheduleTaskAction}
+                        unscheduleAction={unscheduleTaskAction}
                       />
                     </div>
                   ))}

--- a/web/src/components/tasks/task-item.tsx
+++ b/web/src/components/tasks/task-item.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useTransition, useRef, useEffect } from "react";
-import { Archive, ChevronDown, ChevronRight, Pencil, X } from "lucide-react";
+import { Archive, CalendarClock, ChevronDown, ChevronRight, Pencil, X } from "lucide-react";
 import type { Task, Subtask, TaskList } from "@/lib/types";
 import { todayString } from "@/lib/timezone";
 
@@ -35,6 +35,35 @@ interface Props {
   addSubtaskAction: (parentId: string, title: string) => Promise<{ error?: string }>;
   completeSubtaskAction: (id: string) => Promise<{ error?: string }>;
   deleteSubtaskAction: (id: string) => Promise<{ error?: string }>;
+  scheduleAction: (
+    id: string,
+    startISO: string,
+    endISO: string,
+  ) => Promise<{ error?: string; warning?: string }>;
+  unscheduleAction: (id: string) => Promise<{ error?: string; warning?: string }>;
+}
+
+const DURATIONS = [15, 30, 45, 60, 90] as const;
+
+/** Local YYYY-MM-DD / HH:MM parts of an ISO instant, for the date/time inputs. */
+function localParts(iso: string): { date: string; time: string } {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return {
+    date: `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`,
+    time: `${pad(d.getHours())}:${pad(d.getMinutes())}`,
+  };
+}
+
+/** Short local label for the scheduled-block chip, e.g. "Aug 20, 2:00 PM". */
+function formatScheduled(iso: string): string {
+  return new Date(iso).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
 }
 
 function SubtaskRow({
@@ -173,6 +202,8 @@ export default function TaskItem({
   addSubtaskAction,
   completeSubtaskAction,
   deleteSubtaskAction,
+  scheduleAction,
+  unscheduleAction,
 }: Props) {
   const [isPending, startTransition] = useTransition();
   const [editing, setEditing] = useState(false);
@@ -193,6 +224,59 @@ export default function TaskItem({
   const [editListId, setEditListId] = useState(task.list_id ?? "");
 
   const taskList = task.list_id ? lists.find((l) => l.id === task.list_id) : null;
+
+  // Scheduling — seed the inputs from an existing block, else empty / 30 min.
+  const seededStart = task.scheduled_start ? localParts(task.scheduled_start) : null;
+  const seededDuration =
+    task.scheduled_start && task.scheduled_end
+      ? Math.max(
+          15,
+          Math.round(
+            (new Date(task.scheduled_end).getTime() - new Date(task.scheduled_start).getTime()) /
+              60_000,
+          ),
+        )
+      : 30;
+  const [showSchedule, setShowSchedule] = useState(false);
+  const [schedDate, setSchedDate] = useState(seededStart?.date ?? "");
+  const [schedTime, setSchedTime] = useState(seededStart?.time ?? "");
+  const [schedDuration, setSchedDuration] = useState<number>(seededDuration);
+  const [schedNote, setSchedNote] = useState<string | null>(null);
+
+  function saveSchedule() {
+    if (!schedDate || !schedTime) {
+      setSchedNote("Pick a date and time.");
+      return;
+    }
+    const start = new Date(`${schedDate}T${schedTime}`);
+    if (Number.isNaN(start.getTime())) {
+      setSchedNote("Invalid date/time.");
+      return;
+    }
+    const startISO = start.toISOString();
+    const endISO = new Date(start.getTime() + schedDuration * 60_000).toISOString();
+    setSchedNote(null);
+    startTransition(async () => {
+      const res = await scheduleAction(task.id, startISO, endISO);
+      if (res.error) {
+        setSchedNote(res.error);
+        return;
+      }
+      if (res.warning) setSchedNote(res.warning);
+      else setShowSchedule(false);
+    });
+  }
+
+  function removeSchedule() {
+    startTransition(async () => {
+      const res = await unscheduleAction(task.id);
+      if (res.error) setSchedNote(res.error);
+      else {
+        setSchedNote(res.warning ?? null);
+        if (!res.warning) setShowSchedule(false);
+      }
+    });
+  }
 
   useEffect(() => {
     if (editing) inputRef.current?.focus();
@@ -359,6 +443,18 @@ export default function TaskItem({
           </span>
         )}
 
+        {/* Scheduled block chip */}
+        {task.scheduled_start && (
+          <span
+            className="flex items-center flex-shrink-0 tnum"
+            style={{ gap: 3, fontSize: "var(--t-micro)", color: "var(--accent)" }}
+            title="On your calendar"
+          >
+            <CalendarClock size={11} />
+            {formatScheduled(task.scheduled_start)}
+          </span>
+        )}
+
         {/* Expand/collapse chevron */}
         {totalCount > 0 && (
           <button
@@ -370,6 +466,20 @@ export default function TaskItem({
             {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
           </button>
         )}
+
+        {/* Schedule on calendar */}
+        <button
+          onClick={() => setShowSchedule((v) => !v)}
+          className="flex-shrink-0 flex items-center justify-center transition-opacity hover:opacity-70"
+          style={{
+            width: 32,
+            height: 32,
+            color: task.scheduled_start ? "var(--accent)" : "var(--color-text-faint)",
+          }}
+          title={task.scheduled_start ? "Edit calendar block" : "Add to calendar"}
+        >
+          <CalendarClock size={13} />
+        </button>
 
         {/* Edit due date / priority */}
         <button
@@ -500,6 +610,100 @@ export default function TaskItem({
           >
             <X size={12} />
           </button>
+        </div>
+      )}
+
+      {/* Calendar scheduling panel */}
+      {showSchedule && (
+        <div style={{ paddingBottom: "var(--space-3)", paddingLeft: 56 }}>
+          <div className="flex items-center flex-wrap" style={{ gap: "var(--space-2)" }}>
+            <input
+              type="date"
+              aria-label="Schedule date"
+              value={schedDate}
+              onChange={(e) => setSchedDate(e.target.value)}
+              className="focus:outline-none"
+              style={{
+                fontSize: "var(--t-micro)",
+                background: "transparent",
+                border: "1px solid var(--rule)",
+                borderRadius: "var(--r-1)",
+                padding: "4px 8px",
+                color: "var(--color-text)",
+              }}
+            />
+            <input
+              type="time"
+              aria-label="Schedule time"
+              value={schedTime}
+              onChange={(e) => setSchedTime(e.target.value)}
+              className="focus:outline-none"
+              style={{
+                fontSize: "var(--t-micro)",
+                background: "transparent",
+                border: "1px solid var(--rule)",
+                borderRadius: "var(--r-1)",
+                padding: "4px 8px",
+                color: "var(--color-text)",
+              }}
+            />
+            <select
+              aria-label="Duration"
+              value={schedDuration}
+              onChange={(e) => setSchedDuration(Number(e.target.value))}
+              className="focus:outline-none"
+              style={{
+                fontSize: "var(--t-micro)",
+                background: "transparent",
+                border: "1px solid var(--rule)",
+                borderRadius: "var(--r-1)",
+                padding: "4px 8px",
+                color: "var(--color-text)",
+              }}
+            >
+              {DURATIONS.map((d) => (
+                <option key={d} value={d}>
+                  {d} min
+                </option>
+              ))}
+            </select>
+            <button
+              onClick={saveSchedule}
+              className="transition-opacity hover:opacity-80"
+              style={{
+                fontSize: "var(--t-micro)",
+                fontWeight: 500,
+                background: "var(--accent)",
+                color: "var(--color-text-on-cta)",
+                borderRadius: "var(--r-1)",
+                padding: "4px 10px",
+              }}
+            >
+              {task.scheduled_start ? "Update" : "Add to calendar"}
+            </button>
+            {task.scheduled_start && (
+              <button
+                onClick={removeSchedule}
+                className="transition-opacity hover:opacity-70"
+                style={{ fontSize: "var(--t-micro)", color: "var(--color-danger)" }}
+              >
+                Remove
+              </button>
+            )}
+            <button
+              onClick={() => setShowSchedule(false)}
+              className="flex-shrink-0 p-1 transition-opacity hover:opacity-70"
+              style={{ color: "var(--color-text-faint)" }}
+              title="Cancel"
+            >
+              <X size={12} />
+            </button>
+          </div>
+          {schedNote && (
+            <p style={{ fontSize: "var(--t-micro)", color: "var(--color-danger)", marginTop: 4 }}>
+              {schedNote}
+            </p>
+          )}
         </div>
       )}
 

--- a/web/src/lib/tasks/schedule-task.ts
+++ b/web/src/lib/tasks/schedule-task.ts
@@ -1,0 +1,152 @@
+import { google } from "googleapis";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getGoogleAuthClient } from "@/lib/google-auth";
+
+// Task ↔ Google Calendar, copying the workout_plans pattern (web/src/lib/tools/workouts.ts):
+// the app row owns a single `calendar_event_id`; scheduled_start/end record the block so the UI
+// and re-patch don't need a round-trip. Both operations are PARTIAL-SUCCESS: the schedule is
+// persisted on the task first, then Google is attempted — a calendar failure is reported, never
+// thrown, so the block is still recorded and the caller can tell the user sync failed (e.g. Google
+// not connected) rather than losing the action.
+
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
+
+export interface ScheduleResult {
+  ok: boolean;
+  error?: string; // hard failure (task not found / not owned) — nothing was changed
+  calendar_synced: boolean;
+  calendar_error?: string; // soft failure — the block saved, the Google event did not
+}
+
+/** Create or move the Google event for a task and record the block. startISO/endISO are absolute (UTC). */
+export async function scheduleTask({
+  supabase,
+  userId,
+  taskId,
+  startISO,
+  endISO,
+}: {
+  supabase: SupabaseClient;
+  userId: string;
+  taskId: string;
+  startISO: string;
+  endISO: string;
+}): Promise<ScheduleResult> {
+  const { data: task, error: fetchErr } = await supabase
+    .from("tasks")
+    .select("id, title, calendar_event_id")
+    .eq("id", taskId)
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (fetchErr) return { ok: false, error: fetchErr.message, calendar_synced: false };
+  if (!task) return { ok: false, error: "Task not found.", calendar_synced: false };
+
+  // Persist the block first, so the schedule survives even if Google is unreachable.
+  const { error: saveErr } = await supabase
+    .from("tasks")
+    .update({ scheduled_start: startISO, scheduled_end: endISO })
+    .eq("id", taskId)
+    .eq("user_id", userId);
+  if (saveErr) return { ok: false, error: saveErr.message, calendar_synced: false };
+
+  try {
+    const auth = await getGoogleAuthClient({ db: supabase, userId });
+    const calendar = google.calendar({ version: "v3", auth });
+    // startISO/endISO carry a UTC offset (…Z), so Google places the event correctly without a
+    // separate timeZone field, and displays it in the calendar's own zone.
+    const body = {
+      summary: task.title,
+      start: { dateTime: startISO },
+      end: { dateTime: endISO },
+    };
+
+    let eventId: string | null = task.calendar_event_id ?? null;
+    if (eventId) {
+      await withTimeout(
+        calendar.events.patch({
+          calendarId: "primary",
+          eventId,
+          requestBody: { ...body, status: "confirmed" },
+        }),
+        8000,
+        "calendar patch",
+      );
+    } else {
+      const res = await withTimeout(
+        calendar.events.insert({ calendarId: "primary", requestBody: body }),
+        8000,
+        "calendar insert",
+      );
+      eventId = res.data.id ?? null;
+      await supabase
+        .from("tasks")
+        .update({ calendar_event_id: eventId })
+        .eq("id", taskId)
+        .eq("user_id", userId);
+    }
+    return { ok: true, calendar_synced: true };
+  } catch (calErr) {
+    return {
+      ok: true,
+      calendar_synced: false,
+      calendar_error: calErr instanceof Error ? calErr.message : "Calendar sync failed",
+    };
+  }
+}
+
+/** Remove a task's Google event and clear its block. */
+export async function unscheduleTask({
+  supabase,
+  userId,
+  taskId,
+}: {
+  supabase: SupabaseClient;
+  userId: string;
+  taskId: string;
+}): Promise<ScheduleResult> {
+  const { data: task, error: fetchErr } = await supabase
+    .from("tasks")
+    .select("id, calendar_event_id")
+    .eq("id", taskId)
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (fetchErr) return { ok: false, error: fetchErr.message, calendar_synced: false };
+  if (!task) return { ok: false, error: "Task not found.", calendar_synced: false };
+
+  let calendarError: string | undefined;
+  if (task.calendar_event_id) {
+    try {
+      const auth = await getGoogleAuthClient({ db: supabase, userId });
+      const calendar = google.calendar({ version: "v3", auth });
+      await withTimeout(
+        calendar.events.delete({ calendarId: "primary", eventId: task.calendar_event_id }),
+        8000,
+        "calendar delete",
+      );
+    } catch (calErr) {
+      // 404/410 = already gone = success. Anything else is a soft failure worth surfacing.
+      const code =
+        (calErr as { code?: number }).code ??
+        (calErr as { response?: { status?: number } }).response?.status;
+      if (code !== 404 && code !== 410) {
+        calendarError = calErr instanceof Error ? calErr.message : "Calendar delete failed";
+      }
+    }
+  }
+
+  const { error: clearErr } = await supabase
+    .from("tasks")
+    .update({ calendar_event_id: null, scheduled_start: null, scheduled_end: null })
+    .eq("id", taskId)
+    .eq("user_id", userId);
+  if (clearErr) return { ok: false, error: clearErr.message, calendar_synced: false };
+
+  return { ok: true, calendar_synced: !calendarError, calendar_error: calendarError };
+}

--- a/web/src/lib/tools/tasks.ts
+++ b/web/src/lib/tools/tasks.ts
@@ -1,6 +1,7 @@
 import { tool, jsonSchema } from "ai";
 import { ok, err } from "./_contract";
 import type { ToolContext } from "./_context";
+import { scheduleTask, unscheduleTask } from "@/lib/tasks/schedule-task";
 
 export function buildTasksTools({ supabase, userId }: ToolContext) {
   return {
@@ -20,7 +21,7 @@ export function buildTasksTools({ supabase, userId }: ToolContext) {
         let q = supabase
           .from("tasks")
           .select(
-            "id, title, priority, status, due_date, category, list_id, completed_at, created_at",
+            "id, title, priority, status, due_date, category, list_id, scheduled_start, scheduled_end, completed_at, created_at",
           )
           .eq("status", status)
           .order("created_at", { ascending: false });
@@ -188,6 +189,61 @@ export function buildTasksTools({ supabase, userId }: ToolContext) {
         if (!data)
           return err(`No active task found with id ${id} for this user — nothing was changed.`);
         return ok({ task: data });
+      },
+    }),
+
+    schedule_task: tool({
+      description:
+        "Put a task on the user's Google Calendar as a time block (or move an existing block). Provide start as an ISO 8601 datetime WITH offset (e.g. 2026-08-20T14:00:00-07:00) and a duration in minutes. Records the block on the task and creates/updates the calendar event. Partial success: if Google isn't connected the block is still saved and calendar_synced is false.",
+      inputSchema: jsonSchema<{ id: string; start: string; duration_minutes?: number }>({
+        type: "object",
+        required: ["id", "start"],
+        properties: {
+          id: { type: "string", description: "Task UUID." },
+          start: {
+            type: "string",
+            description: "ISO 8601 start datetime with UTC offset, e.g. 2026-08-20T14:00:00-07:00.",
+          },
+          duration_minutes: {
+            type: "number",
+            description: "Block length in minutes. Defaults to 30.",
+          },
+        },
+      }),
+      execute: async ({ id, start, duration_minutes }) => {
+        if (!userId) return err("No user context.");
+        const startMs = Date.parse(start);
+        if (Number.isNaN(startMs)) return err(`start is not a valid ISO datetime: "${start}"`);
+        const mins = duration_minutes && duration_minutes > 0 ? duration_minutes : 30;
+        const startISO = new Date(startMs).toISOString();
+        const endISO = new Date(startMs + mins * 60_000).toISOString();
+        const res = await scheduleTask({ supabase, userId, taskId: id, startISO, endISO });
+        if (!res.ok) return err(res.error ?? "Failed to schedule task.");
+        return ok({
+          scheduled_start: startISO,
+          scheduled_end: endISO,
+          calendar_synced: res.calendar_synced,
+          ...(res.calendar_error ? { calendar_error: res.calendar_error } : {}),
+        });
+      },
+    }),
+
+    unschedule_task: tool({
+      description:
+        "Remove a task's calendar block: deletes its Google Calendar event and clears the block on the task.",
+      inputSchema: jsonSchema<{ id: string }>({
+        type: "object",
+        required: ["id"],
+        properties: { id: { type: "string", description: "Task UUID." } },
+      }),
+      execute: async ({ id }) => {
+        if (!userId) return err("No user context.");
+        const res = await unscheduleTask({ supabase, userId, taskId: id });
+        if (!res.ok) return err(res.error ?? "Failed to unschedule task.");
+        return ok({
+          calendar_synced: res.calendar_synced,
+          ...(res.calendar_error ? { calendar_error: res.calendar_error } : {}),
+        });
       },
     }),
   };

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -31,6 +31,9 @@ export interface Task {
   due_date: string | null;
   category: string | null;
   list_id: string | null;
+  calendar_event_id: string | null;
+  scheduled_start: string | null;
+  scheduled_end: string | null;
   completed_at: string | null;
   created_at: string;
   parent_id: string | null;


### PR DESCRIPTION
Phase 2 of the tasks overhaul: **task → calendar** (explicit "Add to calendar" with a time block). Builds on Phase 1 lists (#680). Next: history + retention, then dependencies (#470).

## What it does

A calendar button on each task opens a **date + time + duration** picker. "Add to calendar" creates a Google Calendar event on `primary`, and the row shows a chip with the block time. Editing re-patches the event; "Remove" deletes it. Scheduling is separate from the existing due-date.

## Changes

**Schema** — `20260814010000_task_scheduling.sql`
- `tasks.calendar_event_id text`, `scheduled_start timestamptz`, `scheduled_end timestamptz` (all nullable) + index on `scheduled_start`.

**Lib** — `web/src/lib/tasks/schedule-task.ts` (`scheduleTask` / `unscheduleTask`)
- Mirrors the workout_plans calendar pattern: `getGoogleAuthClient` → create/patch/delete on `primary`, store the event id back on the task, 8s timeouts, delete treats 404/410 as success.
- **Partial success**: the block is persisted on the task first, then Google is attempted; a sync failure (e.g. Google not connected) is reported, never thrown — the block is still saved and the UI shows a soft warning.
- Start/end are absolute UTC ISO (the client computes them from local date+time), so the event lands at the right instant without server-side tz math.

**UI** — `task-item.tsx`: calendar button, schedule panel (date/time/duration/Add·Update·Remove), and a `CalendarClock` chip on scheduled rows.

**MCP** — `schedule_task` (id + ISO start + duration), `unschedule_task`; `get_tasks` returns the block.

## Deliberately deferred
- Completing/archiving a task **leaves** its calendar event in place. Auto-clearing a *future* block on completion is a possible follow-up (kept out to avoid deleting past/historical events).

## Checks (local)
`tsc` clean · eslint 0 errors · prettier clean · `lint-tokens.sh` pass · node 162/162 · python 25/25.

Deploy note: migration + app rebuild on compute-core; client change → hard-refresh the PWA after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)