### PR TITLE
feat: task calendar — all-day blocks, end time, add-from-create (Phase 2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **Task calendar scheduling: all-day blocks, explicit end time, and add-from-create.** Refines the
+  Phase 2 scheduler on feedback: the per-task panel now takes a **start and end time** (15-minute
+  steps) instead of a duration dropdown, and **blank times mean an all-day event**. The add-task
+  form gains a **calendar toggle** — off by default — that reveals start/end time inputs, so a task
+  can be dropped on the calendar as it's created (using its due-date, or today, as the date; all-day
+  if no times). New `tasks.scheduled_all_day` flag; `scheduleTask` and the `schedule_task` MCP tool
+  now take a discriminated block (all-day date vs timed range). All-day dates are stored as noon-UTC
+  so the calendar day never shifts across time zones.
+
 - **Schedule a task onto Google Calendar (time block).** A task can now be dropped on the calendar
   as an explicit block: a calendar button on each row opens a date + time + duration picker
   ("Add to calendar"), and the row shows a chip with the block time. New nullable columns

--- a/supabase/migrations/20260814020000_task_all_day_schedule.sql
+++ b/supabase/migrations/20260814020000_task_all_day_schedule.sql
@@ -1,0 +1,7 @@
+-- All-day task scheduling. A calendar block can now be all-day (a date, no time) as well as a
+-- timed range. Google models the two differently ({date} vs {dateTime}), so the task needs to
+-- remember which it is. For an all-day block, scheduled_start holds noon-UTC of the date (so the
+-- local calendar date never shifts across time zones) and scheduled_end is null.
+
+alter table tasks
+  add column if not exists scheduled_all_day boolean not null default false;

--- a/web/src/app/(protected)/tasks/page.tsx
+++ b/web/src/app/(protected)/tasks/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 import AddTaskForm from "@/components/tasks/add-task-form";
 import CompletedTasks from "@/components/tasks/completed-tasks";
 import ListTabs from "@/components/tasks/list-tabs";
