### PR TITLE
fix: task add-form disappearing + 15-min time steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **Add-task box could "disappear" after adding, and time pickers ignored 15-min steps.** Two
+  regressions from the calendar work: (1) the title input was `flex-1 min-w-0`, so the extra
+  scheduling controls in the row could squeeze it to zero width — it now has a real minimum width;
+  and pressing Enter fired the submit twice (the input's key handler *and* the form's native
+  submit), racing two adds — the key handler now `preventDefault`s. (2) `<input type="time"
+  step="900">` doesn't actually constrain the picker to quarter hours (especially on mobile), so
+  start/end time are now a `TimeSelect` dropdown of 15-minute slots, identical on phone and desktop.
+
 - **A deliberate rest day counted as a missed session.** `coach_check.py`'s miss streak keyed off
   session-existence alone and ignored `workout_plans.status`, so a `cancelled`/`skipped` day (a
   chosen rest) read as a miss — inflating the streak that escalates coaching (2 misses cuts volume,

--- a/web/src/components/tasks/add-task-form.tsx
+++ b/web/src/components/tasks/add-task-form.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition, useRef } from "react";
 import { Plus, CalendarClock } from "lucide-react";
 import type { TaskList } from "@/lib/types";
 import type { ScheduleBlock } from "@/lib/tasks/schedule-task";
+import TimeSelect from "./time-select";
 
 interface Props {
   addAction: (
@@ -103,14 +104,23 @@ export default function AddTaskForm({ addAction, lists, defaultListId }: Props) 
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === "Enter") handleSubmit();
+            // preventDefault stops the form's native submit from ALSO firing handleSubmit — a
+            // double-fire raced two adds and left the transition wedged (issue: box "disappeared").
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleSubmit();
+            }
           }}
           placeholder="Add a task…"
-          className="flex-1 bg-transparent focus:outline-none min-w-0"
+          className="bg-transparent focus:outline-none"
           style={{
             color: "var(--color-text)",
             fontSize: "var(--t-body)",
             caretColor: "var(--accent)",
+            // flex-grow, but never shrink below a legible width — with min-w-0 the extra controls
+            // in this row could squeeze the input to zero and it looked like it had vanished.
+            flex: "1 1 160px",
+            minWidth: 160,
           }}
         />
 
@@ -206,38 +216,18 @@ export default function AddTaskForm({ addAction, lists, defaultListId }: Props) 
 
         {calendarOn && (
           <div className="flex items-center flex-shrink-0" style={{ gap: "var(--space-1)" }}>
-            <input
-              type="time"
-              step={900}
-              aria-label="Start time"
+            <TimeSelect
+              ariaLabel="Start time"
               value={startTime}
-              onChange={(e) => setStartTime(e.target.value)}
-              className="focus:outline-none"
-              style={{
-                fontSize: "var(--t-micro)",
-                background: "transparent",
-                border: "1px solid var(--rule)",
-                borderRadius: "var(--r-1)",
-                padding: "4px 6px",
-                color: startTime ? "var(--color-text)" : "var(--color-text-faint)",
-              }}
+              onChange={setStartTime}
+              placeholder="all-day"
             />
             <span style={{ color: "var(--color-text-faint)", fontSize: "var(--t-micro)" }}>–</span>
-            <input
-              type="time"
-              step={900}
-              aria-label="End time"
+            <TimeSelect
+              ariaLabel="End time"
               value={endTime}
-              onChange={(e) => setEndTime(e.target.value)}
-              className="focus:outline-none"
-              style={{
-                fontSize: "var(--t-micro)",
-                background: "transparent",
-                border: "1px solid var(--rule)",
-                borderRadius: "var(--r-1)",
-                padding: "4px 6px",
-                color: endTime ? "var(--color-text)" : "var(--color-text-faint)",
-              }}
+              onChange={setEndTime}
+              placeholder="end"
             />
           </div>
         )}

--- a/web/src/components/tasks/task-item.tsx
+++ b/web/src/components/tasks/task-item.tsx
@@ -5,6 +5,7 @@ import { Archive, CalendarClock, ChevronDown, ChevronRight, Pencil, X } from "lu
 import type { Task, Subtask, TaskList } from "@/lib/types";
 import type { ScheduleBlock } from "@/lib/tasks/schedule-task";
 import { todayString } from "@/lib/timezone";
