### PR TITLE
fix: log dates in the user's timezone, not UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,28 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **Dates were logged in UTC, so anything after ~5 PM Pacific was stamped with tomorrow.** The
+  container clock is UTC, so `new Date().toISOString().slice(0, 10)` — used to default
+  `cooks.cooked_on` and `meal_log.date` — returned the _next_ day for the last 7-8 hours of every
+  day. A shrimp dinner cooked at 5:53 PM PDT on 2026-08-19 was written as `cooked_on 2026-08-20`,
+  dating the leftovers into the future in a fridge list whose whole job is "eat the oldest thing
+  first"; any meal logged after 5 PM would likewise have landed on the next day's intake total.
+  Both defaults now use `todayString()` from `lib/timezone`, which formats in `USER_TIMEZONE`
+  (default `America/Los_Angeles`) — the helper already existed and this module simply never used it.
+  Same fix applied to the two other user-facing "today" defaults: the new-calendar-event date and
+  the onboarding date-of-birth `max`.
+
+  The weekly planner (`/api/internal/plan`) had the same bug in a nastier form: it built its week
+  window from `new Date()` + `getDay()` on a UTC server, so planning on a **Sunday evening Pacific**
+  read the clock as Monday and returned the Monday _after_ the week that was about to start —
+  silently skipping a week. Its window is now date strings throughout, via a new
+  `comingMonday(from)` helper. New `src/__tests__/timezone-dates.test.ts` pins all of it, including
+  DST boundaries and the exact instant that produced the bad row.
+
+  Deliberately **not** changed: `addDays`, `journal/prompts.shiftDate` and `sync/google-health.dateStr`
+  also call `toISOString()`, but each is anchored to an explicit UTC instant (noon-UTC, or an
+  already-offset-shifted timestamp) and is correct as written.
+
 - **Add-task box could "disappear" after adding, and time pickers ignored 15-min steps.** Two
   regressions from the calendar work: (1) the title input was `flex-1 min-w-0`, so the extra
   scheduling controls in the row could squeeze it to zero width — it now has a real minimum width;