-import { scheduleTask, unscheduleTask } from "@/lib/tasks/schedule-task";
+import { scheduleTask, unscheduleTask, type ScheduleBlock } from "@/lib/tasks/schedule-task";
 import type { Task, TaskList } from "@/lib/types";
 
 async function addTask(
@@ -20,7 +20,8 @@ async function addTask(
   priority: string,
   dueDate: string,
   listId: string,
-): Promise<{ error?: string }> {
+  schedule: ScheduleBlock | null,
+): Promise<{ error?: string; warning?: string }> {
   "use server";
   try {
     const supabase = await createClient();
@@ -28,17 +29,34 @@ async function addTask(
       data: { user },
     } = await supabase.auth.getUser();
     if (!user) return { error: "Unauthorized" };
-    const { error } = await supabase.from("tasks").insert({
-      user_id: user.id,
-      title,
-      priority: priority || "medium",
-      status: "active",
-      due_date: dueDate || null,
-      list_id: listId || null,
-    });
+    const { data: inserted, error } = await supabase
+      .from("tasks")
+      .insert({
+        user_id: user.id,
+        title,
+        priority: priority || "medium",
+        status: "active",
+        due_date: dueDate || null,
+        list_id: listId || null,
+      })
+      .select("id")
+      .single();
     if (error) return { error: error.message };
     revalidatePath("/tasks");
     revalidatePath("/dashboard");
+    // Optionally drop it on the calendar in the same action.
+    if (schedule && inserted?.id) {
+      const res = await scheduleTask({
+        supabase,
+        userId: user.id,
+        taskId: inserted.id,
+        block: schedule,
+      });
+      revalidatePath("/tasks");
+      if (res.ok && !res.calendar_synced) {
+        return { warning: `Task added; calendar didn't sync: ${res.calendar_error ?? "unknown"}` };
+      }
+    }
     return {};
   } catch (err) {
     return { error: err instanceof Error ? err.message : "Failed to add task" };
@@ -232,8 +250,7 @@ async function deleteList(id: string): Promise<{ error?: string }> {
 
 async function scheduleTaskAction(
   taskId: string,
-  startISO: string,
-  endISO: string,
+  block: ScheduleBlock,
 ): Promise<{ error?: string; warning?: string }> {
   "use server";
   try {
@@ -242,7 +259,7 @@ async function scheduleTaskAction(
       data: { user },
     } = await supabase.auth.getUser();
     if (!user) return { error: "Unauthorized" };
-    const res = await scheduleTask({ supabase, userId: user.id, taskId, startISO, endISO });
+    const res = await scheduleTask({ supabase, userId: user.id, taskId, block });
     if (!res.ok) return { error: res.error ?? "Failed to schedule" };
     revalidatePath("/tasks");
     revalidatePath("/dashboard");

--- a/web/src/components/tasks/add-task-form.tsx
+++ b/web/src/components/tasks/add-task-form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState, useTransition, useRef } from "react";
-import { Plus } from "lucide-react";
+import { Plus, CalendarClock } from "lucide-react";
 import type { TaskList } from "@/lib/types";
+import type { ScheduleBlock } from "@/lib/tasks/schedule-task";
 
 interface Props {
   addAction: (
@@ -10,9 +11,17 @@ interface Props {
     priority: string,
     dueDate: string,
     listId: string,
-  ) => Promise<{ error?: string }>;
+    schedule: ScheduleBlock | null,
+  ) => Promise<{ error?: string; warning?: string }>;
   lists: TaskList[];
   defaultListId: string;
+}
+
+/** Today as YYYY-MM-DD in the browser's local zone. */
+function todayLocal(): string {
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 }
 
 const PRIORITIES = [
@@ -26,24 +35,47 @@ export default function AddTaskForm({ addAction, lists, defaultListId }: Props) 
   const [priority, setPriority] = useState<"high" | "medium" | "low">("medium");
   const [dueDate, setDueDate] = useState("");
   const [listId, setListId] = useState(defaultListId);
+  const [calendarOn, setCalendarOn] = useState(false);
+  const [startTime, setStartTime] = useState("");
+  const [endTime, setEndTime] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const inputRef = useRef<HTMLInputElement>(null);
 
+  // Build the calendar block from the toggle + date + times. Blank times → all-day; a lone start
+  // gets a default 30-min end. Event date is the due-date, or today if none is set.
+  function buildSchedule(): ScheduleBlock | null {
+    if (!calendarOn) return null;
+    const date = dueDate || todayLocal();
+    if (startTime) {
+      const s = new Date(`${date}T${startTime}`);
+      const e = endTime ? new Date(`${date}T${endTime}`) : new Date(s.getTime() + 30 * 60_000);
+      return { allDay: false, startISO: s.toISOString(), endISO: e.toISOString() };
+    }
+    return { allDay: true, date };
+  }
+
   function handleSubmit(e?: React.FormEvent) {
     e?.preventDefault();
     if (!title.trim() || isPending) return;
+    if (calendarOn && startTime && endTime && endTime <= startTime) {
+      setError("End time must be after start time.");
+      return;
+    }
     setError(null);
     startTransition(async () => {
-      const result = await addAction(title.trim(), priority, dueDate, listId);
+      const result = await addAction(title.trim(), priority, dueDate, listId, buildSchedule());
       if (result.error) {
         setError(result.error);
         return;
       }
+      setError(result.warning ?? null);
       setTitle("");
       setPriority("medium");
       setDueDate("");
-      // Keep the list selection — you're usually adding several to the same list.
+      setStartTime("");
+      setEndTime("");
+      // Keep the list selection and calendar toggle — you're usually adding several similar tasks.
       inputRef.current?.focus();
     });
   }
@@ -152,6 +184,63 @@ export default function AddTaskForm({ addAction, lists, defaultListId }: Props) 
             width: 120,
           }}
         />
+
+        {/* Calendar toggle + optional time block */}
+        <button
+          type="button"
+          onClick={() => setCalendarOn((v) => !v)}
+          className="flex-shrink-0 flex items-center justify-center transition-opacity hover:opacity-80"
+          style={{
+            width: 32,
+            height: 32,
+            borderRadius: "var(--r-1)",
+            border: "1px solid var(--rule)",
+            color: calendarOn ? "var(--color-text-on-cta)" : "var(--color-text-faint)",
+            background: calendarOn ? "var(--accent)" : "transparent",
+          }}
+          title={calendarOn ? "On calendar (click to turn off)" : "Add to calendar"}
+          aria-pressed={calendarOn}
+        >
+          <CalendarClock size={14} />
+        </button>
+
+        {calendarOn && (
+          <div className="flex items-center flex-shrink-0" style={{ gap: "var(--space-1)" }}>
+            <input
+              type="time"
+              step={900}
+              aria-label="Start time"
+              value={startTime}
+              onChange={(e) => setStartTime(e.target.value)}
+              className="focus:outline-none"
+              style={{
+                fontSize: "var(--t-micro)",
+                background: "transparent",
+                border: "1px solid var(--rule)",
+                borderRadius: "var(--r-1)",
+                padding: "4px 6px",
+                color: startTime ? "var(--color-text)" : "var(--color-text-faint)",
+              }}
+            />
+            <span style={{ color: "var(--color-text-faint)", fontSize: "var(--t-micro)" }}>–</span>
+            <input
+              type="time"
+              step={900}
+              aria-label="End time"
+              value={endTime}
+              onChange={(e) => setEndTime(e.target.value)}
+              className="focus:outline-none"
+              style={{
+                fontSize: "var(--t-micro)",
+                background: "transparent",
+                border: "1px solid var(--rule)",
+                borderRadius: "var(--r-1)",
+                padding: "4px 6px",
+                color: endTime ? "var(--color-text)" : "var(--color-text-faint)",
+              }}
+            />
+          </div>
+        )}
 
         <button
           type="submit"

--- a/web/src/components/tasks/task-item.tsx
+++ b/web/src/components/tasks/task-item.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition, useRef, useEffect } from "react";
 import { Archive, CalendarClock, ChevronDown, ChevronRight, Pencil, X } from "lucide-react";
 import type { Task, Subtask, TaskList } from "@/lib/types";
+import type { ScheduleBlock } from "@/lib/tasks/schedule-task";
 import { todayString } from "@/lib/timezone";
 
 function relativeDue(dateStr: string): { label: string; urgent: boolean } {
@@ -37,13 +38,10 @@ interface Props {
   deleteSubtaskAction: (id: string) => Promise<{ error?: string }>;
   scheduleAction: (
     id: string,
-    startISO: string,
-    endISO: string,
+    block: ScheduleBlock,
   ) => Promise<{ error?: string; warning?: string }>;
   unscheduleAction: (id: string) => Promise<{ error?: string; warning?: string }>;
 }
-
-const DURATIONS = [15, 30, 45, 60, 90] as const;
 
 /** Local YYYY-MM-DD / HH:MM parts of an ISO instant, for the date/time inputs. */
 function localParts(iso: string): { date: string; time: string } {
@@ -55,7 +53,16 @@ function localParts(iso: string): { date: string; time: string } {
   };
 }
 
-/** Short local label for the scheduled-block chip, e.g. "Aug 20, 2:00 PM". */
+/** All-day date label ("Aug 20") from the noon-UTC marker, without a tz shift. */
+function formatDay(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+/** Timed label, e.g. "Aug 20, 2:00 PM". */
 function formatScheduled(iso: string): string {
   return new Date(iso).toLocaleString("en-US", {
     month: "short",
@@ -225,39 +232,42 @@ export default function TaskItem({
 
   const taskList = task.list_id ? lists.find((l) => l.id === task.list_id) : null;
 
-  // Scheduling — seed the inputs from an existing block, else empty / 30 min.
+  // Scheduling — seed from an existing block. All-day: date only, times blank. Timed: date + times.
   const seededStart = task.scheduled_start ? localParts(task.scheduled_start) : null;
-  const seededDuration =
-    task.scheduled_start && task.scheduled_end
-      ? Math.max(
-          15,
-          Math.round(
-            (new Date(task.scheduled_end).getTime() - new Date(task.scheduled_start).getTime()) /
-              60_000,
-          ),
-        )
-      : 30;
+  const seededEnd = task.scheduled_end ? localParts(task.scheduled_end) : null;
+  const seededDate = task.scheduled_all_day
+    ? (task.scheduled_start ?? "").slice(0, 10) // noon-UTC marker → the intended date
+    : (seededStart?.date ?? "");
   const [showSchedule, setShowSchedule] = useState(false);
-  const [schedDate, setSchedDate] = useState(seededStart?.date ?? "");
-  const [schedTime, setSchedTime] = useState(seededStart?.time ?? "");
-  const [schedDuration, setSchedDuration] = useState<number>(seededDuration);
+  const [schedDate, setSchedDate] = useState(seededDate);
+  const [schedStart, setSchedStart] = useState(
+    task.scheduled_all_day ? "" : (seededStart?.time ?? ""),
+  );
+  const [schedEnd, setSchedEnd] = useState(task.scheduled_all_day ? "" : (seededEnd?.time ?? ""));
   const [schedNote, setSchedNote] = useState<string | null>(null);
 
   function saveSchedule() {
-    if (!schedDate || !schedTime) {
-      setSchedNote("Pick a date and time.");
+    if (!schedDate) {
+      setSchedNote("Pick a date.");
       return;
     }
-    const start = new Date(`${schedDate}T${schedTime}`);
-    if (Number.isNaN(start.getTime())) {
-      setSchedNote("Invalid date/time.");
+    if (schedStart && schedEnd && schedEnd <= schedStart) {
+      setSchedNote("End time must be after start time.");
       return;
     }
-    const startISO = start.toISOString();
-    const endISO = new Date(start.getTime() + schedDuration * 60_000).toISOString();
+    // A start time → timed (blank end defaults to +30 min). No start time → all-day.
+    const block: ScheduleBlock = schedStart
+      ? (() => {
+          const s = new Date(`${schedDate}T${schedStart}`);
+          const e = schedEnd
+            ? new Date(`${schedDate}T${schedEnd}`)
+            : new Date(s.getTime() + 30 * 60_000);
+          return { allDay: false as const, startISO: s.toISOString(), endISO: e.toISOString() };
+        })()
+      : { allDay: true, date: schedDate };
     setSchedNote(null);
     startTransition(async () => {
-      const res = await scheduleAction(task.id, startISO, endISO);
+      const res = await scheduleAction(task.id, block);
       if (res.error) {
         setSchedNote(res.error);
         return;
@@ -451,7 +461,9 @@ export default function TaskItem({
             title="On your calendar"
           >
             <CalendarClock size={11} />
-            {formatScheduled(task.scheduled_start)}
+            {task.scheduled_all_day
+              ? `${formatDay(task.scheduled_start)} · all day`
+              : formatScheduled(task.scheduled_start)}
           </span>
         )}
 
@@ -634,9 +646,10 @@ export default function TaskItem({
             />
             <input
               type="time"
-              aria-label="Schedule time"
-              value={schedTime}
-              onChange={(e) => setSchedTime(e.target.value)}
+              step={900}
+              aria-label="Start time"
+              value={schedStart}
+              onChange={(e) => setSchedStart(e.target.value)}
               className="focus:outline-none"
               style={{
                 fontSize: "var(--t-micro)",
@@ -644,13 +657,16 @@ export default function TaskItem({
                 border: "1px solid var(--rule)",
                 borderRadius: "var(--r-1)",
                 padding: "4px 8px",
-                color: "var(--color-text)",
+                color: schedStart ? "var(--color-text)" : "var(--color-text-faint)",
               }}
             />
-            <select
-              aria-label="Duration"
-              value={schedDuration}
-              onChange={(e) => setSchedDuration(Number(e.target.value))}
+            <span style={{ color: "var(--color-text-faint)", fontSize: "var(--t-micro)" }}>–</span>
+            <input
+              type="time"
+              step={900}
+              aria-label="End time"
+              value={schedEnd}
+              onChange={(e) => setSchedEnd(e.target.value)}
               className="focus:outline-none"
               style={{
                 fontSize: "var(--t-micro)",
@@ -658,15 +674,15 @@ export default function TaskItem({
                 border: "1px solid var(--rule)",
                 borderRadius: "var(--r-1)",
                 padding: "4px 8px",
-                color: "var(--color-text)",
+                color: schedEnd ? "var(--color-text)" : "var(--color-text-faint)",
               }}
+            />
+            <span
+              style={{ fontSize: "var(--t-micro)", color: "var(--color-text-faint)" }}
+              title="Leave times blank for an all-day event"
             >
-              {DURATIONS.map((d) => (
-                <option key={d} value={d}>
-                  {d} min
-                </option>
-              ))}
-            </select>
+              {schedStart ? "" : "all-day"}
+            </span>
             <button
               onClick={saveSchedule}
               className="transition-opacity hover:opacity-80"

--- a/web/src/lib/tasks/schedule-task.ts
+++ b/web/src/lib/tasks/schedule-task.ts
@@ -25,19 +25,27 @@ export interface ScheduleResult {
   calendar_error?: string; // soft failure — the block saved, the Google event did not
 }
 
-/** Create or move the Google event for a task and record the block. startISO/endISO are absolute (UTC). */
+/** A task's calendar block: an all-day date, or a timed range (absolute UTC ISO instants). */
+export type ScheduleBlock =
+  | { allDay: true; date: string } // YYYY-MM-DD
+  | { allDay: false; startISO: string; endISO: string };
+
+/** Add one calendar day to a YYYY-MM-DD date — Google's all-day `end.date` is exclusive. */
+function nextDay(date: string): string {
+  return new Date(Date.parse(`${date}T00:00:00Z`) + 86_400_000).toISOString().slice(0, 10);
+}
+
+/** Create or move the Google event for a task and record the block. */
 export async function scheduleTask({
   supabase,
   userId,
   taskId,
-  startISO,
-  endISO,
+  block,
 }: {
   supabase: SupabaseClient;
   userId: string;
   taskId: string;
-  startISO: string;
-  endISO: string;
+  block: ScheduleBlock;
 }): Promise<ScheduleResult> {
   const { data: task, error: fetchErr } = await supabase
     .from("tasks")
@@ -48,10 +56,22 @@ export async function scheduleTask({
   if (fetchErr) return { ok: false, error: fetchErr.message, calendar_synced: false };
   if (!task) return { ok: false, error: "Task not found.", calendar_synced: false };
 
-  // Persist the block first, so the schedule survives even if Google is unreachable.
+  // Persist the block first, so the schedule survives even if Google is unreachable. All-day is
+  // stored as noon-UTC of the date (never shifts across time zones), with a null end.
+  const stored = block.allDay
+    ? {
+        scheduled_all_day: true,
+        scheduled_start: `${block.date}T12:00:00.000Z`,
+        scheduled_end: null,
+      }
+    : {
+        scheduled_all_day: false,
+        scheduled_start: block.startISO,
+        scheduled_end: block.endISO,
+      };
   const { error: saveErr } = await supabase
     .from("tasks")
-    .update({ scheduled_start: startISO, scheduled_end: endISO })
+    .update(stored)
     .eq("id", taskId)
     .eq("user_id", userId);
   if (saveErr) return { ok: false, error: saveErr.message, calendar_synced: false };
@@ -59,13 +79,19 @@ export async function scheduleTask({
   try {
     const auth = await getGoogleAuthClient({ db: supabase, userId });
     const calendar = google.calendar({ version: "v3", auth });
-    // startISO/endISO carry a UTC offset (…Z), so Google places the event correctly without a
-    // separate timeZone field, and displays it in the calendar's own zone.
-    const body = {
-      summary: task.title,
-      start: { dateTime: startISO },
-      end: { dateTime: endISO },
-    };
+    // Timed blocks carry a UTC offset (…Z), so Google places the event without a separate timeZone
+    // field. All-day uses {date}; Google's end.date is exclusive, hence nextDay().
+    const body = block.allDay
+      ? {
+          summary: task.title,
+          start: { date: block.date },
+          end: { date: nextDay(block.date) },
+        }
+      : {
+          summary: task.title,
+          start: { dateTime: block.startISO },
+          end: { dateTime: block.endISO },
+        };
 
     let eventId: string | null = task.calendar_event_id ?? null;
     if (eventId) {
@@ -143,7 +169,12 @@ export async function unscheduleTask({
 
   const { error: clearErr } = await supabase
     .from("tasks")
-    .update({ calendar_event_id: null, scheduled_start: null, scheduled_end: null })
+    .update({
+      calendar_event_id: null,
+      scheduled_start: null,
+      scheduled_end: null,
+      scheduled_all_day: false,
+    })
     .eq("id", taskId)
     .eq("user_id", userId);
   if (clearErr) return { ok: false, error: clearErr.message, calendar_synced: false };

--- a/web/src/lib/tools/tasks.ts
+++ b/web/src/lib/tools/tasks.ts
@@ -194,30 +194,72 @@ export function buildTasksTools({ supabase, userId }: ToolContext) {
 
     schedule_task: tool({
       description:
-        "Put a task on the user's Google Calendar as a time block (or move an existing block). Provide start as an ISO 8601 datetime WITH offset (e.g. 2026-08-20T14:00:00-07:00) and a duration in minutes. Records the block on the task and creates/updates the calendar event. Partial success: if Google isn't connected the block is still saved and calendar_synced is false.",
-      inputSchema: jsonSchema<{ id: string; start: string; duration_minutes?: number }>({
+        "Put a task on the user's Google Calendar as a calendar block (or move an existing one). For a TIMED block, provide start (ISO 8601 with offset, e.g. 2026-08-20T14:00:00-07:00) and either end or duration_minutes. For an ALL-DAY block, set all_day:true and date (YYYY-MM-DD). Partial success: if Google isn't connected the block is still saved and calendar_synced is false.",
+      inputSchema: jsonSchema<{
+        id: string;
+        all_day?: boolean;
+        date?: string;
+        start?: string;
+        end?: string;
+        duration_minutes?: number;
+      }>({
         type: "object",
-        required: ["id", "start"],
+        required: ["id"],
         properties: {
           id: { type: "string", description: "Task UUID." },
+          all_day: { type: "boolean", description: "True for an all-day block (needs date)." },
+          date: { type: "string", description: "All-day date, YYYY-MM-DD." },
           start: {
             type: "string",
-            description: "ISO 8601 start datetime with UTC offset, e.g. 2026-08-20T14:00:00-07:00.",
+            description: "Timed block start, ISO 8601 with offset, e.g. 2026-08-20T14:00:00-07:00.",
           },
+          end: { type: "string", description: "Timed block end, ISO 8601 with offset." },
           duration_minutes: {
             type: "number",
-            description: "Block length in minutes. Defaults to 30.",
+            description: "Timed block length if end is omitted. Defaults to 30.",
           },
         },
       }),
-      execute: async ({ id, start, duration_minutes }) => {
+      execute: async ({ id, all_day, date, start, end, duration_minutes }) => {
         if (!userId) return err("No user context.");
+        if (all_day) {
+          if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+            return err("all_day requires date in YYYY-MM-DD format.");
+          }
+          const res = await scheduleTask({
+            supabase,
+            userId,
+            taskId: id,
+            block: { allDay: true, date },
+          });
+          if (!res.ok) return err(res.error ?? "Failed to schedule task.");
+          return ok({
+            all_day: true,
+            date,
+            calendar_synced: res.calendar_synced,
+            ...(res.calendar_error ? { calendar_error: res.calendar_error } : {}),
+          });
+        }
+        if (!start) return err("A timed block needs start (or set all_day + date).");
         const startMs = Date.parse(start);
         if (Number.isNaN(startMs)) return err(`start is not a valid ISO datetime: "${start}"`);
-        const mins = duration_minutes && duration_minutes > 0 ? duration_minutes : 30;
+        let endMs: number;
+        if (end) {
+          endMs = Date.parse(end);
+          if (Number.isNaN(endMs)) return err(`end is not a valid ISO datetime: "${end}"`);
+        } else {
+          const mins = duration_minutes && duration_minutes > 0 ? duration_minutes : 30;
+          endMs = startMs + mins * 60_000;
+        }
+        if (endMs <= startMs) return err("end must be after start.");
         const startISO = new Date(startMs).toISOString();
-        const endISO = new Date(startMs + mins * 60_000).toISOString();
-        const res = await scheduleTask({ supabase, userId, taskId: id, startISO, endISO });
+        const endISO = new Date(endMs).toISOString();
+        const res = await scheduleTask({
+          supabase,
+          userId,
+          taskId: id,
+          block: { allDay: false, startISO, endISO },
+        });
         if (!res.ok) return err(res.error ?? "Failed to schedule task.");
         return ok({
           scheduled_start: startISO,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -34,6 +34,7 @@ export interface Task {
   calendar_event_id: string | null;
   scheduled_start: string | null;
   scheduled_end: string | null;
+  scheduled_all_day: boolean;
   completed_at: string | null;
   created_at: string;
   parent_id: string | null;


### PR DESCRIPTION
Refines the Phase 2 scheduler (#681) on feedback from using it.

## Changes
1. **End time, not duration** — the per-task schedule panel now takes a **start + end time** in **15-minute steps** (`<input type=time step=900>`), replacing the 30-min duration dropdown.
2. **All-day blocks** — leaving the times blank creates an **all-day** calendar event. New `tasks.scheduled_all_day` flag; all-day dates are stored as noon-UTC so the calendar day never shifts across time zones.
3. **Schedule at creation** — the add-task form gains a **calendar toggle** (off by default). When on, it reveals start/end time inputs and the new task is dropped on the calendar in the same action — using its due-date as the event date (or today if none), all-day when no times.

## Under the hood
- `scheduleTask` and the `schedule_task` MCP tool now take a discriminated `ScheduleBlock` — `{ allDay: true, date }` or `{ allDay: false, startISO, endISO }`. MCP `schedule_task` accepts `all_day`+`date`, or `start`+`end`/`duration_minutes`.
- `addTask` schedules in the same server action and returns a soft `warning` if the calendar didn't sync (partial-success preserved).

## Checks (local)
`tsc` clean · eslint 0 errors · prettier clean · `lint-tokens.sh` pass · node 162/162 · python 25/25.

Deploy: 1 migration (adds `scheduled_all_day`) + rebuild; client change → hard-refresh the PWA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)