+import TimeSelect from "./time-select";
 
 function relativeDue(dateStr: string): { label: string; urgent: boolean } {
   const today = todayString();
@@ -644,38 +645,18 @@ export default function TaskItem({
                 color: "var(--color-text)",
               }}
             />
-            <input
-              type="time"
-              step={900}
-              aria-label="Start time"
+            <TimeSelect
+              ariaLabel="Start time"
               value={schedStart}
-              onChange={(e) => setSchedStart(e.target.value)}
-              className="focus:outline-none"
-              style={{
-                fontSize: "var(--t-micro)",
-                background: "transparent",
-                border: "1px solid var(--rule)",
-                borderRadius: "var(--r-1)",
-                padding: "4px 8px",
-                color: schedStart ? "var(--color-text)" : "var(--color-text-faint)",
-              }}
+              onChange={setSchedStart}
+              placeholder="all-day"
             />
             <span style={{ color: "var(--color-text-faint)", fontSize: "var(--t-micro)" }}>–</span>
-            <input
-              type="time"
-              step={900}
-              aria-label="End time"
+            <TimeSelect
+              ariaLabel="End time"
               value={schedEnd}
-              onChange={(e) => setSchedEnd(e.target.value)}
-              className="focus:outline-none"
-              style={{
-                fontSize: "var(--t-micro)",
-                background: "transparent",
-                border: "1px solid var(--rule)",
-                borderRadius: "var(--r-1)",
-                padding: "4px 8px",
-                color: schedEnd ? "var(--color-text)" : "var(--color-text-faint)",
-              }}
+              onChange={setSchedEnd}
+              placeholder="end"
             />
             <span
               style={{ fontSize: "var(--t-micro)", color: "var(--color-text-faint)" }}

--- a/web/src/components/tasks/time-select.tsx
+++ b/web/src/components/tasks/time-select.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+// A dropdown of 15-minute time slots. Native <input type="time" step="900"> only enforces the
+// step in its spinner/validation — the wheel picker (and most mobile keyboards) still let you pick
+// any minute. A <select> guarantees quarter-hour steps identically on phone and desktop.
+
+const TIME_OPTIONS: { value: string; label: string }[] = (() => {
+  const out: { value: string; label: string }[] = [];
+  for (let m = 0; m < 24 * 60; m += 15) {
+    const h = Math.floor(m / 60);
+    const min = m % 60;
+    const value = `${String(h).padStart(2, "0")}:${String(min).padStart(2, "0")}`;
+    const h12 = ((h + 11) % 12) + 1;
+    const ap = h < 12 ? "AM" : "PM";
+    out.push({ value, label: `${h12}:${String(min).padStart(2, "0")} ${ap}` });
+  }
+  return out;
+})();
+
+export default function TimeSelect({
+  value,
+  onChange,
+  ariaLabel,
+  placeholder = "—:—",
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  ariaLabel: string;
+  placeholder?: string;
+}) {
+  return (
+    <select
+      aria-label={ariaLabel}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="focus:outline-none flex-shrink-0"
+      style={{
+        fontSize: "var(--t-micro)",
+        background: "transparent",
+        border: "1px solid var(--rule)",
+        borderRadius: "var(--r-1)",
+        padding: "4px 6px",
+        color: value ? "var(--color-text)" : "var(--color-text-faint)",
+      }}
+    >
+      <option value="">{placeholder}</option>
+      {TIME_OPTIONS.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  );
+}


### PR DESCRIPTION
Fixes two bugs reported after using the Phase 2.1 scheduler.

## 1. "Add a task…" box disappeared after adding one (couldn't add another without refresh)
Two contributing causes, both fixed:
- The title input was `flex-1 min-w-0`. With the extra scheduling controls now in that row, flexbox could shrink it to **zero width** — it read as gone. It now keeps a real minimum width (`flex: 1 1 160px; min-width: 160`).
- Pressing **Enter** fired `handleSubmit` twice — once from the input's `onKeyDown`, once from the form's native submit — racing two adds and leaving the transition wedged. The key handler now `preventDefault`s so only one fires.

## 2. Start/end time weren't in 15-minute steps
`<input type="time" step="900">` only constrains the spinner/validation; the wheel picker and mobile keyboards still allow any minute. Replaced with a shared **`TimeSelect`** — a dropdown of quarter-hour slots (12-hour labels) — used in both the add form and the per-task schedule panel, so it behaves identically on phone and desktop.

## Note
I couldn't reproduce #1 locally (it needs the live RSC + Supabase session), so it's a best-effort fix targeting the two most likely causes. If the box still vanishes after this ships, a console error + which device would pin it down.

## Checks (local)
`tsc` clean · eslint 0 errors · prettier clean · `lint-tokens.sh` pass · node 162/162 · python 25/25.

Client-only change (no migration). Rebuild + hard-refresh the PWA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)