--- a/web/src/__tests__/timezone-dates.test.ts
+++ b/web/src/__tests__/timezone-dates.test.ts
@@ -1,0 +1,82 @@
+// Unit tests for the user-timezone date helpers (lib/timezone.ts).
+// Run with: node --experimental-strip-types --test src/__tests__/timezone-dates.test.ts
+// (from the web/ directory)
+//
+// WHY THIS EXISTS
+//
+// mr-bridge runs in a container whose clock is UTC. Every `new Date()` in the app is
+// therefore a UTC instant, and `toISOString().slice(0, 10)` turns it into a UTC DATE.
+// For a user in America/Los_Angeles that date is wrong for the last 7-8 hours of every
+// single day — 5 PM Pacific is already tomorrow in UTC.
+//
+// This shipped as a real data bug. A shrimp dinner cooked at 5:53 PM Pacific on
+// 2026-08-19 was written to `cooks.cooked_on = 2026-08-20`, dating the leftovers a day
+// into the future in a fridge list whose entire job is "eat the oldest thing first".
+// The same expression defaulted `meal_log.date`, so any meal logged after 5 PM would
+// have landed on the next day's intake total.
+//
+// The rule the app now follows: a date that describes WHEN THE USER DID SOMETHING is
+// derived from `todayString()`, never from `toISOString()`.
+//
+// Note what is deliberately NOT covered here: `addDays`, `shiftDate` in journal/prompts,
+// and `dateStr` in sync/google-health all use `toISOString()` on purpose, anchored to an
+// explicit UTC instant (noon-UTC, or an already-offset-shifted timestamp). Those are
+// correct and must not be "fixed".
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { todayString, addDays, comingMonday } from "../lib/timezone.ts";
+
+test("todayString returns the user-timezone date, not the UTC date", () => {
+  const tz = "America/Los_Angeles";
+  const today = todayString(tz);
+  assert.match(today, /^\d{4}-\d{2}-\d{2}$/);
+
+  // The invariant that actually matters: for any instant, the Pacific date is either
+  // the same as the UTC date or one day BEHIND it — never ahead.
+  const utcToday = new Date().toISOString().slice(0, 10);
+  assert.ok(
+    today === utcToday || addDays(today, 1) === utcToday,
+    `Pacific date ${today} should equal or trail UTC date ${utcToday}`,
+  );
+});
+
+test("todayString disagrees with the UTC date during the Pacific evening", () => {
+  // Pin the exact failure that produced the bad cooked_on: 2026-08-20T00:53Z is
+  // 5:53 PM PDT on 2026-08-19. The formatter must say the 19th.
+  const instant = new Date("2026-08-20T00:53:45.928Z");
+  const pacific = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/Los_Angeles",
+  }).format(instant);
+  assert.equal(pacific, "2026-08-19");
+  assert.equal(instant.toISOString().slice(0, 10), "2026-08-20"); // what the bug wrote
+});
+
+test("comingMonday returns the next Monday, and never today when today is a Monday", () => {
+  assert.equal(comingMonday("2026-08-19"), "2026-08-24"); // Wed -> following Mon
+  assert.equal(comingMonday("2026-08-23"), "2026-08-24"); // Sun -> tomorrow
+  assert.equal(comingMonday("2026-08-24"), "2026-08-31"); // Mon -> NEXT Mon, not itself
+  assert.equal(comingMonday("2026-08-25"), "2026-08-31"); // Tue -> following Mon
+});
+
+test("comingMonday always lands on a Monday and is 1-7 days out", () => {
+  let d = "2026-01-01";
+  for (let i = 0; i < 400; i++) {
+    const mon = comingMonday(d);
+    assert.equal(new Date(`${mon}T12:00:00Z`).getUTCDay(), 1, `${mon} is not a Monday`);
+    const gap = Math.round(
+      (Date.parse(`${mon}T12:00:00Z`) - Date.parse(`${d}T12:00:00Z`)) / 86_400_000,
+    );
+    assert.ok(gap >= 1 && gap <= 7, `gap from ${d} to ${mon} was ${gap}`);
+    d = addDays(d, 1);
+  }
+});
+
+test("comingMonday holds across a DST boundary", () => {
+  // US DST ends 2026-11-01. A naive local-Date implementation drifts here.
+  assert.equal(comingMonday("2026-10-30"), "2026-11-02");
+  assert.equal(comingMonday("2026-11-01"), "2026-11-02");
+  // And spring forward, 2026-03-08.
+  assert.equal(comingMonday("2026-03-06"), "2026-03-09");
+  assert.equal(comingMonday("2026-03-08"), "2026-03-09");
+});

--- a/web/src/app/api/internal/plan/route.ts
+++ b/web/src/app/api/internal/plan/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServiceClient } from "@/lib/supabase/service";
 import { validateWeights } from "@/lib/fitness/equipment-validation";
+import { todayString, comingMonday, addDays } from "@/lib/timezone";
 
 interface WorkoutExercise {
   exercise: string;
@@ -34,28 +35,17 @@ function checkAuth(request: NextRequest): boolean {
   return !!(process.env.CRON_SECRET && auth === `Bearer ${process.env.CRON_SECRET}`);
 }
 
-function getComingMonday(weekStart?: string): Date {
-  if (weekStart) {
-    const [y, m, d] = weekStart.split("-").map(Number);
-    return new Date(y, m - 1, d);
-  }
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  const pyDow = (today.getDay() + 6) % 7; // 0=Mon … 6=Sun
-  const days = (7 - pyDow) % 7 || 7;
-  const monday = new Date(today);
-  monday.setDate(monday.getDate() + days);
-  return monday;
-}
-
-function toDateStr(d: Date): string {
-  return d.toISOString().slice(0, 10);
-}
-
-function addDays(d: Date, n: number): Date {
-  const r = new Date(d);
-  r.setDate(r.getDate() + n);
-  return r;
+/**
+ * The Monday that starts the week being planned, as YYYY-MM-DD.
+ *
+ * Everything downstream is a date STRING in the user's timezone. This route used to
+ * carry `Date` objects and stringify them with `toISOString()`, which is UTC — on a
+ * container running UTC (which is what mr-bridge runs), planning on a Sunday evening
+ * Pacific read the clock as Monday and jumped to the Monday AFTER the week that was
+ * about to start. Keeping the whole window as strings removes the conversion entirely.
+ */
+function getComingMondayStr(weekStart?: string): string {
+  return weekStart ?? comingMonday(todayString());
 }
 
 function fmtHrs(h: number | null | undefined): string {
@@ -76,13 +66,11 @@ export async function GET(request: NextRequest) {
 
   const db = createServiceClient();
   const weekStartParam = request.nextUrl.searchParams.get("week_start") ?? undefined;
-  const nextMonday = getComingMonday(weekStartParam);
+  const nextMonday = getComingMondayStr(weekStartParam);
   const priorMonday = addDays(nextMonday, -7);
   const priorSunday = addDays(nextMonday, -1);
   const nextSunday = addDays(nextMonday, 6);
-  const [nMon, pMon, pSun, nSun] = [nextMonday, priorMonday, priorSunday, nextSunday].map(
-    toDateStr,
-  );
+  const [nMon, pMon, pSun, nSun] = [nextMonday, priorMonday, priorSunday, nextSunday];
 
   const [
     profileR,
@@ -416,7 +404,7 @@ export async function GET(request: NextRequest) {
       if (!habitMap[name]) habitMap[name] = {};
       habitMap[name][h.date] = h.completed;
     }
-    const dates = Array.from({ length: 7 }, (_, i) => toDateStr(addDays(priorMonday, i)));
+    const dates = Array.from({ length: 7 }, (_, i) => addDays(priorMonday, i));
     for (const reg of registry) {
       const rowData = habitMap[reg.name] ?? {};
       const completed = dates.filter((d) => rowData[d] === true).length;
@@ -443,7 +431,7 @@ export async function GET(request: NextRequest) {
 
   const dayNames = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
   lines.push("\n## COMING WEEK — dates available for scheduling");
-  for (let i = 0; i < 7; i++) lines.push(`- ${toDateStr(addDays(nextMonday, i))} (${dayNames[i]})`);
+  for (let i = 0; i < 7; i++) lines.push(`- ${addDays(nextMonday, i)} (${dayNames[i]})`);
 
   return new Response(lines.join("\n"), {
     headers: { "Content-Type": "text/plain; charset=utf-8" },
@@ -475,9 +463,8 @@ export async function POST(request: NextRequest) {
   }
 
   const db = createServiceClient();
-  const nextMonday = getComingMonday(week_start);
-  const nextMondayStr = toDateStr(nextMonday);
-  const nextSundayStr = toDateStr(addDays(nextMonday, 6));
+  const nextMondayStr = getComingMondayStr(week_start);
+  const nextSundayStr = addDays(nextMondayStr, 6);
 
   const { count } = await db
     .from("workout_plans")

--- a/web/src/components/calendar/event-modal.tsx
+++ b/web/src/components/calendar/event-modal.tsx
@@ -4,6 +4,7 @@ import { useState, type FormEvent } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 import type { CalendarRangeEvent } from "@/lib/calendar-types";
+import { todayString } from "@/lib/timezone";
 
 interface EventModalProps {
   open: boolean;
@@ -50,9 +51,7 @@ export default function EventModal({
   // target event or slot changes, so these initializers always run fresh.
   const [title, setTitle] = useState(editEvent?.title ?? "");
   const [date, setDate] = useState(
-    editEvent
-      ? editEvent.start.slice(0, 10)
-      : (initialDate ?? new Date().toISOString().slice(0, 10)),
+    editEvent ? editEvent.start.slice(0, 10) : (initialDate ?? todayString()),
   );
   const [allDay, setAllDay] = useState(editEvent?.allDay ?? false);
   const [startTime, setStartTime] = useState(() => {

--- a/web/src/components/onboarding/onboarding-wizard.tsx
+++ b/web/src/components/onboarding/onboarding-wizard.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import { WatchlistSettings } from "@/components/settings/watchlist-settings";
 import { SportsSettings } from "@/components/settings/sports-settings";
 import type { SportsFavorite } from "@/lib/sync/sports";
+import { todayString } from "@/lib/timezone";
 
 const TOTAL_STEPS = 8;
 
@@ -576,7 +577,7 @@ export function OnboardingWizard({
                 type="date"
                 value={birthday}
                 onChange={(e) => setBirthday(e.target.value)}
-                max={new Date().toISOString().split("T")[0]}
+                max={todayString()}
                 className="focus:outline-none input-focus-ring"
                 style={inputStyle}
               />

--- a/web/src/lib/nutrition/cooks.ts
+++ b/web/src/lib/nutrition/cooks.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { estimateFromText } from "./estimate";
 import { perPortion } from "./recipe-macros";
+import { todayString } from "@/lib/timezone";
 
 /**
  * A cook is one time the user actually made food.
@@ -124,7 +125,9 @@ export async function createCook(
       user_id: userId,
       recipe_id: input.recipeId ?? null,
       name,
-      cooked_on: input.cookedOn ?? new Date().toISOString().slice(0, 10),
+      // todayString(), not toISOString() — the server runs UTC, so an evening Pacific
+      // cook used to be stamped with tomorrow's date and land in the fridge a day early.
+      cooked_on: input.cookedOn ?? todayString(),
       portions: input.portions,
       portions_remaining: input.portions,
       notes: input.notes ?? null,
@@ -229,7 +232,9 @@ export async function eatFromCook(
       .maybeSingle();
     logDate = (plan?.date as string | undefined) ?? undefined;
   }
-  logDate = logDate ?? new Date().toISOString().slice(0, 10);
+  // Same UTC trap as cooked_on: an evening Pacific meal must log to the day the user
+  // ate it, not the next UTC day, or it lands on the wrong day's intake total.
+  logDate = logDate ?? todayString();
 
   const { data: logged, error: logErr } = await db
     .from("meal_log")

--- a/web/src/lib/timezone.ts
+++ b/web/src/lib/timezone.ts
@@ -104,3 +104,26 @@ export function addDays(date: string, days: number): string {
   d.setUTCDate(d.getUTCDate() + days);
   return d.toISOString().slice(0, 10);
 }
+
+/**
+ * Returns the Monday that STARTS the coming week, as YYYY-MM-DD.
+ *
+ * `from` must itself be a YYYY-MM-DD string already in the user's timezone —
+ * pass `todayString()`, never a `Date`. Taking a string is the point: the caller
+ * cannot accidentally hand this a UTC instant, which is exactly how the weekly
+ * planner used to skip a week (see below).
+ *
+ * If `from` is itself a Monday the result is the NEXT Monday, never `from`. This
+ * drives "plan the coming week", which is always the week that has not started yet.
+ *
+ * WHY THIS IS NOT INLINE ARITHMETIC ON A Date. The planner previously did
+ * `new Date()` + `getDay()` on a server running UTC. Sunday evening Pacific is
+ * already Monday in UTC, so `getDay()` returned Mon, the "coming Monday" became
+ * Mon + 7, and planning on a Sunday night silently skipped the week that was
+ * about to start.
+ */
+export function comingMonday(from: string): string {
+  // Anchor at noon UTC so the weekday never shifts under a DST boundary.
+  const dow = (new Date(`${from}T12:00:00Z`).getUTCDay() + 6) % 7; // 0=Mon … 6=Sun
+  return addDays(from, (7 - dow) % 7 || 7);
+}


### PR DESCRIPTION
## The bug

The mr-bridge container's clock is **UTC**. `new Date().toISOString().slice(0, 10)` therefore
returns **tomorrow's date for the last 7-8 hours of every Pacific day**, and that expression was
what defaulted both `cooks.cooked_on` and `meal_log.date`.

This is not hypothetical — it wrote a bad row on 2026-08-19:

```
cook d0dec574  "Shrimp + Brussels Sprouts + Spinach + Green Bell Pepper"
  created_at  2026-08-20T00:53:45Z   ← 5:53 PM PDT on 8/19
  cooked_on   2026-08-20             ← tomorrow
```

The fridge list is ordered `cooked_on ASC` and exists to answer "eat the oldest thing first", so a
leftover dated into the future sorts last and ages out. `meal_log.date` was correct only because the
caller passed a date explicitly; anything logged after 5 PM through the default path would have
landed on the **next day's intake total**.

## The fix

`lib/timezone.todayString()` already existed and formats in `USER_TIMEZONE` (default
`America/Los_Angeles`) — the nutrition module simply never imported it. Both defaults now use it.

Same one-line fix applied to the two other user-facing "today" defaults:

| Site | Was | Now |
|---|---|---|
| `nutrition/cooks.ts` `cooked_on` | `new Date().toISOString().slice(0,10)` | `todayString()` |
| `nutrition/cooks.ts` `meal_log.date` | same | `todayString()` |
| `calendar/event-modal.tsx` new-event date | same | `todayString()` |
| `onboarding-wizard.tsx` DOB `max` | `...split("T")[0]` | `todayString()` |

### The weekly planner had it worse

`/api/internal/plan` built its week window from `new Date()` + `getDay()` on a UTC server. **Sunday
evening Pacific is already Monday in UTC**, so `getDay()` returned Mon, `(7 - 0) % 7 || 7` fell
through to `7`, and the "coming Monday" became the Monday *after* the week that was about to start —
planning on a Sunday night silently skipped a week.

Its window is now date **strings** end to end (new `comingMonday(from)` helper in `lib/timezone`),
which removes the `Date` → `toISOString()` conversion entirely rather than patching around it. Taking
a string is deliberate: a caller can no longer hand it a UTC instant by accident.

## Deliberately NOT changed

Three other `toISOString().slice(0, 10)` call sites are **correct** and were left alone — each is
anchored to an explicit UTC instant, not to "now":

- `lib/timezone.addDays` — anchors at `T12:00:00Z` specifically so DST can't shift the date
- `lib/journal/prompts.shiftDate` — same pattern on a date string
- `lib/sync/google-health.dateStr` — reads back an instant already shifted by the payload's own `utcOffset`

The remaining hits (calendar grid keys, export filename, package placeholders, admin `last_reset`)
are display/cosmetic rather than logging, and the calendar view components would need their `Date`
construction audited too — out of scope here.

## Tests

New `src/__tests__/timezone-dates.test.ts`:

- `todayString` never runs ahead of the UTC date
- the **exact instant that produced the bad row** (`2026-08-20T00:53:45.928Z` → `2026-08-19`)
- `comingMonday` never returns today when today is a Monday
- a 400-day sweep asserting the result is always a Monday 1-7 days out
- both 2026 DST boundaries (spring forward 3/08, fall back 11/01)

```
167/167 unit tests pass
tsc --noEmit   clean
eslint         0 errors (13 pre-existing warnings, unrelated)
prettier       clean
```

## Note on deployment

`USER_TIMEZONE` is **not** set in the live `~/docker/mr-bridge/.env`, so `USER_TZ` resolves via the
hardcoded `America/Los_Angeles` fallback in `lib/timezone.ts`. That is correct for this deployment,
so the fix works as-is with no env change. Setting it explicitly would be clearer but adds a
live-only key, which this deployment has a history of losing on re-pull — left alone on purpose.

The bad row from 8/19 has already been corrected in the database by hand (`cooked_on` → `2026-08-19`,
with a note recording the cause); `meal_log.date` was already right, so there is no macro or intake
impact to restate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAkNWnDn8Nw5sQo23Prh3U
